### PR TITLE
Add shape border drawing

### DIFF
--- a/Ash2/App/config/player.toml
+++ b/Ash2/App/config/player.toml
@@ -8,52 +8,34 @@ radius = 36.0
 start_angle = 155.0
 angle = 50.0
 color = {r = 0.941, g = 0.941, b = 0.941}
-
-[body.border]
-thickness = 1.5
-color = {r = 0.2, g = 0.2, b = 0.2}
+border = {thickness = 1.5, color = {r = 0.2, g = 0.2, b = 0.2}}
 
 [head]
-offset = {w = 0.0, h = 40.0, d = -0.1}
+offset = {w = 0.0, h = 39.0, d = -0.1}
 radius = 18.0
 color = {r = 0.941, g = 0.941, b = 0.941}
-
-[head.border]
-thickness = 1.5
-color = {r = 0.2, g = 0.2, b = 0.2}
+border = {thickness = 1.5, color = {r = 0.2, g = 0.2, b = 0.2}}
 
 [hand_front]
-offset = {w = 9.0, h = 19.0, d = -0.3}
+offset = {w = 9.0, h = 17.0, d = -0.3}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
-
-[hand_front.border]
-thickness = 1.0
-color = {r = 0.2, g = 0.2, b = 0.2}
+border = {thickness = 1.0, color = {r = 0.2, g = 0.2, b = 0.2}}
 
 [hand_back]
 offset = {w = -10.0, h = 21.0, d = 0.3}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
-
-[hand_back.border]
-thickness = 1.0
-color = {r = 0.2, g = 0.2, b = 0.2}
+border = {thickness = 1.0, color = {r = 0.2, g = 0.2, b = 0.2}}
 
 [foot_left]
 offset = {w = -8.0, h = 6.0, d = 0.2}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
-
-[foot_left.border]
-thickness = 1.0
-color = {r = 0.2, g = 0.2, b = 0.2}
+border = {thickness = 1.0, color = {r = 0.2, g = 0.2, b = 0.2}}
 
 [foot_right]
-offset = {w = +7.0, h = 5.0, d = 0.2}
+offset = {w = +8.0, h = 4.0, d = 0.2}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
-
-[foot_right.border]
-thickness = 1.0
-color = {r = 0.2, g = 0.2, b = 0.2}
+border = {thickness = 1.0, color = {r = 0.2, g = 0.2, b = 0.2}}

--- a/Ash2/App/config/player.toml
+++ b/Ash2/App/config/player.toml
@@ -9,27 +9,51 @@ start_angle = 155.0
 angle = 50.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
+[body.border]
+thickness = 1.5
+color = {r = 0.2, g = 0.2, b = 0.2}
+
 [head]
 offset = {w = 0.0, h = 40.0, d = -0.1}
 radius = 18.0
 color = {r = 0.941, g = 0.941, b = 0.941}
+
+[head.border]
+thickness = 1.5
+color = {r = 0.2, g = 0.2, b = 0.2}
 
 [hand_front]
 offset = {w = 9.0, h = 19.0, d = -0.3}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
+[hand_front.border]
+thickness = 1.0
+color = {r = 0.2, g = 0.2, b = 0.2}
+
 [hand_back]
 offset = {w = -10.0, h = 21.0, d = 0.3}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
+
+[hand_back.border]
+thickness = 1.0
+color = {r = 0.2, g = 0.2, b = 0.2}
 
 [foot_left]
 offset = {w = -8.0, h = 6.0, d = 0.2}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
 
+[foot_left.border]
+thickness = 1.0
+color = {r = 0.2, g = 0.2, b = 0.2}
+
 [foot_right]
 offset = {w = +7.0, h = 5.0, d = 0.2}
 radius = 6.0
 color = {r = 0.941, g = 0.941, b = 0.941}
+
+[foot_right.border]
+thickness = 1.0
+color = {r = 0.2, g = 0.2, b = 0.2}

