### PR TITLE
Manage player parts with Hierarchy

### DIFF
--- a/Ash2/App/config/player.toml
+++ b/Ash2/App/config/player.toml
@@ -1,6 +1,35 @@
 speed = 200.0
 jump_speed = 400.0
 gravity = 980.0
-sprite_width = 40.0
-sprite_height = 60.0
-sprite_color = {r = 1.0, g = 1.0, b = 1.0}
+
+[body]
+offset = {w = 0.0, h = 25.0, d = 0.0}
+radius = 20.0
+start_angle = 1.5708
+angle = 3.14159
+color = {r = 0.941, g = 0.941, b = 0.941}
+
+[head]
+offset = {w = 0.0, h = 60.0, d = -0.1}
+radius = 12.0
+color = {r = 0.941, g = 0.941, b = 0.941}
+
+[hand_front]
+offset = {w = 25.0, h = 30.0, d = -0.3}
+radius = 7.0
+color = {r = 0.941, g = 0.941, b = 0.941}
+
+[hand_back]
+offset = {w = -25.0, h = 30.0, d = 0.3}
+radius = 7.0
+color = {r = 0.941, g = 0.941, b = 0.941}
+
+[foot_left]
+offset = {w = -12.0, h = 5.0, d = 0.2}
+radius = 8.0
+color = {r = 0.941, g = 0.941, b = 0.941}
+
+[foot_right]
+offset = {w = 12.0, h = 5.0, d = 0.2}
+radius = 8.0
+color = {r = 0.941, g = 0.941, b = 0.941}

--- a/Ash2/App/config/player.toml
+++ b/Ash2/App/config/player.toml
@@ -3,33 +3,33 @@ jump_speed = 400.0
 gravity = 980.0
 
 [body]
-offset = {w = 0.0, h = 35.0, d = 0.0}
-radius = 30.0
-start_angle = 149.0
-angle = 66.0
+offset = {w = 0.0, h = 40.0, d = 0.0}
+radius = 36.0
+start_angle = 155.0
+angle = 50.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [head]
-offset = {w = 0.0, h = 35.0, d = -0.1}
-radius = 15.0
+offset = {w = 0.0, h = 40.0, d = -0.1}
+radius = 18.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [hand_front]
-offset = {w = 25.0, h = 30.0, d = -0.3}
-radius = 5.0
+offset = {w = 9.0, h = 19.0, d = -0.3}
+radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [hand_back]
-offset = {w = -25.0, h = 30.0, d = 0.3}
-radius = 5.0
+offset = {w = -10.0, h = 21.0, d = 0.3}
+radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [foot_left]
-offset = {w = -12.0, h = 5.0, d = 0.2}
-radius = 5.0
+offset = {w = -8.0, h = 6.0, d = 0.2}
+radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [foot_right]
-offset = {w = 12.0, h = 5.0, d = 0.2}
-radius = 5.0
+offset = {w = +7.0, h = 5.0, d = 0.2}
+radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}

--- a/Ash2/App/config/player.toml
+++ b/Ash2/App/config/player.toml
@@ -3,33 +3,33 @@ jump_speed = 400.0
 gravity = 980.0
 
 [body]
-offset = {w = 0.0, h = 25.0, d = 0.0}
-radius = 20.0
-start_angle = 1.5708
-angle = 3.14159
+offset = {w = 0.0, h = 35.0, d = 0.0}
+radius = 30.0
+start_angle = 149.0
+angle = 66.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [head]
-offset = {w = 0.0, h = 60.0, d = -0.1}
-radius = 12.0
+offset = {w = 0.0, h = 35.0, d = -0.1}
+radius = 15.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [hand_front]
 offset = {w = 25.0, h = 30.0, d = -0.3}
-radius = 7.0
+radius = 5.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [hand_back]
 offset = {w = -25.0, h = 30.0, d = 0.3}
-radius = 7.0
+radius = 5.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [foot_left]
 offset = {w = -12.0, h = 5.0, d = 0.2}
-radius = 8.0
+radius = 5.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
 [foot_right]
 offset = {w = 12.0, h = 5.0, d = 0.2}
-radius = 8.0
+radius = 5.0
 color = {r = 0.941, g = 0.941, b = 0.941}

--- a/Ash2/App/config/scenario.toml
+++ b/Ash2/App/config/scenario.toml
@@ -4,16 +4,5 @@ phase = "scenario"
 param = "GameStart"
 
 [[GameStart]]
