### PR TITLE
Fix Hierarchy::Attach not detaching from existing parent

### DIFF
--- a/Ash2/src/Component/Hierarchy.cpp
+++ b/Ash2/src/Component/Hierarchy.cpp
@@ -11,6 +11,8 @@ void Hierarchy::Attach(entt::registry& registry, entt::entity parent,
     registry.emplace<Hierarchy>(child);
   }
 
+  Detach(registry, child);
+
   auto& parentNode = registry.get<Hierarchy>(parent);
   auto& childNode = registry.get<Hierarchy>(child);
 

--- a/Ash2/src/Component/Hierarchy.hpp
+++ b/Ash2/src/Component/Hierarchy.hpp
@@ -17,6 +17,7 @@ class Hierarchy {
   [[nodiscard]] entt::entity prevSibling() const { return m_prevSibling; }
 
   /// @brief 子を親にアタッチする（先頭に O(1) 挿入）
+  /// @details 子がすでに別の親を持つ場合は先に Detach してから挿入する
   /// @param registry ECS レジストリ
   /// @param parent   親エンティティ（Hierarchy がなければ自動追加）
   /// @param child    子エンティティ（Hierarchy がなければ自動追加）

--- a/Ash2/tests/TestAttachmentSystem.cpp
+++ b/Ash2/tests/TestAttachmentSystem.cpp
@@ -125,4 +125,27 @@ TEST_CASE("AttachmentSystem - Detach removes child from linked list") {
   REQUIRE_FALSE(registry.all_of<LocalOffset>(child));
 }
 
+TEST_CASE("AttachmentSystem - re-attaching child to different parent") {
+  entt::registry registry;
+
+  auto parent1 = registry.create();
+  registry.emplace<WorldPos>(parent1);
+  auto parent2 = registry.create();
+  registry.emplace<WorldPos>(parent2);
+  auto child = registry.create();
+  registry.emplace<WorldPos>(child);
+
+  Hierarchy::Attach(registry, parent1, child);
+  Hierarchy::Attach(registry, parent2, child);
+
+  REQUIRE(registry.get<const Hierarchy>(parent1).firstChild() ==
+          entt::entity{entt::null});
+  REQUIRE(registry.get<const Hierarchy>(parent2).firstChild() == child);
+  REQUIRE(registry.get<const Hierarchy>(child).parent() == parent2);
+  REQUIRE(registry.get<const Hierarchy>(child).prevSibling() ==
+          entt::entity{entt::null});
+  REQUIRE(registry.get<const Hierarchy>(child).nextSibling() ==
+          entt::entity{entt::null});
+}
+
 #endif


### PR DESCRIPTION
## Summary

- `Hierarchy::Attach` now calls `Detach(registry, child)` before inserting the child into the new parent's linked list
- Prevents linked-list corruption when a child is re-parented from one entity to another
- Added a test case covering the re-attach scenario (`re-attaching child to different parent`)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)