### PR TITLE
Implement horizontal player movement

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -331,6 +331,7 @@
     <Xml Include="App\example\xml\test.xml" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Input\PlayerInputAction.hpp" />
     <ClInclude Include="src\Component\Player.hpp" />
     <ClInclude Include="src\Component\Velocity.hpp" />
     <ClInclude Include="src\Config\PlayerConfig.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -18,6 +18,9 @@
     <Filter Include="Header Files\Component">
       <UniqueIdentifier>{a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Input">
+      <UniqueIdentifier>{b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Header Files\Config">
       <UniqueIdentifier>{e3f4a5b6-c7d8-9e0f-1a2b-3c4d5e6f7a8b}</UniqueIdentifier>
     </Filter>
@@ -839,6 +842,9 @@
     </Xml>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Input\PlayerInputAction.hpp">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
     <ClInclude Include="Component\Player.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>

--- a/Ash2/src/Input/PlayerInputAction.hpp
+++ b/Ash2/src/Input/PlayerInputAction.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief プレイヤー操作のキー割り当て
+struct PlayerInputAction {
+  /// 左移動
+  InputGroup moveLeft;
+  /// 右移動
+  InputGroup moveRight;
+
+  /// @brief デフォルトのキー割り当てを返す
+  /// @return デフォルトの PlayerInputAction
+  [[nodiscard]] static PlayerInputAction Default();
+};
+
+inline PlayerInputAction PlayerInputAction::Default() {
+  return {
+      .moveLeft = KeyLeft | KeyA,
+      .moveRight = KeyRight | KeyD,
+  };
+}

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -3,6 +3,7 @@
 #include <ThirdParty/entt/entt.hpp>
 
 #include "Config/PlayerConfig.hpp"
+#include "Input/PlayerInputAction.hpp"
 #include "Scene/DemoPhase.hpp"
 #include "Scene/PhaseStack.hpp"
 
@@ -27,6 +28,7 @@ void Main() {
 
   const TOMLReader toml(U"config/player.toml");
   registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(toml));
+  registry.ctx().emplace<PlayerInputAction>(PlayerInputAction::Default());
 
   PhaseStack phaseStack(std::make_unique<DemoPhase>(), registry);
 

--- a/Ash2/src/Scene/DemoPhase.cpp
+++ b/Ash2/src/Scene/DemoPhase.cpp
@@ -1,6 +1,32 @@
 #include "Scene/DemoPhase.hpp"
 
-IPhase::PhaseCommand DemoPhase::update(
-    [[maybe_unused]] entt::registry& registry) {
+#include "Component/Player.hpp"
+#include "Component/Velocity.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "Input/PlayerInputAction.hpp"
+#include "WorldPos.hpp"
+
+void DemoPhase::onAfterPush(entt::registry& registry) {
+  auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<WorldPos>(player);
+  registry.emplace<Velocity>(player);
+}
+
+IPhase::PhaseCommand DemoPhase::update(entt::registry& registry) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& actions = registry.ctx().get<PlayerInputAction>();
+  const double dt = Scene::DeltaTime();
+
+  const double vw = actions.moveRight.pressed()  ? cfg.speed
+                    : actions.moveLeft.pressed() ? -cfg.speed
+                                                 : 0.0;
+
+  auto view = registry.view<Player, WorldPos, Velocity>();
+  for (auto [entity, pos, vel] : view.each()) {
+    vel.w = vw;
+    pos.w += vel.w * dt;
+  }
+
   return PhaseCommand::None();
 }

--- a/Ash2/src/Scene/DemoPhase.hpp
+++ b/Ash2/src/Scene/DemoPhase.hpp
@@ -5,6 +5,10 @@
 /// @brief プレイヤー操作デモシーン
 class DemoPhase : public IPhase {
  public:
+  /// @brief プレイヤーエンティティを生成する
+  /// @param registry ECS レジストリ
+  void onAfterPush(entt::registry& registry) override;
+
   /// @brief 毎フレームの更新処理
   /// @param registry ECS レジストリ
   /// @return フェーズスタックへの操作

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,8 @@ Ash2/
 │   │   ├── Config/
 │   │   │   ├── PlayerConfig.hpp  # プレイヤー設定値
 │   │   │   └── PlayerConfig.cpp  # fromTOML() 実装
+│   │   ├── Input/
+│   │   │   └── PlayerInputAction.hpp  # プレイヤー操作のキー割り当て
 │   │   └── Scene/
 │   │       ├── IPhase.hpp      # フェーズ基底クラス
 │   │       ├── PhaseStack.hpp  # フェーズスタック
@@ -100,6 +102,22 @@ PhaseStack
 | `Velocity` | 速度（w/h/d、ピクセル/秒） |
 | `Player` | プレイヤーを示すタグ（空構造体） |
 
+### 入力管理（Input）
+
+プレイヤー操作のキー割り当てを `PlayerInputAction` 構造体で管理する。
+
+- 各アクション（moveLeft / moveRight 等）を Siv3D の `InputGroup` で保持
+- `InputGroup` は複数のキーを OR でまとめられるため、「左矢印またはA」のような複合割り当てが可能
+- `Default()` ファクトリでデフォルト割り当てを生成し、`registry.ctx()` に格納
+- キーコンフィグ対応時は `PlayerInputAction` の中身を差し替えるだけでよい
+
+```cpp
+// デフォルト割り当て
+auto actions = PlayerInputAction::Default();
+// カスタム割り当て（将来）
+actions.moveLeft = KeyLeft | KeyA | GamepadButton(0);
+```
+
 ### 設定値管理（Config）
 
 ゲームの定数値を型付き構造体（`PlayerConfig` 等）として管理する。
@@ -140,6 +158,7 @@ Vec2 toScreen() → { w, -(d + h) }
 | `src/Component/Player.hpp` | `Player` | プレイヤータグ（空構造体） |
 | `src/Component/Velocity.hpp` | `Velocity` | 速度コンポーネント（w, h, d、ピクセル/秒） |
 | `src/Config/PlayerConfig.hpp/.cpp` | `PlayerConfig` | プレイヤー設定値（速度・ジャンプ・重力） |
+| `src/Input/PlayerInputAction.hpp` | `PlayerInputAction` | プレイヤー操作のキー割り当て（InputGroup） |
 | `src/Scene/IPhase.hpp` | `IPhase` | フェーズ基底クラス |
 | `src/Scene/IPhase.hpp` | `IPhase::PhaseCommand` | フェーズスタック操作コマンド |
 | `src/Scene/PhaseStack.hpp/.cpp` | `PhaseStack` | フェーズをスタックで管理 |


### PR DESCRIPTION
## Summary

- `PlayerInputAction` 構造体を新設し、キー割り当てをゲームロジックから分離
- `PlayerInputAction::Default()` を `registry.ctx()` に登録（`PlayerConfig` と同じパターン）
- `DemoPhase::onAfterPush` でプレイヤーエンティティ（`Player` + `WorldPos` + `Velocity`）を生成
- `DemoPhase::update` で左右入力 → `Velocity.w` → `WorldPos.w` を更新

## 拡張性

キーコンフィグ実装時は `PlayerInputAction` の中身を差し替えるだけでゲームロジック側の変更は不要。`InputGroup` により複数キーやコントローラーボタンの OR 割り当ても可能。

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)