### PR TITLE
Pass dt to IPhase::update() and implement WaitPhase

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -46,6 +46,10 @@ jobs:
           $testFiles = Get-ChildItem -Path "$projectDir\tests" -Filter "*.cpp" |
             Select-Object -ExpandProperty FullName
 
+          $srcFiles = @(
+            "$projectDir\src\Phase\WaitPhase.cpp"
+          )
+
           cl.exe `
             /std:c++latest /Zc:__cplusplus /utf-8 /EHsc `
             /DUSE_TEST `
@@ -55,6 +59,7 @@ jobs:
             /I"$sdkRoot\include\ThirdParty" `
             "$outDir\main.cpp" `
             $testFiles `
+            $srcFiles `
             /Fe:"$outDir\tests.exe"
 
           if ($LASTEXITCODE -ne 0) { exit 1 }

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="src\Main.cpp" />
     <ClCompile Include="src\Phase\ScenarioPhase.cpp" />
     <ClCompile Include="src\Phase\DemoPhase.cpp" />
+    <ClCompile Include="src\Phase\WaitPhase.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\Phase\PhaseStack.cpp" />
     <ClCompile Include="src\stdafx.cpp">
@@ -344,6 +345,7 @@
     <ClInclude Include="src\Config\PlayerConfig.hpp" />
     <ClInclude Include="src\Config\ScenarioData.hpp" />
     <ClInclude Include="src\Phase\ScenarioPhase.hpp" />
+    <ClInclude Include="src\Phase\WaitPhase.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\Component\WorldPos.hpp" />
     <ClInclude Include="src\Phase\DemoPhase.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClCompile Include="Phase\DemoPhase.cpp">
       <Filter>Source Files\Phase</Filter>
     </ClCompile>
+    <ClCompile Include="Phase\WaitPhase.cpp">
+      <Filter>Source Files\Phase</Filter>
+    </ClCompile>
     <ClCompile Include="Phase\PhaseStack.cpp">
       <Filter>Source Files\Phase</Filter>
     </ClCompile>
@@ -894,6 +897,9 @@
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="Phase\DemoPhase.hpp">
+      <Filter>Header Files\Phase</Filter>
+    </ClInclude>
+    <ClInclude Include="Phase\WaitPhase.hpp">
       <Filter>Header Files\Phase</Filter>
     </ClInclude>
     <ClInclude Include="Phase\IPhase.hpp">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -198,6 +198,12 @@
     <ClCompile Include="TestWorldPos.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="TestPlayerConfig.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TestWaitPhase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="App\icon.ico">

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -18,10 +18,9 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
       player, RectDrawable{.size = cfg.spriteSize, .color = cfg.spriteColor});
 }
 
-IPhase::PhaseCommand DemoPhase::update(entt::registry& registry) {
+IPhase::PhaseCommand DemoPhase::update(entt::registry& registry, double dt) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& actions = registry.ctx().get<PlayerInputAction>();
-  const double dt = Scene::DeltaTime();
 
   const double vw = actions.moveRight.pressed()  ? cfg.speed
                     : actions.moveLeft.pressed() ? -cfg.speed

--- a/Ash2/src/Phase/DemoPhase.hpp
+++ b/Ash2/src/Phase/DemoPhase.hpp
@@ -11,6 +11,8 @@ class DemoPhase : public IPhase {
 
   /// @brief 毎フレームの更新処理
   /// @param registry ECS レジストリ
+  /// @param dt 経過時間（秒）
   /// @return フェーズスタックへの操作
-  [[nodiscard]] PhaseCommand update(entt::registry& registry) override;
+  [[nodiscard]] PhaseCommand update(entt::registry& registry,
+                                    double dt) override;
 };

--- a/Ash2/src/Phase/IPhase.hpp
+++ b/Ash2/src/Phase/IPhase.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Siv3D.hpp>
+
 #include <ThirdParty/entt/entt.hpp>
 
 /// @brief フェーズの基底クラス

--- a/Ash2/src/Phase/IPhase.hpp
+++ b/Ash2/src/Phase/IPhase.hpp
@@ -47,8 +47,10 @@ class IPhase {
 
   /// @brief 毎フレームの更新処理
   /// @param registry ECS レジストリ
+  /// @param dt 経過時間（秒）
   /// @return フェーズスタックへの操作
-  [[nodiscard]] virtual PhaseCommand update(entt::registry& registry) = 0;
+  [[nodiscard]] virtual PhaseCommand update(entt::registry& registry,
+                                            double dt) = 0;
 
   /// @brief スタックから取り出される直前に呼ばれる
   /// @param registry ECS レジストリ

--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -10,7 +10,8 @@ void PhaseStack::update(entt::registry& registry) {
     return;
   }
 
-  auto command = m_stack.back()->update(registry);
+  const double dt = Scene::DeltaTime();
+  auto command = m_stack.back()->update(registry, dt);
 
   switch (command.type) {
     case IPhase::PhaseCommand::Type::None:

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -11,7 +11,8 @@ ScenarioPhase::ScenarioPhase(s3d::String sectionName)
 
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 
-IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry) {
+IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
+                                           double /*dt*/) {
   const auto& steps =
       registry.ctx().get<ScenarioData>().sections.at(m_sectionName);
   if (m_currentStep >= steps.size()) {

--- a/Ash2/src/Phase/ScenarioPhase.hpp
+++ b/Ash2/src/Phase/ScenarioPhase.hpp
@@ -16,8 +16,10 @@ class ScenarioPhase : public IPhase {
 
   /// @brief 毎フレーム 1 ステップを処理する
   /// @param registry ECS レジストリ
+  /// @param dt 経過時間（秒）
   /// @return フェーズスタックへの操作
-  [[nodiscard]] PhaseCommand update(entt::registry& registry) override;
+  [[nodiscard]] PhaseCommand update(entt::registry& registry,
+                                    double dt) override;
 
   /// @brief 生成したエンティティと NameLookup エントリを削除する
   /// @param registry ECS レジストリ

--- a/Ash2/src/Phase/WaitPhase.cpp
+++ b/Ash2/src/Phase/WaitPhase.cpp
@@ -1,0 +1,8 @@
+#include "Phase/WaitPhase.hpp"
+
+WaitPhase::WaitPhase(double duration) : m_duration(duration) {}
+
+IPhase::PhaseCommand WaitPhase::update(entt::registry&, double dt) {
+  m_elapsed += dt;
+  return m_elapsed >= m_duration ? PhaseCommand::Pop() : PhaseCommand::None();
+}

--- a/Ash2/src/Phase/WaitPhase.hpp
+++ b/Ash2/src/Phase/WaitPhase.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "IPhase.hpp"
+
+/// @brief 指定秒数待機してから Pop するフェーズ
+class WaitPhase : public IPhase {
+ public:
+  /// @brief コンストラクタ
+  /// @param duration 待機時間（秒）
+  explicit WaitPhase(double duration);
+
+  /// @brief 経過時間を積算し、duration を超えたら Pop を返す
+  /// @param registry ECS レジストリ
+  /// @param dt 経過時間（秒）
+  /// @return duration 経過後に Pop、それまでは None
+  [[nodiscard]] PhaseCommand update(entt::registry& registry,
+                                    double dt) override;
+
+ private:
+  /// 待機時間（秒）
+  double m_duration;
+  /// 積算経過時間（秒）
+  double m_elapsed = 0.0;
+};

--- a/Ash2/tests/TestWaitPhase.cpp
+++ b/Ash2/tests/TestWaitPhase.cpp
@@ -1,0 +1,30 @@
+#if USE_TEST
+#include <ThirdParty/Catch2/catch.hpp>
+#include <ThirdParty/entt/entt.hpp>
+
+#include "Phase/WaitPhase.hpp"
+
+TEST_CASE("WaitPhase - returns None before duration elapses") {
+  entt::registry registry;
+  WaitPhase phase{2.0};
+  auto cmd = phase.update(registry, 1.0);
+  REQUIRE(cmd.type == IPhase::PhaseCommand::Type::None);
+}
+
+TEST_CASE("WaitPhase - returns Pop when duration is reached exactly") {
+  entt::registry registry;
+  WaitPhase phase{1.0};
+  auto cmd = phase.update(registry, 1.0);
+  REQUIRE(cmd.type == IPhase::PhaseCommand::Type::Pop);
+}
+
+TEST_CASE("WaitPhase - returns Pop after accumulated dt exceeds duration") {
+  entt::registry registry;
+  WaitPhase phase{1.0};
+  auto first = phase.update(registry, 0.6);
+  REQUIRE(first.type == IPhase::PhaseCommand::Type::None);
+  auto second = phase.update(registry, 0.6);
+  REQUIRE(second.type == IPhase::PhaseCommand::Type::Pop);
+}
+
+#endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,9 @@ Ash2/
 │   │       ├── DemoPhase.hpp       # プレイヤー操作デモシーン
 │   │       ├── DemoPhase.cpp
 │   │       ├── ScenarioPhase.hpp   # TOML シナリオ進行フェーズ
-│   │       └── ScenarioPhase.cpp
+│   │       ├── ScenarioPhase.cpp
+│   │       ├── WaitPhase.hpp       # 指定秒数待機フェーズ
+│   │       └── WaitPhase.cpp
 │   ├── App/
 │   │   └── config/
 │   │       ├── player.toml     # プレイヤー設定ファイル
@@ -76,9 +78,9 @@ Ash2/
 ```
 Main()
   └─ System::Update() ループ
