### PR TITLE
Implement pseudo-3D sprite rendering

### DIFF
--- a/Ash2/App/config/player.toml
+++ b/Ash2/App/config/player.toml
@@ -1,3 +1,6 @@
 speed = 200.0
 jump_speed = 400.0
 gravity = 980.0
+sprite_width = 40.0
+sprite_height = 60.0
+sprite_color = {r = 1.0, g = 1.0, b = 1.0}

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="src\Config\PlayerConfig.cpp" />
     <ClCompile Include="src\Main.cpp" />
     <ClCompile Include="src\Scene\DemoPhase.cpp" />
+    <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\Scene\PhaseStack.cpp" />
     <ClCompile Include="src\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -331,9 +332,11 @@
     <Xml Include="App\example\xml\test.xml" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Component\Drawable.hpp" />
     <ClInclude Include="src\Input\PlayerInputAction.hpp" />
     <ClInclude Include="src\Component\Player.hpp" />
     <ClInclude Include="src\Component\Velocity.hpp" />
+    <ClInclude Include="src\System\DrawSystem.hpp" />
     <ClInclude Include="src\Config\PlayerConfig.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\WorldPos.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -27,6 +27,12 @@
     <Filter Include="Source Files\Config">
       <UniqueIdentifier>{f4a5b6c7-d8e9-0f1a-2b3c-4d5e6f7a8b9c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\System">
+      <UniqueIdentifier>{c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\System">
+      <UniqueIdentifier>{d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a}</UniqueIdentifier>
+    </Filter>
     <Filter Include="ThirdParty">
       <UniqueIdentifier>{b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e}</UniqueIdentifier>
     </Filter>
@@ -164,6 +170,9 @@
   <ItemGroup>
     <ClCompile Include="Config\PlayerConfig.cpp">
       <Filter>Source Files\Config</Filter>
+    </ClCompile>
+    <ClCompile Include="System\DrawSystem.cpp">
+      <Filter>Source Files\System</Filter>
     </ClCompile>
     <ClCompile Include="Main.cpp">
       <Filter>Source Files</Filter>
@@ -845,8 +854,14 @@
     <ClInclude Include="Input\PlayerInputAction.hpp">
       <Filter>Header Files\Input</Filter>
     </ClInclude>
+    <ClInclude Include="Component\Drawable.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
     <ClInclude Include="Component\Player.hpp">
       <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="System\DrawSystem.hpp">
+      <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="Component\Velocity.hpp">
       <Filter>Header Files\Component</Filter>

--- a/Ash2/src/Component/Drawable.hpp
+++ b/Ash2/src/Component/Drawable.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <variant>
+
+/// @brief 矩形スプライト描画データ
+struct RectDrawable {
+  /// 描画サイズ（幅・高さ）
+  SizeF size;
+  /// 描画色
+  ColorF color;
+};
+
+/// @brief 描画コンポーネント（描画形状の variant）
+using Drawable = std::variant<RectDrawable>;

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -5,5 +5,10 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
       .speed = toml[U"speed"].get<double>(),
       .jumpSpeed = toml[U"jump_speed"].get<double>(),
       .gravity = toml[U"gravity"].get<double>(),
+      .spriteWidth = toml[U"sprite_width"].get<double>(),
+      .spriteHeight = toml[U"sprite_height"].get<double>(),
+      .spriteColorR = toml[U"sprite_color"][U"r"].get<double>(),
+      .spriteColorG = toml[U"sprite_color"][U"g"].get<double>(),
+      .spriteColorB = toml[U"sprite_color"][U"b"].get<double>(),
   };
 }

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -9,6 +9,16 @@ struct PlayerConfig {
   double jumpSpeed;
   /// 重力加速度（ピクセル/秒^2）
   double gravity;
+  /// スプライト幅（ピクセル）
+  double spriteWidth;
+  /// スプライト高さ（ピクセル）
+  double spriteHeight;
+  /// スプライト色 R
+  double spriteColorR;
+  /// スプライト色 G
+  double spriteColorG;
+  /// スプライト色 B
+  double spriteColorB;
 
   /// @brief TOML からプレイヤー設定を生成する
   /// @param toml TOML 値

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -35,6 +35,6 @@ void Main() {
 
   while (System::Update()) {
     phaseStack.update(registry);
-    DrawSystem::draw(registry);
+    DrawSystem::Draw(registry);
   }
 }

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -6,6 +6,7 @@
 #include "Input/PlayerInputAction.hpp"
 #include "Scene/DemoPhase.hpp"
 #include "Scene/PhaseStack.hpp"
+#include "System/DrawSystem.hpp"
 
 #if USE_TEST
 #define CATCH_CONFIG_RUNNER
@@ -34,5 +35,6 @@ void Main() {
 
   while (System::Update()) {
     phaseStack.update(registry);
+    DrawSystem::draw(registry);
   }
 }

--- a/Ash2/src/Scene/DemoPhase.cpp
+++ b/Ash2/src/Scene/DemoPhase.cpp
@@ -15,9 +15,9 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<WorldPos>(player);
   registry.emplace<Velocity>(player);
   registry.emplace<Drawable>(
-      player, RectDrawable{SizeF{cfg.spriteWidth, cfg.spriteHeight},
-                           ColorF{cfg.spriteColorR, cfg.spriteColorG,
-                                  cfg.spriteColorB}});
+      player, RectDrawable{.size = SizeF{cfg.spriteWidth, cfg.spriteHeight},
+                           .color = ColorF{cfg.spriteColorR, cfg.spriteColorG,
+                                           cfg.spriteColorB}});
 }
 
 IPhase::PhaseCommand DemoPhase::update(entt::registry& registry) {

--- a/Ash2/src/Scene/DemoPhase.cpp
+++ b/Ash2/src/Scene/DemoPhase.cpp
@@ -1,5 +1,6 @@
 #include "Scene/DemoPhase.hpp"
 
+#include "Component/Drawable.hpp"
 #include "Component/Player.hpp"
 #include "Component/Velocity.hpp"
 #include "Config/PlayerConfig.hpp"
@@ -7,10 +8,16 @@
 #include "WorldPos.hpp"
 
 void DemoPhase::onAfterPush(entt::registry& registry) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+
   auto player = registry.create();
   registry.emplace<Player>(player);
   registry.emplace<WorldPos>(player);
   registry.emplace<Velocity>(player);
+  registry.emplace<Drawable>(
+      player, RectDrawable{SizeF{cfg.spriteWidth, cfg.spriteHeight},
+                           ColorF{cfg.spriteColorR, cfg.spriteColorG,
+                                  cfg.spriteColorB}});
 }
 
 IPhase::PhaseCommand DemoPhase::update(entt::registry& registry) {

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -3,7 +3,7 @@
 #include "Component/Drawable.hpp"
 #include "WorldPos.hpp"
 
-void DrawSystem::draw(const entt::registry& registry) {
+void DrawSystem::Draw(const entt::registry& registry) {
   const Vec2 cameraOffset = Scene::Center();
 
   struct DrawEntry {
@@ -12,15 +12,14 @@ void DrawSystem::draw(const entt::registry& registry) {
   };
 
   Array<DrawEntry> entries;
-  for (auto [entity, pos, drawable] :
+  for (auto& [entity, pos, drawable] :
        registry.view<const WorldPos, const Drawable>().each()) {
     entries.push_back({std::cref(pos), std::cref(drawable)});
   }
 
-  std::sort(entries.begin(), entries.end(),
-            [](const DrawEntry& a, const DrawEntry& b) {
-              return DrawOrderLess(a.pos.get(), b.pos.get());
-            });
+  std::ranges::sort(entries, [](const DrawEntry& a, const DrawEntry& b) {
+    return DrawOrderLess(a.pos.get(), b.pos.get());
+  });
 
   for (const auto& entry : entries) {
     const Vec2 screenPos = cameraOffset + entry.pos.get().toScreen();

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -1,0 +1,37 @@
+#include "System/DrawSystem.hpp"
+
+#include "Component/Drawable.hpp"
+#include "WorldPos.hpp"
+
+void DrawSystem::draw(const entt::registry& registry) {
+  const Vec2 cameraOffset = Scene::Center();
+
+  struct DrawEntry {
+    std::reference_wrapper<const WorldPos> pos;
+    std::reference_wrapper<const Drawable> drawable;
+  };
+
+  Array<DrawEntry> entries;
+  for (auto [entity, pos, drawable] :
+       registry.view<const WorldPos, const Drawable>().each()) {
+    entries.push_back({std::cref(pos), std::cref(drawable)});
+  }
+
+  std::sort(entries.begin(), entries.end(),
+            [](const DrawEntry& a, const DrawEntry& b) {
+              return DrawOrderLess(a.pos.get(), b.pos.get());
+            });
+
+  for (const auto& entry : entries) {
+    const Vec2 screenPos = cameraOffset + entry.pos.get().toScreen();
+    std::visit(
+        [&screenPos](const auto& shape) {
+          using T = std::decay_t<decltype(shape)>;
+          if constexpr (std::is_same_v<T, RectDrawable>) {
+            RectF{Arg::bottomCenter(screenPos), shape.size.x, shape.size.y}
+                .draw(shape.color);
+          }
+        },
+        entry.drawable.get());
+  }
+}

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -12,7 +12,7 @@ void DrawSystem::Draw(const entt::registry& registry) {
   };
 
   Array<DrawEntry> entries;
-  for (auto& [entity, pos, drawable] :
+  for (const auto& [entity, pos, drawable] :
        registry.view<const WorldPos, const Drawable>().each()) {
     entries.push_back({std::cref(pos), std::cref(drawable)});
   }

--- a/Ash2/src/System/DrawSystem.hpp
+++ b/Ash2/src/System/DrawSystem.hpp
@@ -6,5 +6,5 @@ class DrawSystem {
  public:
   /// @brief WorldPos + Drawable を持つエンティティを奥から順に描画する
   /// @param registry ECS レジストリ
-  static void draw(const entt::registry& registry);
+  static void Draw(const entt::registry& registry);
 };

--- a/Ash2/src/System/DrawSystem.hpp
+++ b/Ash2/src/System/DrawSystem.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <ThirdParty/entt/entt.hpp>
+
+/// @brief スプライト描画システム
+class DrawSystem {
+ public:
+  /// @brief WorldPos + Drawable を持つエンティティを奥から順に描画する
+  /// @param registry ECS レジストリ
+  static void draw(const entt::registry& registry);
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,7 @@ Ash2/
 │   │   ├── stdafx.h            # プリコンパイルヘッダ（Siv3D 一括インクルード）
 │   │   ├── WorldPos.hpp        # ワールド座標
 │   │   ├── Component/
+│   │   │   ├── Drawable.hpp    # 描画コンポーネント（variant）
 │   │   │   ├── Player.hpp      # プレイヤータグ
 │   │   │   └── Velocity.hpp    # 速度コンポーネント
 │   │   ├── Config/
@@ -24,6 +25,9 @@ Ash2/
 │   │   │   └── PlayerConfig.cpp  # fromTOML() 実装
 │   │   ├── Input/
 │   │   │   └── PlayerInputAction.hpp  # プレイヤー操作のキー割り当て
+│   │   ├── System/
+│   │   │   ├── DrawSystem.hpp  # 描画システム
+│   │   │   └── DrawSystem.cpp
 │   │   └── Scene/
 │   │       ├── IPhase.hpp      # フェーズ基底クラス
 │   │       ├── PhaseStack.hpp  # フェーズスタック
@@ -65,8 +69,9 @@ Ash2/
 ```
 Main()
   └─ System::Update() ループ
-       └─ PhaseStack::update(registry)
-            └─ IPhase::update(registry)  ← 現在の最前面フェーズ
+       ├─ PhaseStack::update(registry)
+       │    └─ IPhase::update(registry)  ← 現在の最前面フェーズ
+       └─ DrawSystem::draw(registry)     ← 描画（depth ソート後）
 ```
 
 `entt::registry` をゲーム全体で共有し、フェーズ間でエンティティの状態を引き継ぐ。
@@ -101,6 +106,7 @@ PhaseStack
 | `WorldPos` | 位置（w/h/d） |
 | `Velocity` | 速度（w/h/d、ピクセル/秒） |
 | `Player` | プレイヤーを示すタグ（空構造体） |
+| `Drawable` | 描画形状の variant（`RectDrawable` 等） |
 
 ### 入力管理（Input）
 
@@ -157,6 +163,7 @@ bool isOnGround() → h <= 0.0
 | ファイル | クラス / 構造体 | 説明 |
 |---------|---------------|------|
 | `src/WorldPos.hpp` | `WorldPos` | ワールド座標（w, h, d）と画面座標変換 |
+| `src/Component/Drawable.hpp` | `RectDrawable`, `Drawable` | 描画コンポーネント（形状の variant） |
 | `src/Component/Player.hpp` | `Player` | プレイヤータグ（空構造体） |
 | `src/Component/Velocity.hpp` | `Velocity` | 速度コンポーネント（w, h, d、ピクセル/秒） |
 | `src/Config/PlayerConfig.hpp/.cpp` | `PlayerConfig` | プレイヤー設定値（速度・ジャンプ・重力） |
@@ -165,3 +172,4 @@ bool isOnGround() → h <= 0.0
 | `src/Scene/IPhase.hpp` | `IPhase::PhaseCommand` | フェーズスタック操作コマンド |
 | `src/Scene/PhaseStack.hpp/.cpp` | `PhaseStack` | フェーズをスタックで管理 |
 | `src/Scene/DemoPhase.hpp/.cpp` | `DemoPhase` | プレイヤー操作デモシーン |
+| `src/System/DrawSystem.hpp/.cpp` | `DrawSystem` | depth ソート後に Drawable を描画 |


### PR DESCRIPTION
## Summary

- `Drawable` コンポーネント（`std::variant<RectDrawable>`）を追加し、将来の描画形状拡張に対応
- `DrawSystem::draw()` で `WorldPos + Drawable` エンティティを depth ソートし奥から順に描画
- プレイヤーにスプライトサイズ・色を `player.toml` で設定可能にした
- カメラオフセットは `Scene::Center()` 固定（後でカメラコンポーネントに差し替え予定）

Closes #13

## Test plan

- [x] ビルドが通ること
- [x] プレイヤーが画面中央付近に矩形として表示されること
- [x] 左右・前後移動・ジャンプが引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)