-action = "make"
-name = "player"
-worldPos = {w = 100.0, h = 0.0, d = 200.0}
-drawable = {w = 50.0, h = 80.0, r = 1.0, g = 0.33, b = 0.2}
-
-[[GameStart]]
-action = "push"
-phase = "wait"
-duration = 2.0
-
-[[GameStart]]
 action = "push"
 phase = "demo"

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -1,14 +1,39 @@
 #include "PlayerConfig.hpp"
 
+namespace {
+WorldPos ParseOffset(const s3d::TOMLValue& v) {
+  return {.w = v[U"w"].get<double>(),
+          .h = v[U"h"].get<double>(),
+          .d = v[U"d"].get<double>()};
+}
+
+s3d::ColorF ParseColor(const s3d::TOMLValue& v) {
+  return {v[U"r"].get<double>(), v[U"g"].get<double>(), v[U"b"].get<double>()};
+}
+
+PlayerPiePartConfig ParsePiePart(const s3d::TOMLValue& v) {
+  return {.offset = ParseOffset(v[U"offset"]),
+          .radius = v[U"radius"].get<double>(),
+          .startAngle = v[U"start_angle"].get<double>(),
+          .angle = v[U"angle"].get<double>(),
+          .color = ParseColor(v[U"color"])};
+}
+
+PlayerCirclePartConfig ParseCirclePart(const s3d::TOMLValue& v) {
+  return {.offset = ParseOffset(v[U"offset"]),
+          .radius = v[U"radius"].get<double>(),
+          .color = ParseColor(v[U"color"])};
+}
+}  // namespace
+
 PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