--- a/Ash2/src/Component/Drawable.hpp
+++ b/Ash2/src/Component/Drawable.hpp
@@ -3,12 +3,22 @@
 
 #include <variant>
 
+/// @brief 枠線スタイル
+struct BorderStyle {
+  /// 枠線の色
+  ColorF color;
+  /// 枠線の太さ
+  double thickness;
+};
+
 /// @brief 矩形描画データ
 struct RectDrawable {
   /// 描画サイズ（幅・高さ）
   SizeF size;
   /// 描画色
   ColorF color;
+  /// 枠線（none = 枠線なし）
+  Optional<BorderStyle> border;
 };
 
 /// @brief 円描画データ
@@ -17,6 +27,8 @@ struct CircleDrawable {
   double radius;
   /// 描画色
   ColorF color;
+  /// 枠線（none = 枠線なし）
+  Optional<BorderStyle> border;
 };
 
 /// @brief 扇形描画データ
@@ -29,6 +41,8 @@ struct PieDrawable {
   double angle;
   /// 描画色
   ColorF color;
+  /// 枠線（none = 枠線なし）
+  Optional<BorderStyle> border;
 };
 
 /// @brief 描画コンポーネント（描画形状の variant）

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -11,18 +11,29 @@ s3d::ColorF ParseColor(const s3d::TOMLValue& v) {
   return {v[U"r"].get<double>(), v[U"g"].get<double>(), v[U"b"].get<double>()};
 }
 
+s3d::Optional<BorderStyle> ParseBorder(const s3d::TOMLValue& v) {
+  const auto& border = v[U"border"];
+  if (border.getType() != s3d::TOMLValueType::Table) {
+    return s3d::none;
+  }
+  return BorderStyle{.color = ParseColor(border[U"color"]),
+                     .thickness = border[U"thickness"].get<double>()};
+}
+
 PlayerPiePartConfig ParsePiePart(const s3d::TOMLValue& v) {
   return {.offset = ParseOffset(v[U"offset"]),
           .radius = v[U"radius"].get<double>(),
           .startAngle = Math::ToRadians(v[U"start_angle"].get<double>()),
           .angle = Math::ToRadians(v[U"angle"].get<double>()),
-          .color = ParseColor(v[U"color"])};
+          .color = ParseColor(v[U"color"]),
+          .border = ParseBorder(v)};
 }
 
 PlayerCirclePartConfig ParseCirclePart(const s3d::TOMLValue& v) {
   return {.offset = ParseOffset(v[U"offset"]),
           .radius = v[U"radius"].get<double>(),
-          .color = ParseColor(v[U"color"])};
+          .color = ParseColor(v[U"color"]),
+          .border = ParseBorder(v)};
 }
 }  // namespace
 

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <Siv3D.hpp>
 
+#include "Component/Drawable.hpp"
 #include "Component/WorldPos.hpp"
 
 /// @brief 扇形パーツの設定値
@@ -15,6 +16,8 @@ struct PlayerPiePartConfig {
   double angle;
   /// 描画色
   s3d::ColorF color;
+  /// 枠線（none = 枠線なし）
+  s3d::Optional<BorderStyle> border;
 };
 
 /// @brief 円形パーツの設定値
@@ -25,6 +28,8 @@ struct PlayerCirclePartConfig {
   double radius;
   /// 描画色
   s3d::ColorF color;
+  /// 枠線（none = 枠線なし）
+  s3d::Optional<BorderStyle> border;
 };
 
 /// @brief プレイヤーの設定値

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -23,8 +23,9 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
   const auto makeCircle = [&](const PlayerCirclePartConfig& part) {
     auto e = registry.create();
     registry.emplace<WorldPos>(e);
-    registry.emplace<Drawable>(
-        e, CircleDrawable{.radius = part.radius, .color = part.color});
+    registry.emplace<Drawable>(e, CircleDrawable{.radius = part.radius,
+                                                 .color = part.color,
+                                                 .border = part.border});
     Hierarchy::Attach(registry, m_playerRoot, e, part.offset);
   };
 