-       ├─ PhaseStack::update(registry)
-       │    └─ IPhase::update(registry)  ← 現在の最前面フェーズ
-       └─ DrawSystem::draw(registry)     ← 描画（depth ソート後）
+       ├─ PhaseStack::update(registry)          ← Scene::DeltaTime() を取得
+       │    └─ IPhase::update(registry, dt)     ← 現在の最前面フェーズ
+       └─ DrawSystem::draw(registry)            ← 描画（depth ソート後）
 ```
 
 `entt::registry` をゲーム全体で共有し、フェーズ間でエンティティの状態を引き継ぐ。
@@ -91,9 +93,9 @@ Main()
 PhaseStack
   └─ Array<unique_ptr<IPhase>>  （末尾 = 最前面）
        ├─ IPhase（抽象）
-       │   ├─ onAfterPush()    プッシュ直後に呼ばれる
-       │   ├─ update()         毎フレーム更新（純粋仮想）→ PhaseCommand を返す
-       │   └─ onBeforePop()    ポップ直前に呼ばれる
+       │   ├─ onAfterPush()        プッシュ直後に呼ばれる
+       │   ├─ update(registry, dt) 毎フレーム更新（純粋仮想）→ PhaseCommand を返す
+       │   └─ onBeforePop()        ポップ直前に呼ばれる
        └─ PhaseCommand
            ├─ None   継続
            ├─ Pop    自身をポップ
@@ -182,5 +184,6 @@ PhaseStack
 | `src/Phase/PhaseStack.hpp/.cpp` | `PhaseStack` | フェーズをスタックで管理 |
 | `src/Phase/DemoPhase.hpp/.cpp` | `DemoPhase` | プレイヤー操作デモシーン |
 | `src/Phase/ScenarioPhase.hpp/.cpp` | `ScenarioPhase` | TOML シナリオ進行フェーズ |
+| `src/Phase/WaitPhase.hpp/.cpp` | `WaitPhase` | 指定秒数待機してから Pop するフェーズ |
 | `src/System/DrawSystem.hpp/.cpp` | `DrawSystem` | depth ソート後に Drawable を描画 |
 | `src/System/NameLookup.hpp` | `NameLookup` | 名前→エンティティ参照コンテキスト（型エイリアス） |


### PR DESCRIPTION
## Summary

- `IPhase::update()` に `double dt` 引数を追加し、`PhaseStack::update()` で `Scene::DeltaTime()` を取得して渡すよう変更
- `DemoPhase` / `ScenarioPhase` のシグネチャを更新
- 指定秒数待機してから Pop する `WaitPhase` を新規実装
- `WaitPhase` のユニットテストを追加

close #29

## Test plan

- [x] Visual Studio 2022 でビルドが通ること
- [x] `WaitPhase` のユニットテスト（TestWaitPhase.cpp）が全パスすること