### PR TITLE
Add TOML-based scenario system

### DIFF
--- a/Ash2/App/config/scenario.toml
+++ b/Ash2/App/config/scenario.toml
@@ -1,0 +1,10 @@
+[[init]]
+action = "reset"
+phase = "scenario"
+param = "GameStart"
+
+[[GameStart]]
+action = "make"
+name = "player"
+worldPos = {w = 100.0, h = 0.0, d = 200.0}
+drawable = {w = 50.0, h = 80.0, r = 1.0, g = 0.33, b = 0.2}

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -118,7 +118,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\Config\PlayerConfig.cpp" />
+    <ClCompile Include="src\Config\ScenarioData.cpp" />
     <ClCompile Include="src\Main.cpp" />
+    <ClCompile Include="src\Scene\ScenarioPhase.cpp" />
     <ClCompile Include="src\Scene\DemoPhase.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\Scene\PhaseStack.cpp" />
@@ -333,11 +335,15 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Component\Drawable.hpp" />
+    <ClInclude Include="src\Component\Name.hpp" />
     <ClInclude Include="src\Input\PlayerInputAction.hpp" />
     <ClInclude Include="src\Component\Player.hpp" />
     <ClInclude Include="src\Component\Velocity.hpp" />
     <ClInclude Include="src\System\DrawSystem.hpp" />
+    <ClInclude Include="src\System\NameLookup.hpp" />
     <ClInclude Include="src\Config\PlayerConfig.hpp" />
+    <ClInclude Include="src\Config\ScenarioData.hpp" />
+    <ClInclude Include="src\Scene\ScenarioPhase.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\WorldPos.hpp" />
     <ClInclude Include="src\Scene\DemoPhase.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -171,6 +171,12 @@
     <ClCompile Include="Config\PlayerConfig.cpp">
       <Filter>Source Files\Config</Filter>
     </ClCompile>
+    <ClCompile Include="Config\ScenarioData.cpp">
+      <Filter>Source Files\Config</Filter>
+    </ClCompile>
+    <ClCompile Include="Scene\ScenarioPhase.cpp">
+      <Filter>Source Files\Scene</Filter>
+    </ClCompile>
     <ClCompile Include="System\DrawSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
@@ -857,10 +863,16 @@
     <ClInclude Include="Component\Drawable.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
+    <ClInclude Include="Component\Name.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
     <ClInclude Include="Component\Player.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="System\DrawSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\NameLookup.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="Component\Velocity.hpp">
@@ -868,6 +880,12 @@
     </ClInclude>
     <ClInclude Include="Config\PlayerConfig.hpp">
       <Filter>Header Files\Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\ScenarioData.hpp">
+      <Filter>Header Files\Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Scene\ScenarioPhase.hpp">
+      <Filter>Header Files\Scene</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>

--- a/Ash2/src/Component/Name.hpp
+++ b/Ash2/src/Component/Name.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief エンティティ名コンポーネント
+struct Name {
+  /// エンティティを識別する名前
+  s3d::String value;
+};

--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -1,0 +1,13 @@
+#include "Config/ScenarioData.hpp"
+
+ScenarioData ScenarioData::FromToml(const s3d::TOMLValue& toml) {
+  ScenarioData data;
+  for (const auto& member : toml.tableView()) {
+    s3d::Array<s3d::TOMLValue> steps;
+    for (const auto& step : member.value.tableArrayView()) {
+      steps.push_back(step);
+    }
+    data.sections[member.name] = std::move(steps);
+  }
+  return data;
+}

--- a/Ash2/src/Config/ScenarioData.hpp
+++ b/Ash2/src/Config/ScenarioData.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief シナリオデータ（ロード時に全セクションを変換済み）
+struct ScenarioData {
+  /// セクション名 → ステップ一覧のテーブル
+  s3d::HashTable<s3d::String, s3d::Array<s3d::TOMLValue>> sections;
+
+  /// @brief TOML からシナリオデータを生成する
+  /// @param toml シナリオ TOML のルート値
+  /// @return ScenarioData
+  [[nodiscard]] static ScenarioData FromToml(const s3d::TOMLValue& toml);
+};

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -3,10 +3,12 @@
 #include <ThirdParty/entt/entt.hpp>
 
 #include "Config/PlayerConfig.hpp"
+#include "Config/ScenarioData.hpp"
 #include "Input/PlayerInputAction.hpp"
-#include "Scene/DemoPhase.hpp"
 #include "Scene/PhaseStack.hpp"
+#include "Scene/ScenarioPhase.hpp"
 #include "System/DrawSystem.hpp"
