### PR TITLE
IPhase::Push/Reset と PhaseStack に nullptr アサーションを追加 #61

### DIFF
--- a/Ash2/src/Phase/IPhase.hpp
+++ b/Ash2/src/Phase/IPhase.hpp
@@ -33,12 +33,12 @@ class IPhase {
     [[nodiscard]] static PhaseCommand Pop();
 
     /// @brief スタックにフェーズを積むコマンドを返す
-    /// @param phase 次のフェーズ
+    /// @param phase 次のフェーズ（nullptr 不可）
     /// @return Push コマンド
     [[nodiscard]] static PhaseCommand Push(std::unique_ptr<IPhase>&& phase);
 
     /// @brief スタックをクリアしてフェーズを積むコマンドを返す
-    /// @param phase 次のフェーズ
+    /// @param phase 次のフェーズ（nullptr 不可）
     /// @return Reset コマンド
     [[nodiscard]] static PhaseCommand Reset(std::unique_ptr<IPhase>&& phase);
   };
@@ -71,10 +71,12 @@ inline IPhase::PhaseCommand IPhase::PhaseCommand::Pop() {
 
 inline IPhase::PhaseCommand IPhase::PhaseCommand::Push(
     std::unique_ptr<IPhase>&& phase) {
+  assert(phase != nullptr);
   return {.type = Type::Push, .nextPhase = std::move(phase)};
 }
 
 inline IPhase::PhaseCommand IPhase::PhaseCommand::Reset(
     std::unique_ptr<IPhase>&& phase) {
+  assert(phase != nullptr);
   return {.type = Type::Reset, .nextPhase = std::move(phase)};
 }

--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -21,10 +21,12 @@ void PhaseStack::update(entt::registry& registry, const FrameData& frameData) {
       break;
 
     case IPhase::PhaseCommand::Type::Push:
+      assert(command.nextPhase != nullptr);
       push(registry, std::move(command.nextPhase));
       break;
 
     case IPhase::PhaseCommand::Type::Reset:
+      assert(command.nextPhase != nullptr);
       while (not m_stack.empty()) {
         pop(registry);
       }

--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -42,6 +42,7 @@ void PhaseStack::pop(entt::registry& registry) {
 
 void PhaseStack::push(entt::registry& registry,
                       std::unique_ptr<IPhase>&& phase) {
+  assert(phase != nullptr);
   m_stack.push_back(std::move(phase));
   m_stack.back()->onAfterPush(registry);
 }


### PR DESCRIPTION
## 変更概要

- `PhaseCommand::Push()` / `PhaseCommand::Reset()` ファクトリ関数に `assert(phase != nullptr)` を追加
- `PhaseStack::update()` の Push / Reset ケースにも `assert(command.nextPhase != nullptr)` を追加して二重防護

nullptr を渡した場合にコンパイルエラーにはならないが、`PhaseStack` 側でクラッシュする問題（#61）を早期検出できるようにした。