-  return PlayerConfig{
-      .speed = toml[U"speed"].get<double>(),
-      .jumpSpeed = toml[U"jump_speed"].get<double>(),
-      .gravity = toml[U"gravity"].get<double>(),
-      .spriteSize = SizeF{toml[U"sprite_width"].get<double>(),
-                          toml[U"sprite_height"].get<double>()},
-      .spriteColor = ColorF{toml[U"sprite_color"][U"r"].get<double>(),
-                            toml[U"sprite_color"][U"g"].get<double>(),
-                            toml[U"sprite_color"][U"b"].get<double>()},
-  };
+  return {.speed = toml[U"speed"].get<double>(),
+          .jumpSpeed = toml[U"jump_speed"].get<double>(),
+          .gravity = toml[U"gravity"].get<double>(),
+          .body = ParsePiePart(toml[U"body"]),
+          .head = ParseCirclePart(toml[U"head"]),
+          .handFront = ParseCirclePart(toml[U"hand_front"]),
+          .handBack = ParseCirclePart(toml[U"hand_back"]),
+          .footLeft = ParseCirclePart(toml[U"foot_left"]),
+          .footRight = ParseCirclePart(toml[U"foot_right"])};
 }

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -14,8 +14,8 @@ s3d::ColorF ParseColor(const s3d::TOMLValue& v) {
 PlayerPiePartConfig ParsePiePart(const s3d::TOMLValue& v) {
   return {.offset = ParseOffset(v[U"offset"]),
           .radius = v[U"radius"].get<double>(),
-          .startAngle = v[U"start_angle"].get<double>(),
-          .angle = v[U"angle"].get<double>(),
+          .startAngle = Math::ToRadians(v[U"start_angle"].get<double>()),
+          .angle = Math::ToRadians(v[U"angle"].get<double>()),
           .color = ParseColor(v[U"color"])};
 }
 

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -1,6 +1,32 @@
 #pragma once
 #include <Siv3D.hpp>
 
+#include "Component/WorldPos.hpp"
+
+/// @brief 扇形パーツの設定値
+struct PlayerPiePartConfig {
+  /// 親からの相対座標
+  WorldPos offset;
+  /// 半径
+  double radius;
+  /// 開始角度（ラジアン、12時方向から時計回り）
+  double startAngle;
+  /// 角度（ラジアン）
+  double angle;
+  /// 描画色
+  s3d::ColorF color;
+};
+
+/// @brief 円形パーツの設定値
+struct PlayerCirclePartConfig {
+  /// 親からの相対座標
+  WorldPos offset;
+  /// 半径
+  double radius;
+  /// 描画色
+  s3d::ColorF color;
+};
+
 /// @brief プレイヤーの設定値
 struct PlayerConfig {
   /// 横移動速度（ピクセル/秒）
@@ -9,10 +35,18 @@ struct PlayerConfig {
   double jumpSpeed;
   /// 重力加速度（ピクセル/秒^2）
   double gravity;
-  /// スプライトサイズ（ピクセル）
-  s3d::SizeF spriteSize;
-  /// スプライト色
-  s3d::ColorF spriteColor;
+  /// 体パーツ設定
+  PlayerPiePartConfig body;
+  /// 頭パーツ設定
+  PlayerCirclePartConfig head;
+  /// 手（前）パーツ設定
+  PlayerCirclePartConfig handFront;
+  /// 手（後）パーツ設定
+  PlayerCirclePartConfig handBack;
+  /// 足（左）パーツ設定
+  PlayerCirclePartConfig footLeft;
+  /// 足（右）パーツ設定
+  PlayerCirclePartConfig footRight;
 
   /// @brief TOML からプレイヤー設定を生成する
   /// @param toml TOML 値

--- a/Ash2/src/Input/InputState.hpp
+++ b/Ash2/src/Input/InputState.hpp
@@ -12,4 +12,6 @@ struct InputState {
   bool moveBackward = false;
   /// ジャンプキーが押された（1フレーム限り）
   bool jumpDown = false;
+  /// 設定再読み込みキーが押された（1フレーム限り）
+  bool reloadConfig = false;
 };

--- a/Ash2/src/Input/PlayerInputAction.hpp
+++ b/Ash2/src/Input/PlayerInputAction.hpp
@@ -15,6 +15,8 @@ struct PlayerInputAction {
   InputGroup moveBackward;
   /// ジャンプ
   InputGroup jump;
+  /// 設定再読み込み
+  InputGroup reloadConfig;
 
   /// @brief デフォルトのキー割り当てを返す
   /// @return デフォルトの PlayerInputAction
@@ -32,6 +34,7 @@ inline PlayerInputAction PlayerInputAction::Default() {
       .moveForward = KeyUp | KeyW,
       .moveBackward = KeyDown | KeyS,
       .jump = KeySpace,
+      .reloadConfig = KeyF5,
   };
 }
 
@@ -42,5 +45,6 @@ inline InputState PlayerInputAction::toInputState() const {
       .moveForward = moveForward.pressed(),
       .moveBackward = moveBackward.pressed(),
       .jumpDown = jump.down(),
+      .reloadConfig = reloadConfig.down(),
   };
 }

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -49,6 +49,10 @@ void Main() {
         .dt = Scene::DeltaTime(),
         .input = actions.toInputState(),
     };
+    if (frameData.input.reloadConfig) {
+      const TOMLReader playerToml(U"config/player.toml");
+      registry.ctx().get<PlayerConfig>() = PlayerConfig::FromToml(playerToml);
+    }
     phaseStack.update(registry, frameData);
     AttachmentSystem::UpdateTransform(registry);
     DrawSystem::Draw(registry);

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -1,21 +1,47 @@
 #include "Phase/DemoPhase.hpp"
 
 #include "Component/Drawable.hpp"
+#include "Component/Hierarchy.hpp"
+#include "Component/Name.hpp"
 #include "Component/Player.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/PlayerConfig.hpp"
 #include "Phase/FrameData.hpp"
+#include "System/NameLookup.hpp"
 
 void DemoPhase::onAfterPush(entt::registry& registry) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
 
-  auto player = registry.create();
-  registry.emplace<Player>(player);
-  registry.emplace<WorldPos>(player);
-  registry.emplace<Velocity>(player);
-  registry.emplace<Drawable>(
-      player, RectDrawable{.size = cfg.spriteSize, .color = cfg.spriteColor});
+  m_playerRoot = registry.create();
+  registry.emplace<Player>(m_playerRoot);
+  registry.emplace<WorldPos>(m_playerRoot);
+  registry.emplace<Velocity>(m_playerRoot);
+  registry.emplace<Name>(m_playerRoot, Name{U"player"});
+  registry.ctx().get<NameLookup>()[U"player"] = m_playerRoot;
+
+  const auto makeCircle = [&](const PlayerCirclePartConfig& part) {
+    auto e = registry.create();
+    registry.emplace<WorldPos>(e);
+    registry.emplace<Drawable>(
+        e, CircleDrawable{.radius = part.radius, .color = part.color});
+    Hierarchy::Attach(registry, m_playerRoot, e, part.offset);
+  };
+
+  auto body = registry.create();
+  registry.emplace<WorldPos>(body);
+  registry.emplace<Drawable>(body,
+                             PieDrawable{.radius = cfg.body.radius,
+                                         .startAngle = cfg.body.startAngle,
+                                         .angle = cfg.body.angle,
+                                         .color = cfg.body.color});
+  Hierarchy::Attach(registry, m_playerRoot, body, cfg.body.offset);
+
+  makeCircle(cfg.head);
+  makeCircle(cfg.handFront);
+  makeCircle(cfg.handBack);
+  makeCircle(cfg.footLeft);
+  makeCircle(cfg.footRight);
 }
 
 IPhase::PhaseCommand DemoPhase::update(entt::registry& registry,
@@ -51,4 +77,13 @@ IPhase::PhaseCommand DemoPhase::update(entt::registry& registry,
   }
 
   return PhaseCommand::None();
+}
+
+void DemoPhase::onBeforePop(entt::registry& registry) {
+  if (m_playerRoot == entt::null) {
+    return;
+  }
+  registry.ctx().get<NameLookup>().erase(U"player");
+  Hierarchy::DestroyWithChildren(registry, m_playerRoot);
+  m_playerRoot = entt::null;
 }

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -76,7 +76,16 @@ IPhase::PhaseCommand DemoPhase::update(entt::registry& registry,
     }
   }
 