@@ -34,7 +35,8 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
                              PieDrawable{.radius = cfg.body.radius,
                                          .startAngle = cfg.body.startAngle,
                                          .angle = cfg.body.angle,
-                                         .color = cfg.body.color});
+                                         .color = cfg.body.color,
+                                         .border = cfg.body.border});
   Hierarchy::Attach(registry, m_playerRoot, body, cfg.body.offset);
 
   makeCircle(cfg.head);

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -33,15 +33,35 @@ void DrawSystem::Draw(const entt::registry& registry) {
     std::visit(
         Overloaded{
             [&screenPos](const RectDrawable& shape) {
-              RectF{Arg::center(screenPos), shape.size.x, shape.size.y}.draw(
-                  shape.color);
+              const RectF rect{Arg::center(screenPos), shape.size.x,
+                               shape.size.y};
+              rect.draw(shape.color);
+              if (shape.border) {
+                rect.drawFrame(shape.border->thickness, shape.border->color);
+              }
             },
             [&screenPos](const CircleDrawable& shape) {
-              Circle{screenPos, shape.radius}.draw(shape.color);
+              const Circle circle{screenPos, shape.radius};
+              circle.draw(shape.color);
+              if (shape.border) {
+                circle.drawFrame(shape.border->thickness, shape.border->color);
+              }
             },
             [&screenPos](const PieDrawable& shape) {
-              Circle{screenPos, shape.radius}.drawPie(shape.startAngle,
-                                                      shape.angle, shape.color);
+              const Circle circle{screenPos, shape.radius};
+              circle.drawPie(shape.startAngle, shape.angle, shape.color);
+              if (shape.border) {
+                const auto& b = *shape.border;
+                circle.drawArc(shape.startAngle, shape.angle, 0.0, b.thickness,
+                               b.color);
+                const Vec2 p1 =
+                    screenPos + Vec2{Circular{shape.radius, shape.startAngle}};
+                const Vec2 p2 =
+                    screenPos + Vec2{Circular{shape.radius,
+                                              shape.startAngle + shape.angle}};
+                Line{screenPos, p1}.draw(b.thickness, b.color);
+                Line{screenPos, p2}.draw(b.thickness, b.color);
+              }
             },
         },
         entry.drawable.get());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,7 +146,7 @@ Humble Object パターンで Siv3D 依存を `Main.cpp` に閉じ込める。
 | `src/Component/WorldPos.hpp` | `WorldPos` | ワールド座標と画面座標変換 |
 | `src/Component/Hierarchy.hpp/.cpp` | `Hierarchy` | 親子関係（双方向連結リスト、操作は static メンバ関数経由のみ） |
 | `src/Component/LocalOffset.hpp` | `LocalOffset` | 親からの相対座標 |
-| `src/Component/Drawable.hpp` | `RectDrawable`, `CircleDrawable`, `PieDrawable`, `Drawable` | 描画コンポーネント（形状の variant） |
+| `src/Component/Drawable.hpp` | `BorderStyle`, `RectDrawable`, `CircleDrawable`, `PieDrawable`, `Drawable` | 描画コンポーネント（形状の variant）。各形状は `Optional<BorderStyle>` で枠線を持つ |
 | `src/Component/Name.hpp` | `Name` | エンティティ名コンポーネント |
 | `src/Component/Player.hpp` | `Player` | プレイヤータグ（空構造体） |
 | `src/Component/Velocity.hpp` | `Velocity` | 速度コンポーネント |


### PR DESCRIPTION
## Summary

- `BorderStyle` 構造体を追加し、各 `Drawable`（Rect / Circle / Pie）に `Optional<BorderStyle> border` を持たせた
- `DrawSystem` で枠線描画を実装（`drawFrame` / `drawArc` + `Line`）
- `PlayerConfig` で TOML の `border` インラインテーブルをパース
- `player.toml` の全パーツに枠線設定を追加

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)