### PR TITLE
Fix orphaned children on ScenarioPhase pop #60

### DIFF
--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -1,6 +1,7 @@
 #include "Phase/ScenarioPhase.hpp"
 
 #include "Component/Drawable.hpp"
+#include "Component/Hierarchy.hpp"
 #include "Component/Name.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/ScenarioData.hpp"
@@ -71,7 +72,7 @@ void ScenarioPhase::onBeforePop(entt::registry& registry) {
     if (registry.all_of<Name>(entity)) {
       lookup.erase(registry.get<Name>(entity).value);
     }
-    registry.destroy(entity);
+    Hierarchy::DestroyWithChildren(registry, entity);
   }
   m_createdEntities.clear();
 }


### PR DESCRIPTION
## Summary

- `ScenarioPhase::onBeforePop` で `registry.destroy(entity)` を直接呼んでいたため、子エンティティがアタッチされている場合に子孫が孤児として残っていた
- `Hierarchy::DestroyWithChildren(registry, entity)` に置き換えることで子孫を再帰的に破棄するよう修正

Closes #60