+  if (frameData.input.reloadConfig) {
+    reloadPlayer(registry);
+  }
+
   return PhaseCommand::None();
+}
+
+void DemoPhase::reloadPlayer(entt::registry& registry) {
+  onBeforePop(registry);
+  onAfterPush(registry);
 }
 
 void DemoPhase::onBeforePop(entt::registry& registry) {

--- a/Ash2/src/Phase/DemoPhase.hpp
+++ b/Ash2/src/Phase/DemoPhase.hpp
@@ -5,7 +5,7 @@
 /// @brief プレイヤー操作デモシーン
 class DemoPhase : public IPhase {
  public:
-  /// @brief プレイヤーエンティティを生成する
+  /// @brief プレイヤーエンティティ（ルート＋パーツ6体）を生成する
   /// @param registry ECS レジストリ
   void onAfterPush(entt::registry& registry) override;
 
@@ -15,4 +15,12 @@ class DemoPhase : public IPhase {
   /// @return フェーズスタックへの操作
   [[nodiscard]] PhaseCommand update(entt::registry& registry,
                                     const FrameData& frameData) override;
+
+  /// @brief プレイヤーエンティティ（ルート＋子孫）を破棄する
+  /// @param registry ECS レジストリ
+  void onBeforePop(entt::registry& registry) override;
+
+ private:
+  /// プレイヤーのルートエンティティ
+  entt::entity m_playerRoot = entt::null;
 };

--- a/Ash2/src/Phase/DemoPhase.hpp
+++ b/Ash2/src/Phase/DemoPhase.hpp
@@ -21,6 +21,10 @@ class DemoPhase : public IPhase {
   void onBeforePop(entt::registry& registry) override;
 
  private:
+  /// @brief プレイヤーを破棄して最新の設定で再生成する
+  /// @param registry ECS レジストリ
+  void reloadPlayer(entt::registry& registry);
+
   /// プレイヤーのルートエンティティ
   entt::entity m_playerRoot = entt::null;
 };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,7 +150,7 @@ Humble Object パターンで Siv3D 依存を `Main.cpp` に閉じ込める。
 | `src/Component/Name.hpp` | `Name` | エンティティ名コンポーネント |
 | `src/Component/Player.hpp` | `Player` | プレイヤータグ（空構造体） |
 | `src/Component/Velocity.hpp` | `Velocity` | 速度コンポーネント |
-| `src/Config/PlayerConfig.hpp/.cpp` | `PlayerConfig` | プレイヤー設定値 |
+| `src/Config/PlayerConfig.hpp/.cpp` | `PlayerConfig`, `PlayerPiePartConfig`, `PlayerCirclePartConfig` | プレイヤーとパーツの設定値 |
 | `src/Config/ScenarioData.hpp/.cpp` | `ScenarioData` | シナリオデータ |
 | `src/Input/PlayerInputAction.hpp` | `PlayerInputAction` | プレイヤー操作のキー割り当て |
 | `src/Phase/IPhase.hpp` | `IPhase`, `PhaseCommand` | フェーズ基底クラスとコマンド |


### PR DESCRIPTION
## Summary

- `DemoPhase` でプレイヤーをルートエンティティ（アンカー）＋子エンティティ6体（体/頭/手x2/足x2）の親子構成に変更
- 体は `PieDrawable`、頭・手・足は `CircleDrawable`。d オフセットで描画順を制御
- `PlayerConfig` に `PlayerPiePartConfig` / `PlayerCirclePartConfig` を追加し、`player.toml` で各パーツの形状・色・オフセットを設定可能に
- 仮の `make player` エントリを `scenario.toml` から削除

Close #45

## Test plan

- [x] ビルドが通る
- [x] デモシーンでプレイヤー（6パーツ）が画面に表示される
- [x] 移動・ジャンプ時に全パーツが連動して動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)