### PR TITLE
Isolate Siv3D runtime deps into Main.cpp via FrameData

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -338,7 +338,9 @@
   <ItemGroup>
     <ClInclude Include="src\Component\Drawable.hpp" />
     <ClInclude Include="src\Component\Name.hpp" />
+    <ClInclude Include="src\Input\InputState.hpp" />
     <ClInclude Include="src\Input\PlayerInputAction.hpp" />
+    <ClInclude Include="src\Phase\FrameData.hpp" />
     <ClInclude Include="src\Component\Player.hpp" />
     <ClInclude Include="src\Component\Velocity.hpp" />
     <ClInclude Include="src\System\DrawSystem.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -869,8 +869,14 @@
     </Xml>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Input\InputState.hpp">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
     <ClInclude Include="Input\PlayerInputAction.hpp">
       <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="Phase\FrameData.hpp">
+      <Filter>Header Files\Phase</Filter>
     </ClInclude>
     <ClInclude Include="Component\Drawable.hpp">
       <Filter>Header Files\Component</Filter>

--- a/Ash2/src/Input/InputState.hpp
+++ b/Ash2/src/Input/InputState.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+/// @brief フレームごとのプレイヤー入力状態（Siv3D 非依存）
+struct InputState {
+  /// 左移動キーが押されている
+  bool moveLeft = false;
+  /// 右移動キーが押されている
+  bool moveRight = false;
+  /// 奥移動キーが押されている
+  bool moveForward = false;
+  /// 手前移動キーが押されている
+  bool moveBackward = false;
+  /// ジャンプキーが押された（1フレーム限り）
+  bool jumpDown = false;
+};

--- a/Ash2/src/Input/PlayerInputAction.hpp
+++ b/Ash2/src/Input/PlayerInputAction.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <Siv3D.hpp>
 
+#include "Input/InputState.hpp"
+
 /// @brief プレイヤー操作のキー割り当て
 struct PlayerInputAction {
   /// 左移動
@@ -17,6 +19,10 @@ struct PlayerInputAction {
   /// @brief デフォルトのキー割り当てを返す
   /// @return デフォルトの PlayerInputAction
   [[nodiscard]] static PlayerInputAction Default();
+
+  /// @brief 現在のキー入力状態を InputState に変換して返す
+  /// @return フレームの入力状態
+  [[nodiscard]] InputState toInputState() const;
 };
 
 inline PlayerInputAction PlayerInputAction::Default() {
@@ -26,5 +32,15 @@ inline PlayerInputAction PlayerInputAction::Default() {
       .moveForward = KeyUp | KeyW,
       .moveBackward = KeyDown | KeyS,
       .jump = KeySpace,
+  };
+}
+
+inline InputState PlayerInputAction::toInputState() const {
+  return {
+      .moveLeft = moveLeft.pressed(),
+      .moveRight = moveRight.pressed(),
+      .moveForward = moveForward.pressed(),
+      .moveBackward = moveBackward.pressed(),
+      .jumpDown = jump.down(),
   };
 }

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -5,6 +5,7 @@
 #include "Config/PlayerConfig.hpp"
 #include "Config/ScenarioData.hpp"
 #include "Input/PlayerInputAction.hpp"
+#include "Phase/FrameData.hpp"
 #include "Phase/PhaseRegistry.hpp"
 #include "Phase/PhaseStack.hpp"
 #include "Phase/ScenarioPhase.hpp"
@@ -33,17 +34,21 @@ void Main() {
 
   const TOMLReader playerToml(U"config/player.toml");
   registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(playerToml));
-  registry.ctx().emplace<PlayerInputAction>(PlayerInputAction::Default());
 
   const TOMLReader scenarioToml(U"config/scenario.toml");
   registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(scenarioToml));
 
   registry.ctx().emplace<PhaseRegistry>(MakeDefaultPhaseRegistry());
 
