### PR TITLE
Hierarchy::Detach で前の兄弟が無効な場合に m_firstChild が誤って更新されるバグを修正する #69

### DIFF
--- a/Ash2/src/Component/Hierarchy.cpp
+++ b/Ash2/src/Component/Hierarchy.cpp
@@ -34,10 +34,11 @@ void Hierarchy::Detach(entt::registry& registry, entt::entity child) {
   auto& childNode = registry.get<Hierarchy>(child);
 
   if (childNode.m_parent != entt::null && registry.valid(childNode.m_parent)) {
-    if (childNode.m_prevSibling != entt::null &&
-        registry.valid(childNode.m_prevSibling)) {
-      registry.get<Hierarchy>(childNode.m_prevSibling).m_nextSibling =
-          childNode.m_nextSibling;
+    if (childNode.m_prevSibling != entt::null) {
+      if (registry.valid(childNode.m_prevSibling)) {
+        registry.get<Hierarchy>(childNode.m_prevSibling).m_nextSibling =
+            childNode.m_nextSibling;
+      }
     } else {
       registry.get<Hierarchy>(childNode.m_parent).m_firstChild =
           childNode.m_nextSibling;


### PR DESCRIPTION
## 変更概要

`Hierarchy::Detach` で `m_prevSibling` が存在するが既に破棄済みの場合、`else` ブランチに落ちて親の `m_firstChild` を誤って上書きするバグを修正。

条件式を `m_prevSibling != entt::null` と `registry.valid(m_prevSibling)` の2段階に分離し、`m_firstChild` の更新は先頭ノード（`m_prevSibling == entt::null`）のときのみ行うように変更した。

close #69