+#include "System/NameLookup.hpp"
 
 #if USE_TEST
 #define CATCH_CONFIG_RUNNER
@@ -26,12 +28,16 @@ void Main() {
 #endif
 
   entt::registry registry;
+  registry.ctx().emplace<NameLookup>();
 
-  const TOMLReader toml(U"config/player.toml");
-  registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(toml));
+  const TOMLReader playerToml(U"config/player.toml");
+  registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(playerToml));
   registry.ctx().emplace<PlayerInputAction>(PlayerInputAction::Default());
 
-  PhaseStack phaseStack(std::make_unique<DemoPhase>(), registry);
+  const TOMLReader scenarioToml(U"config/scenario.toml");
+  registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(scenarioToml));
+
+  PhaseStack phaseStack(std::make_unique<ScenarioPhase>(U"init"), registry);
 
   while (System::Update()) {
     phaseStack.update(registry);

--- a/Ash2/src/Scene/ScenarioPhase.cpp
+++ b/Ash2/src/Scene/ScenarioPhase.cpp
@@ -1,0 +1,70 @@
+#include "Scene/ScenarioPhase.hpp"
+
+#include "Component/Drawable.hpp"
+#include "Component/Name.hpp"
+#include "Config/ScenarioData.hpp"
+#include "System/NameLookup.hpp"
+#include "WorldPos.hpp"
+
+ScenarioPhase::ScenarioPhase(const s3d::String& sectionName)
+    : sectionName_(sectionName) {}
+
+void ScenarioPhase::onAfterPush(entt::registry&) { currentStep_ = 0; }
+
+IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry) {
+  const auto& steps =
+      registry.ctx().get<ScenarioData>().sections.at(sectionName_);
+  if (currentStep_ >= steps.size()) {
+    return PhaseCommand::Pop();
+  }
+
+  const auto& step = steps[currentStep_];
+  ++currentStep_;
+  const auto action = step[U"action"].get<String>();
+
+  if (action == U"make") {
+    const auto name = step[U"name"].get<String>();
+    const auto wp = step[U"worldPos"];
+    const auto dr = step[U"drawable"];
+
+    auto entity = registry.create();
+    createdEntities_.push_back(entity);
+
+    registry.emplace<Name>(entity, name);
+    registry.emplace<WorldPos>(entity, WorldPos{
+                                           .w = wp[U"w"].get<double>(),
+                                           .h = wp[U"h"].get<double>(),
+                                           .d = wp[U"d"].get<double>(),
+                                       });
+    registry.emplace<Drawable>(
+        entity,
+        RectDrawable{
+            .size = SizeF{dr[U"w"].get<double>(), dr[U"h"].get<double>()},
+            .color = ColorF{dr[U"r"].get<double>(), dr[U"g"].get<double>(),
+                            dr[U"b"].get<double>()},
+        });
+
+    auto& lookup = registry.ctx().get<NameLookup>();
+    lookup[name] = entity;
+
+    return PhaseCommand::None();
+  }
+
+  if (action == U"reset") {
+    const auto param = step[U"param"].get<String>();
+    return PhaseCommand::Reset(std::make_unique<ScenarioPhase>(param));
+  }
+
+  return PhaseCommand::None();
+}
+
+void ScenarioPhase::onBeforePop(entt::registry& registry) {
+  auto& lookup = registry.ctx().get<NameLookup>();
+  for (auto entity : createdEntities_) {
+    if (registry.all_of<Name>(entity)) {
+      lookup.erase(registry.get<Name>(entity).value);
+    }
+    registry.destroy(entity);
+  }
+  createdEntities_.clear();
+}

--- a/Ash2/src/Scene/ScenarioPhase.cpp
+++ b/Ash2/src/Scene/ScenarioPhase.cpp
@@ -6,8 +6,8 @@
 #include "System/NameLookup.hpp"
 #include "WorldPos.hpp"
 
-ScenarioPhase::ScenarioPhase(const s3d::String& sectionName)
-    : m_sectionName(sectionName) {}
+ScenarioPhase::ScenarioPhase(s3d::String sectionName)
+    : m_sectionName(std::move(sectionName)) {}
 
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 

--- a/Ash2/src/Scene/ScenarioPhase.cpp
+++ b/Ash2/src/Scene/ScenarioPhase.cpp
@@ -7,19 +7,19 @@
 #include "WorldPos.hpp"
 
 ScenarioPhase::ScenarioPhase(const s3d::String& sectionName)
-    : sectionName_(sectionName) {}
+    : m_sectionName(sectionName) {}
 