+  const PlayerInputAction actions = PlayerInputAction::Default();
   PhaseStack phaseStack(std::make_unique<ScenarioPhase>(U"init"), registry);
 
   while (System::Update()) {
-    phaseStack.update(registry);
+    const FrameData frameData{
+        .dt = Scene::DeltaTime(),
+        .input = actions.toInputState(),
+    };
+    phaseStack.update(registry, frameData);
     DrawSystem::Draw(registry);
   }
 }

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -5,7 +5,7 @@
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/PlayerConfig.hpp"
-#include "Input/PlayerInputAction.hpp"
+#include "Phase/FrameData.hpp"
 
 void DemoPhase::onAfterPush(entt::registry& registry) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -18,30 +18,31 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
       player, RectDrawable{.size = cfg.spriteSize, .color = cfg.spriteColor});
 }
 
-IPhase::PhaseCommand DemoPhase::update(entt::registry& registry, double dt) {
+IPhase::PhaseCommand DemoPhase::update(entt::registry& registry,
+                                       const FrameData& frameData) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
-  const auto& actions = registry.ctx().get<PlayerInputAction>();
+  const auto& input = frameData.input;
 
-  const double vw = actions.moveRight.pressed()  ? cfg.speed
-                    : actions.moveLeft.pressed() ? -cfg.speed
-                                                 : 0.0;
-  const double vd = actions.moveForward.pressed()    ? cfg.speed
-                    : actions.moveBackward.pressed() ? -cfg.speed
-                                                     : 0.0;
+  const double vw = input.moveRight  ? cfg.speed
+                    : input.moveLeft ? -cfg.speed
+                                     : 0.0;
+  const double vd = input.moveForward    ? cfg.speed
+                    : input.moveBackward ? -cfg.speed
+                                         : 0.0;
 
   auto view = registry.view<Player, WorldPos, Velocity>();
   for (auto [entity, pos, vel] : view.each()) {
     vel.w = vw;
     vel.d = vd;
-    pos.w += vel.w * dt;
-    pos.d += vel.d * dt;
+    pos.w += vel.w * frameData.dt;
+    pos.d += vel.d * frameData.dt;
 
-    if (actions.jump.down() && pos.isOnGround()) {
+    if (input.jumpDown && pos.isOnGround()) {
       vel.h = cfg.jumpSpeed;
     }
 
-    vel.h -= cfg.gravity * dt;
-    pos.h += vel.h * dt;
+    vel.h -= cfg.gravity * frameData.dt;
+    pos.h += vel.h * frameData.dt;
 
     if (pos.h < 0.0) {
       pos.h = 0.0;

--- a/Ash2/src/Phase/DemoPhase.hpp
+++ b/Ash2/src/Phase/DemoPhase.hpp
@@ -11,8 +11,8 @@ class DemoPhase : public IPhase {
 
   /// @brief 毎フレームの更新処理
   /// @param registry ECS レジストリ
-  /// @param dt 経過時間（秒）
+  /// @param frameData フレームごとの更新データ
   /// @return フェーズスタックへの操作
   [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    double dt) override;
+                                    const FrameData& frameData) override;
 };

--- a/Ash2/src/Phase/FrameData.hpp
+++ b/Ash2/src/Phase/FrameData.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Input/InputState.hpp"
+
+/// @brief フレームごとの更新データ
+struct FrameData {
+  /// 経過時間（秒）
+  double dt = 0.0;
+  /// 入力状態
+  InputState input;
+};

--- a/Ash2/src/Phase/IPhase.hpp
+++ b/Ash2/src/Phase/IPhase.hpp
@@ -4,6 +4,8 @@
 
 #include <ThirdParty/entt/entt.hpp>
 
+#include "Phase/FrameData.hpp"
+
 /// @brief フェーズの基底クラス
 class IPhase {
  public:
@@ -49,10 +51,10 @@ class IPhase {
 
   /// @brief 毎フレームの更新処理
   /// @param registry ECS レジストリ
-  /// @param dt 経過時間（秒）
+  /// @param frameData フレームごとの更新データ
   /// @return フェーズスタックへの操作
   [[nodiscard]] virtual PhaseCommand update(entt::registry& registry,
-                                            double dt) = 0;
+                                            const FrameData& frameData) = 0;
 
   /// @brief スタックから取り出される直前に呼ばれる
   /// @param registry ECS レジストリ

--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -5,13 +5,12 @@ PhaseStack::PhaseStack(std::unique_ptr<IPhase>&& initialPhase,
   push(registry, std::move(initialPhase));
 }
 
-void PhaseStack::update(entt::registry& registry) {
+void PhaseStack::update(entt::registry& registry, const FrameData& frameData) {
   if (m_stack.empty()) {
     return;
   }
 
-  const double dt = Scene::DeltaTime();
-  auto command = m_stack.back()->update(registry, dt);
+  auto command = m_stack.back()->update(registry, frameData);
 
   switch (command.type) {
     case IPhase::PhaseCommand::Type::None:

--- a/Ash2/src/Phase/PhaseStack.hpp
+++ b/Ash2/src/Phase/PhaseStack.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "IPhase.hpp"
+#include "Phase/FrameData.hpp"
 
 /// @brief フェーズをスタックで管理するクラス
 class PhaseStack {
@@ -13,7 +14,8 @@ class PhaseStack {
 
   /// @brief 毎フレームの更新処理
   /// @param registry ECS レジストリ
-  void update(entt::registry& registry);
+  /// @param frameData フレームごとの更新データ
+  void update(entt::registry& registry, const FrameData& frameData);
 
  private:
   /// @brief スタックの先頭フェーズを取り出す

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -13,7 +13,7 @@ ScenarioPhase::ScenarioPhase(s3d::String sectionName)
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 
 IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
-                                           double /*dt*/) {
+                                           const FrameData& /*frameData*/) {
   const auto& steps =
       registry.ctx().get<ScenarioData>().sections.at(m_sectionName);
   if (m_currentStep >= steps.size()) {

--- a/Ash2/src/Phase/ScenarioPhase.hpp
+++ b/Ash2/src/Phase/ScenarioPhase.hpp
@@ -16,10 +16,10 @@ class ScenarioPhase : public IPhase {
 
   /// @brief 毎フレーム 1 ステップを処理する
   /// @param registry ECS レジストリ
-  /// @param dt 経過時間（秒）
+  /// @param frameData フレームごとの更新データ
   /// @return フェーズスタックへの操作
   [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    double dt) override;
+                                    const FrameData& frameData) override;
 
   /// @brief 生成したエンティティと NameLookup エントリを削除する
   /// @param registry ECS レジストリ

--- a/Ash2/src/Phase/WaitPhase.cpp
+++ b/Ash2/src/Phase/WaitPhase.cpp
@@ -2,7 +2,8 @@
 
 WaitPhase::WaitPhase(double duration) : m_duration(duration) {}
 
-IPhase::PhaseCommand WaitPhase::update(entt::registry&, double dt) {
-  m_elapsed += dt;
+IPhase::PhaseCommand WaitPhase::update(entt::registry&,
+                                       const FrameData& frameData) {
+  m_elapsed += frameData.dt;
   return m_elapsed >= m_duration ? PhaseCommand::Pop() : PhaseCommand::None();
 }

--- a/Ash2/src/Phase/WaitPhase.hpp
+++ b/Ash2/src/Phase/WaitPhase.hpp
@@ -11,10 +11,10 @@ class WaitPhase : public IPhase {
 
   /// @brief 経過時間を積算し、duration を超えたら Pop を返す
   /// @param registry ECS レジストリ
-  /// @param dt 経過時間（秒）
+  /// @param frameData フレームごとの更新データ
   /// @return duration 経過後に Pop、それまでは None
   [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    double dt) override;
+                                    const FrameData& frameData) override;
 
  private:
   /// 待機時間（秒）

--- a/Ash2/tests/TestWaitPhase.cpp
+++ b/Ash2/tests/TestWaitPhase.cpp
@@ -2,28 +2,29 @@
 #include <ThirdParty/Catch2/catch.hpp>
 #include <ThirdParty/entt/entt.hpp>
 
+#include "Phase/FrameData.hpp"
 #include "Phase/WaitPhase.hpp"
 
 TEST_CASE("WaitPhase - returns None before duration elapses") {
   entt::registry registry;
   WaitPhase phase{2.0};
-  auto cmd = phase.update(registry, 1.0);
+  auto cmd = phase.update(registry, FrameData{.dt = 1.0});
   REQUIRE(cmd.type == IPhase::PhaseCommand::Type::None);
 }
 
 TEST_CASE("WaitPhase - returns Pop when duration is reached exactly") {
   entt::registry registry;
   WaitPhase phase{1.0};
-  auto cmd = phase.update(registry, 1.0);
+  auto cmd = phase.update(registry, FrameData{.dt = 1.0});
   REQUIRE(cmd.type == IPhase::PhaseCommand::Type::Pop);
 }
 
 TEST_CASE("WaitPhase - returns Pop after accumulated dt exceeds duration") {
   entt::registry registry;
   WaitPhase phase{1.0};
-  auto first = phase.update(registry, 0.6);
+  auto first = phase.update(registry, FrameData{.dt = 0.6});
   REQUIRE(first.type == IPhase::PhaseCommand::Type::None);
-  auto second = phase.update(registry, 0.6);
+  auto second = phase.update(registry, FrameData{.dt = 0.6});
   REQUIRE(second.type == IPhase::PhaseCommand::Type::Pop);
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,7 +96,7 @@ PhaseStack
   └─ Array<unique_ptr<IPhase>>  （末尾 = 最前面）
        ├─ IPhase（抽象）
        │   ├─ onAfterPush()        プッシュ直後に呼ばれる
-       │   ├─ update(registry, dt) 毎フレーム更新（純粋仮想）→ PhaseCommand を返す
+       │   ├─ update(registry, frameData) 毎フレーム更新（純粋仮想）→ PhaseCommand を返す
        │   └─ onBeforePop()        ポップ直前に呼ばれる
        └─ PhaseCommand
            ├─ None   継続
@@ -106,6 +106,7 @@ PhaseStack
 ```
 
 `IPhase` を継承してフェーズ（タイトル・ゲームプレイ等）を実装する。
+`update()` に渡される `FrameData` は `dt`（経過時間）と `InputState`（入力状態）をまとめた Siv3D 非依存の構造体で、テスト時に直接構築して渡せる。
 
 ### ECS（EnTT）
 
@@ -122,12 +123,12 @@ PhaseStack
 
 ### 入力管理（Input）
 
-プレイヤー操作のキー割り当てを `PlayerInputAction` 構造体で管理する。
+入力管理は Humble Object パターンで Siv3D ランタイム依存を `Main.cpp` に閉じ込める。
 
-- 各アクション（moveLeft / moveRight / moveForward / moveBackward / jump 等）を Siv3D の `InputGroup` で保持
-- `InputGroup` は複数のキーを OR でまとめられるため、「左矢印またはA」のような複合割り当てが可能
-- `Default()` ファクトリでデフォルト割り当てを生成し、`registry.ctx()` に格納
-- キーコンフィグ対応時は `PlayerInputAction` の中身を差し替えるだけでよい
+- `PlayerInputAction`（Siv3D 依存）: キー割り当てを `InputGroup` で保持。`Main()` のローカル変数として管理し、キーコンフィグ対応時は中身を差し替えるだけでよい
+- `InputState`（Siv3D 非依存）: フレームごとの入力を plain `bool` で保持
+- `PlayerInputAction::toInputState()` で毎フレーム `InputState` に変換し、`FrameData` に格納してフェーズに渡す
+- フェーズは `FrameData::input` を参照するだけでよく、Siv3D の `InputGroup` に依存しない
 
 ### 設定値管理（Config）
 


### PR DESCRIPTION
## Summary

- `InputState`（plain bool）と `FrameData`（`dt` + `InputState`）を新規追加
- `PlayerInputAction::toInputState()` でフレームごとに入力状態を変換
- `IPhase::update()` / `PhaseStack::update()` の引数を `const FrameData&` に統一
- `PlayerInputAction` を `registry.ctx()` から外し `Main()` のローカル変数へ
- Siv3D ランタイム依存（`InputGroup::pressed()` / `down()`、`Scene::DeltaTime()`）が `Main.cpp` のみに集約される

## Test plan

- [x] Visual Studio で Debug ビルドが通ること
- [x] テストがすべてパスすること
- [x] ゲームを起動してプレイヤーが移動・ジャンプできること

close #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)