### PR TITLE
Entity削除時にNameLookupを自動クリーンアップする

### DIFF
--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClCompile Include="TestWaitPhase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="TestNameLookup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="App\icon.ico">

--- a/Ash2/src/Component/Name.hpp
+++ b/Ash2/src/Component/Name.hpp
@@ -3,6 +3,6 @@
 
 /// @brief エンティティ名コンポーネント
 struct Name {
-  /// エンティティを識別する名前
-  s3d::String value;
+  /// エンティティを識別する名前（不変）
+  const s3d::String value;
 };

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -33,6 +33,7 @@ void Main() {
 
   entt::registry registry;
   registry.ctx().emplace<NameLookup>();
+  NameLookupSystem::Connect(registry);
 
   const TOMLReader playerToml(U"config/player.toml");
   registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(playerToml));

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -89,7 +89,6 @@ void DemoPhase::onBeforePop(entt::registry& registry) {
   if (m_playerRoot == entt::null) {
     return;
   }
-  registry.ctx().get<NameLookup>().erase(U"player");
   Hierarchy::DestroyWithChildren(registry, m_playerRoot);
   m_playerRoot = entt::null;
 }

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -67,11 +67,7 @@ IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
 }
 
 void ScenarioPhase::onBeforePop(entt::registry& registry) {
-  auto& lookup = registry.ctx().get<NameLookup>();
   for (auto entity : m_createdEntities) {
-    if (registry.all_of<Name>(entity)) {
-      lookup.erase(registry.get<Name>(entity).value);
-    }
     Hierarchy::DestroyWithChildren(registry, entity);
   }
   m_createdEntities.clear();

--- a/Ash2/src/System/NameLookup.hpp
+++ b/Ash2/src/System/NameLookup.hpp
@@ -2,6 +2,7 @@
 #include <Siv3D.hpp>
 
 #include <ThirdParty/entt/entt.hpp>
+#include <cassert>
 
 #include "Component/Name.hpp"
 
@@ -13,6 +14,7 @@ namespace NameLookupSystem {
 /// @brief Name コンポーネント削除時に NameLookup
 /// のエントリを削除するシグナルハンドラ
 inline void OnNameDestroyed(entt::registry& registry, entt::entity entity) {
+  assert(registry.ctx().find<NameLookup>() != nullptr);
   registry.ctx().get<NameLookup>().erase(registry.get<Name>(entity).value);
 }
 

--- a/Ash2/src/System/NameLookup.hpp
+++ b/Ash2/src/System/NameLookup.hpp
@@ -3,5 +3,23 @@
 
 #include <ThirdParty/entt/entt.hpp>
 
+#include "Component/Name.hpp"
+
 /// @brief 名前からエンティティへの参照を管理するコンテキスト
 using NameLookup = s3d::HashTable<s3d::String, entt::entity>;
+
+namespace NameLookupSystem {
+
+/// @brief Name コンポーネント削除時に NameLookup
+/// のエントリを削除するシグナルハンドラ
+inline void OnNameDestroyed(entt::registry& registry, entt::entity entity) {
+  registry.ctx().get<NameLookup>().erase(registry.get<Name>(entity).value);
+}
+
+/// @brief registry に Name 削除シグナルを登録する
+/// @param registry 対象レジストリ
+inline void Connect(entt::registry& registry) {
+  registry.on_destroy<Name>().connect<&OnNameDestroyed>();
+}
+
+}  // namespace NameLookupSystem

--- a/Ash2/tests/TestNameLookup.cpp
+++ b/Ash2/tests/TestNameLookup.cpp
@@ -1,0 +1,39 @@
+#if USE_TEST
+#include <ThirdParty/Catch2/catch.hpp>
+#include <ThirdParty/entt/entt.hpp>
+
+#include "Component/Name.hpp"
+#include "System/NameLookup.hpp"
+
+TEST_CASE("NameLookup - auto-cleanup on entity destroy") {
+  entt::registry registry;
+  registry.ctx().emplace<NameLookup>();
+  NameLookupSystem::Connect(registry);
+
+  const auto entity = registry.create();
+  registry.emplace<Name>(entity, Name{U"test"});
+  registry.ctx().get<NameLookup>()[U"test"] = entity;
+
+  REQUIRE(registry.ctx().get<NameLookup>().contains(U"test"));
+
+  registry.destroy(entity);
+
+  REQUIRE_FALSE(registry.ctx().get<NameLookup>().contains(U"test"));
+}
+
+TEST_CASE("NameLookup - auto-cleanup when Name component is removed") {
+  entt::registry registry;
+  registry.ctx().emplace<NameLookup>();
+  NameLookupSystem::Connect(registry);
+
+  const auto entity = registry.create();
+  registry.emplace<Name>(entity, Name{U"test"});
+  registry.ctx().get<NameLookup>()[U"test"] = entity;
+
+  registry.remove<Name>(entity);
+
+  REQUIRE_FALSE(registry.ctx().get<NameLookup>().contains(U"test"));
+
+  registry.destroy(entity);
+}
+#endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,4 +138,4 @@ Humble Object パターンで Siv3D 依存を `Main.cpp` に閉じ込める。
 | `src/System/AnimationSystem.hpp/.cpp` | `AnimationSystem` | スプライトアニメーション更新システム |
 | `src/System/AttachmentSystem.hpp/.cpp` | `AttachmentSystem` | 親子座標伝播システム |
 | `src/System/DrawSystem.hpp/.cpp` | `DrawSystem` | depth ソート後に Drawable を描画 |
-| `src/System/NameLookup.hpp` | `NameLookup` | 名前→エンティティ参照コンテキスト |
+| `src/System/NameLookup.hpp` | `NameLookup`, `NameLookupSystem` | 名前→エンティティ参照コンテキスト。`on_destroy<Name>` シグナルで自動クリーンアップ |


### PR DESCRIPTION
## 概要

- `Name.value` を `const` にして書き換えを禁止。entt が自動で `in_place_delete` を選択し swap-and-pop を回避する
- `NameLookupSystem::Connect()` で `on_destroy<Name>` シグナルを登録し、`Name` コンポーネント削除時に `NameLookup` を自動クリーンアップ
- `ScenarioPhase::onBeforePop()` / `DemoPhase::onBeforePop()` の手動クリーンアップコードを削除
- `TestNameLookup.cpp` でシグナルによる自動クリーンアップを検証

close #51