-void ScenarioPhase::onAfterPush(entt::registry&) { currentStep_ = 0; }
+void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 
 IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry) {
   const auto& steps =
-      registry.ctx().get<ScenarioData>().sections.at(sectionName_);
-  if (currentStep_ >= steps.size()) {
+      registry.ctx().get<ScenarioData>().sections.at(m_sectionName);
+  if (m_currentStep >= steps.size()) {
     return PhaseCommand::Pop();
   }
 
-  const auto& step = steps[currentStep_];
-  ++currentStep_;
+  const auto& step = steps[m_currentStep];
+  ++m_currentStep;
   const auto action = step[U"action"].get<String>();
 
   if (action == U"make") {
@@ -28,7 +28,7 @@ IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry) {
     const auto dr = step[U"drawable"];
 
     auto entity = registry.create();
-    createdEntities_.push_back(entity);
+    m_createdEntities.push_back(entity);
 
     registry.emplace<Name>(entity, name);
     registry.emplace<WorldPos>(entity, WorldPos{
@@ -60,11 +60,11 @@ IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry) {
 
 void ScenarioPhase::onBeforePop(entt::registry& registry) {
   auto& lookup = registry.ctx().get<NameLookup>();
-  for (auto entity : createdEntities_) {
+  for (auto entity : m_createdEntities) {
     if (registry.all_of<Name>(entity)) {
       lookup.erase(registry.get<Name>(entity).value);
     }
     registry.destroy(entity);
   }
-  createdEntities_.clear();
+  m_createdEntities.clear();
 }

--- a/Ash2/src/Scene/ScenarioPhase.hpp
+++ b/Ash2/src/Scene/ScenarioPhase.hpp
@@ -8,7 +8,7 @@ class ScenarioPhase : public IPhase {
  public:
   /// @brief コンストラクタ
   /// @param sectionName 処理するシナリオセクション名
-  explicit ScenarioPhase(const s3d::String& sectionName);
+  explicit ScenarioPhase(s3d::String sectionName);
 
   /// @brief currentStep_ を初期化する
   /// @param registry ECS レジストリ

--- a/Ash2/src/Scene/ScenarioPhase.hpp
+++ b/Ash2/src/Scene/ScenarioPhase.hpp
@@ -25,9 +25,9 @@ class ScenarioPhase : public IPhase {
 
  private:
   /// シナリオセクション名
-  s3d::String sectionName_;
+  s3d::String m_sectionName;
   /// 現在のステップインデックス
-  size_t currentStep_ = 0;
+  size_t m_currentStep = 0;
   /// このフェーズで生成したエンティティ一覧
-  s3d::Array<entt::entity> createdEntities_;
+  s3d::Array<entt::entity> m_createdEntities;
 };

--- a/Ash2/src/Scene/ScenarioPhase.hpp
+++ b/Ash2/src/Scene/ScenarioPhase.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include "IPhase.hpp"
+
+/// @brief TOML シナリオに従ってエンティティ生成・フェーズ遷移を進めるフェーズ
+class ScenarioPhase : public IPhase {
+ public:
+  /// @brief コンストラクタ
+  /// @param sectionName 処理するシナリオセクション名
+  explicit ScenarioPhase(const s3d::String& sectionName);
+
+  /// @brief currentStep_ を初期化する
+  /// @param registry ECS レジストリ
+  void onAfterPush(entt::registry& registry) override;
+
+  /// @brief 毎フレーム 1 ステップを処理する
+  /// @param registry ECS レジストリ
+  /// @return フェーズスタックへの操作
+  [[nodiscard]] PhaseCommand update(entt::registry& registry) override;
+
+  /// @brief 生成したエンティティと NameLookup エントリを削除する
+  /// @param registry ECS レジストリ
+  void onBeforePop(entt::registry& registry) override;
+
+ private:
+  /// シナリオセクション名
+  s3d::String sectionName_;
+  /// 現在のステップインデックス
+  size_t currentStep_ = 0;
+  /// このフェーズで生成したエンティティ一覧
+  s3d::Array<entt::entity> createdEntities_;
+};

--- a/Ash2/src/System/NameLookup.hpp
+++ b/Ash2/src/System/NameLookup.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <ThirdParty/entt/entt.hpp>
+
+/// @brief 名前からエンティティへの参照を管理するコンテキスト
+using NameLookup = s3d::HashTable<s3d::String, entt::entity>;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,25 +18,32 @@ Ash2/
 │   │   ├── WorldPos.hpp        # ワールド座標
 │   │   ├── Component/
 │   │   │   ├── Drawable.hpp    # 描画コンポーネント（variant）
+│   │   │   ├── Name.hpp        # エンティティ名コンポーネント
 │   │   │   ├── Player.hpp      # プレイヤータグ
 │   │   │   └── Velocity.hpp    # 速度コンポーネント
 │   │   ├── Config/
-│   │   │   ├── PlayerConfig.hpp  # プレイヤー設定値
-│   │   │   └── PlayerConfig.cpp  # fromTOML() 実装
+│   │   │   ├── PlayerConfig.hpp   # プレイヤー設定値
+│   │   │   ├── PlayerConfig.cpp
+│   │   │   ├── ScenarioData.hpp   # シナリオデータ（ロード済みステップ一覧）
+│   │   │   └── ScenarioData.cpp
 │   │   ├── Input/
 │   │   │   └── PlayerInputAction.hpp  # プレイヤー操作のキー割り当て
 │   │   ├── System/
 │   │   │   ├── DrawSystem.hpp  # 描画システム
-│   │   │   └── DrawSystem.cpp
+│   │   │   ├── DrawSystem.cpp
+│   │   │   └── NameLookup.hpp  # 名前→エンティティ参照コンテキスト
 │   │   └── Scene/
-│   │       ├── IPhase.hpp      # フェーズ基底クラス
-│   │       ├── PhaseStack.hpp  # フェーズスタック
+│   │       ├── IPhase.hpp          # フェーズ基底クラス
+│   │       ├── PhaseStack.hpp      # フェーズスタック
 │   │       ├── PhaseStack.cpp
-│   │       ├── DemoPhase.hpp   # プレイヤー操作デモシーン
-│   │       └── DemoPhase.cpp
+│   │       ├── DemoPhase.hpp       # プレイヤー操作デモシーン
+│   │       ├── DemoPhase.cpp
+│   │       ├── ScenarioPhase.hpp   # TOML シナリオ進行フェーズ
+│   │       └── ScenarioPhase.cpp
 │   ├── App/
 │   │   └── config/
-│   │       └── player.toml     # プレイヤー設定ファイル
+│   │       ├── player.toml     # プレイヤー設定ファイル
+│   │       └── scenario.toml   # シナリオ定義ファイル
 │   ├── tests/
 │   │   ├── TestWorldPos.cpp    # WorldPos ユニットテスト
 │   │   ├── TestPlayerConfig.cpp # PlayerConfig ユニットテスト
@@ -107,6 +114,7 @@ PhaseStack
 | `Velocity` | 速度（w/h/d、ピクセル/秒） |
 | `Player` | プレイヤーを示すタグ（空構造体） |
 | `Drawable` | 描画形状の variant（`RectDrawable` 等） |
+| `Name` | エンティティを識別する名前（`NameLookup` と連携） |
 
 ### 入力管理（Input）
 
@@ -117,24 +125,28 @@ PhaseStack
 - `Default()` ファクトリでデフォルト割り当てを生成し、`registry.ctx()` に格納
 - キーコンフィグ対応時は `PlayerInputAction` の中身を差し替えるだけでよい
 
-```cpp
-// デフォルト割り当て
-auto actions = PlayerInputAction::Default();
-// カスタム割り当て（将来）
-actions.moveLeft = KeyLeft | KeyA | GamepadButton(0);
-```
-
 ### 設定値管理（Config）
 
 ゲームの定数値を型付き構造体（`PlayerConfig` 等）として管理する。
 
-- `fromTOML()` 静的メソッドで TOML ファイルから生成
+- `FromToml()` 静的メソッドで TOML ファイルから生成
 - `registry.ctx()` に格納してフェーズ間で共有
 
-```cpp
-registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(toml[U"player"]));
-auto& cfg = registry.ctx().get<PlayerConfig>();
-```
+### シナリオシステム（ScenarioPhase）
+
+ゲームの進行を `scenario.toml` で管理する。再コンパイル不要でシナリオを編集できる。
+
+- `ScenarioData::FromToml()` でロード時に全セクションを `HashTable<String, Array<TOMLValue>>` へ変換し `registry.ctx()` に格納
+- `ScenarioPhase` は `IPhase` を継承し、1フレームに1ステップを処理する
+- エンティティを名前で参照するため `NameLookup`（`HashTable<String, entity>`）を `registry.ctx()` で共有
+- `ScenarioPhase::onBeforePop()` でこのフェーズが生成したエンティティと `NameLookup` エントリを削除
+
+対応アクション：
+
+| アクション | 処理 |
+|-----------|------|
+| `make` | エンティティを生成し `Name`・`WorldPos`・`Drawable` を付与 |
+| `reset` | `PhaseCommand::Reset` で指定セクションの `ScenarioPhase` に遷移 |
 
 ### 描画システム（DrawSystem）
 
@@ -145,20 +157,9 @@ auto& cfg = registry.ctx().get<PlayerConfig>();
 
 ### 座標系（WorldPos）
 
-疑似3Dの奥行き表現に使うワールド座標。
+疑似3Dの奥行き表現に使うワールド座標。`w`（横）・`h`（高さ、地面=0）・`d`（奥行き）の3軸。
 
-```
-struct WorldPos {
-  double w;  // 横位置（画面 x に対応）
-  double h;  // 高さ（地面 = 0、上方向が正）
-  double d;  // 奥行き（大きいほど奥 = 画面上方）
-};
-
-Vec2 toScreen() → { w, -(d + h) }
-bool isOnGround() → h <= 0.0
-```
-
-- 画面上の y 座標は `-(d + h)` で計算。奥にあるほど・高いほど画面上方に表示される。
+- 画面 y 座標は `-(d + h)`。奥にあるほど・高いほど画面上方に表示される。
 - `DrawOrderLess(a, b)` で奥 → 手前の描画順ソートができる。
 - `isOnGround()` で着地判定（重力・ジャンプ処理で使用）。
 
@@ -170,12 +171,16 @@ bool isOnGround() → h <= 0.0
 |---------|---------------|------|
 | `src/WorldPos.hpp` | `WorldPos` | ワールド座標（w, h, d）と画面座標変換 |
 | `src/Component/Drawable.hpp` | `RectDrawable`, `Drawable` | 描画コンポーネント（形状の variant） |
+| `src/Component/Name.hpp` | `Name` | エンティティ名コンポーネント |
 | `src/Component/Player.hpp` | `Player` | プレイヤータグ（空構造体） |
 | `src/Component/Velocity.hpp` | `Velocity` | 速度コンポーネント（w, h, d、ピクセル/秒） |
 | `src/Config/PlayerConfig.hpp/.cpp` | `PlayerConfig` | プレイヤー設定値（速度・ジャンプ・重力） |
+| `src/Config/ScenarioData.hpp/.cpp` | `ScenarioData` | シナリオデータ（ロード済みステップ一覧） |
 | `src/Input/PlayerInputAction.hpp` | `PlayerInputAction` | プレイヤー操作のキー割り当て（InputGroup） |
 | `src/Scene/IPhase.hpp` | `IPhase` | フェーズ基底クラス |
 | `src/Scene/IPhase.hpp` | `IPhase::PhaseCommand` | フェーズスタック操作コマンド |
 | `src/Scene/PhaseStack.hpp/.cpp` | `PhaseStack` | フェーズをスタックで管理 |
 | `src/Scene/DemoPhase.hpp/.cpp` | `DemoPhase` | プレイヤー操作デモシーン |
+| `src/Scene/ScenarioPhase.hpp/.cpp` | `ScenarioPhase` | TOML シナリオ進行フェーズ |
 | `src/System/DrawSystem.hpp/.cpp` | `DrawSystem` | depth ソート後に Drawable を描画 |
+| `src/System/NameLookup.hpp` | `NameLookup` | 名前→エンティティ参照コンテキスト（型エイリアス） |

--- a/docs/GIT.md
+++ b/docs/GIT.md
@@ -68,3 +68,7 @@ git -C ~/path/to/repo status
 - 通常マージ（Merge commit）を使用する
 - PRタイトルは英語・命令形
 - マージ後はブランチを削除する
+
+## issueタイトル
+
+- 日本語で書く


### PR DESCRIPTION
## Summary

- `ScenarioData` (`src/Config/`) でロード時に全セクションを `HashTable<String, Array<TOMLValue>>` へ変換し `registry.ctx()` に格納
- `ScenarioPhase` (`src/Scene/`) を `IPhase` の派生として実装。1フレームに1ステップを処理し、`make` / `reset` アクションに対応
- `Name` コンポーネントと `NameLookup` コンテキストを追加し、エンティティを名前で参照できるようにした
- `scenario.toml` テンプレートを追加し、`Main.cpp` の初期フェーズを `ScenarioPhase("init")` に切り替え

close #27

## Test plan

- [x] Visual Studio でビルドが通ることを確認
- [x] 実行後、画面に矩形（プレイヤーエンティティ）が描画されることを確認
- [x] `[[init]]` → reset → `[[GameStart]]` → make → pop の順でフェーズが遷移することをデバッガで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)