### PR TITLE
Implement jump, gravity, and depth movement

### DIFF
--- a/Ash2/src/Input/PlayerInputAction.hpp
+++ b/Ash2/src/Input/PlayerInputAction.hpp
@@ -7,6 +7,12 @@ struct PlayerInputAction {
   InputGroup moveLeft;
   /// 右移動
   InputGroup moveRight;
+  /// 奥へ移動
+  InputGroup moveForward;
+  /// 手前へ移動
+  InputGroup moveBackward;
+  /// ジャンプ
+  InputGroup jump;
 
   /// @brief デフォルトのキー割り当てを返す
   /// @return デフォルトの PlayerInputAction
@@ -17,5 +23,8 @@ inline PlayerInputAction PlayerInputAction::Default() {
   return {
       .moveLeft = KeyLeft | KeyA,
       .moveRight = KeyRight | KeyD,
+      .moveForward = KeyUp | KeyW,
+      .moveBackward = KeyDown | KeyS,
+      .jump = KeySpace,
   };
 }

--- a/Ash2/src/Scene/DemoPhase.cpp
+++ b/Ash2/src/Scene/DemoPhase.cpp
@@ -21,11 +21,28 @@ IPhase::PhaseCommand DemoPhase::update(entt::registry& registry) {
   const double vw = actions.moveRight.pressed()  ? cfg.speed
                     : actions.moveLeft.pressed() ? -cfg.speed
                                                  : 0.0;
+  const double vd = actions.moveForward.pressed()    ? cfg.speed
+                    : actions.moveBackward.pressed() ? -cfg.speed
+                                                     : 0.0;
 
   auto view = registry.view<Player, WorldPos, Velocity>();
   for (auto [entity, pos, vel] : view.each()) {
     vel.w = vw;
+    vel.d = vd;
     pos.w += vel.w * dt;
+    pos.d += vel.d * dt;
+
+    if (actions.jump.down() && pos.isOnGround()) {
+      vel.h = cfg.jumpSpeed;
+    }
+
+    vel.h -= cfg.gravity * dt;
+    pos.h += vel.h * dt;
+
+    if (pos.h < 0.0) {
+      pos.h = 0.0;
+      vel.h = 0.0;
+    }
   }
 
   return PhaseCommand::None();

--- a/Ash2/src/WorldPos.hpp
+++ b/Ash2/src/WorldPos.hpp
@@ -13,6 +13,10 @@ struct WorldPos {
   /// @brief ワールド座標を画面座標に変換する
   /// @return 画面座標（右方向・下方向が正）
   [[nodiscard]] Vec2 toScreen() const { return {w, -(d + h)}; }
+
+  /// @brief 地面上にいるか
+  /// @return 高さが 0 以下なら true
+  [[nodiscard]] bool isOnGround() const { return h <= 0.0; }
 };
 
 /// @brief 描画順の比較関数（奥から手前の順）

--- a/Ash2/tests/TestWorldPos.cpp
+++ b/Ash2/tests/TestWorldPos.cpp
@@ -24,6 +24,18 @@ TEST_CASE("WorldPos::ToScreen - x maps to horizontal position") {
   REQUIRE(left.toScreen().x < right.toScreen().x);
 }
 
+TEST_CASE("WorldPos::isOnGround - on ground when h is 0") {
+  // h=0 は地面上
+  WorldPos pos{.w = 0.0, .h = 0.0, .d = 0.0};
+  REQUIRE(pos.isOnGround());
+}
+
+TEST_CASE("WorldPos::isOnGround - not on ground when h is positive") {
+  // h>0 は地面上ではない
+  WorldPos pos{.w = 0.0, .h = 1.0, .d = 0.0};
+  REQUIRE_FALSE(pos.isOnGround());
+}
+
 TEST_CASE("DrawOrderLess - far objects come first") {
   // 奥のオブジェクトが先に来る
   WorldPos near{.w = 0.0, .h = 0.0, .d = 100.0};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,7 +106,7 @@ PhaseStack
 
 プレイヤー操作のキー割り当てを `PlayerInputAction` 構造体で管理する。
 
-- 各アクション（moveLeft / moveRight 等）を Siv3D の `InputGroup` で保持
+- 各アクション（moveLeft / moveRight / moveForward / moveBackward / jump 等）を Siv3D の `InputGroup` で保持
 - `InputGroup` は複数のキーを OR でまとめられるため、「左矢印またはA」のような複合割り当てが可能
 - `Default()` ファクトリでデフォルト割り当てを生成し、`registry.ctx()` に格納
 - キーコンフィグ対応時は `PlayerInputAction` の中身を差し替えるだけでよい
@@ -143,10 +143,12 @@ struct WorldPos {
 };
 
 Vec2 toScreen() → { w, -(d + h) }
+bool isOnGround() → h <= 0.0
 ```
 
 - 画面上の y 座標は `-(d + h)` で計算。奥にあるほど・高いほど画面上方に表示される。
 - `DrawOrderLess(a, b)` で奥 → 手前の描画順ソートができる。
+- `isOnGround()` で着地判定（重力・ジャンプ処理で使用）。
 
 ---
 


### PR DESCRIPTION
## Summary

- `WorldPos::isOnGround()` を追加（着地判定）
- `PlayerInputAction` に `moveForward`/`moveBackward`（Up/W・Down/S）と `jump`（Space）を追加
- `DemoPhase` に奥行き移動・ジャンプ・重力・着地判定を実装

## Test plan

- [x] Debug ビルドでユニットテストが通ることを確認

> 動作の視覚的な確認は #13（疑似3D描画）実装後に行う。

closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)