### PR TITLE
アセット管理ユーティリティの実装

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -361,6 +361,7 @@
     <ClInclude Include="src\Phase\ScenarioPhase.hpp" />
     <ClInclude Include="src\Phase\WaitPhase.hpp" />
     <ClInclude Include="src\stdafx.h" />
+    <ClInclude Include="src\Asset.hpp" />
     <ClInclude Include="src\Component\WorldPos.hpp" />
     <ClInclude Include="src\Phase\DemoPhase.hpp" />
     <ClInclude Include="src\Phase\IPhase.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -950,6 +950,9 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Asset.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Component\WorldPos.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>

--- a/Ash2/src/Asset.hpp
+++ b/Ash2/src/Asset.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief デバッグ・リリース共通のアセットリストを返す
+/// @details デバッグ時は `asset/` を再帰スキャンし `asset/asset_list`
+/// に書き出す。
+///          リリース時は埋め込みリソースの `asset/asset_list`
+///          を読み、相対パスとして返す。
+/// @return アセットパスの配列
+[[nodiscard]] inline Array<FilePath> GetAssetList() {
+#ifdef _DEBUG
+  Array<FilePath> list;
+  for (const auto& content :
+       FileSystem::DirectoryContents(U"asset", Recursive::Yes)) {
+    if (FileSystem::IsDirectory(content)) {
+      continue;
+    }
+    const auto relativePath = FileSystem::RelativePath(content);
+    if (relativePath == U"asset/asset_list") {
+      continue;
+    }
+    list << relativePath;
+  }
+  TextWriter writer(U"asset/asset_list");
+  if (not writer) {
+    Logger << U"[Asset] Failed to write asset/asset_list. Create the asset/ "
+              U"directory.";
+    return list;
+  }
+  for (const auto& path : list) {
+    writer.writeln(path);
+  }
+  return list;
+#else
+  TextReader reader(Resource(U"asset/asset_list"));
+  if (not reader) {
+    throw Error{U"asset/asset_list not embedded. Add it to Resource.rc."};
+  }
+  Array<FilePath> list;
+  while (const auto line = reader.readLine()) {
+    list << line.value();
+  }
+  return list;
+#endif
+}
+
+/// @brief デバッグ・リリース共通のアセットパスを返す
+/// @param path アセットの相対パス（例: `asset/image/player.png`）
+/// @return デバッグ時は FilePath、リリース時は Resource パス
+[[nodiscard]] inline FilePath AssetPath(StringView path) {
+#ifdef _DEBUG
+  return FilePath{path};
+#else
+  return Resource(path);
+#endif
+}
+
+/// @brief アセットをアセットシステムに登録する
+/// @details `.png` を TextureAsset、`.mp3` を AudioAsset として登録する。
+///          キーはファイルの相対パス（例: `asset/image/player.png`）。
+inline void RegisterAssets() {
+  for (const auto& path : GetAssetList()) {
+    const auto ext = FileSystem::Extension(path);
+    if (ext == U"png") {
+      TextureAsset::Register(path, AssetPath(path));
+    } else if (ext == U"mp3") {
+      AudioAsset::Register(path, AssetPath(path));
+    }
+  }
+}

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -2,6 +2,7 @@
 
 #include <ThirdParty/entt/entt.hpp>
 
+#include "Asset.hpp"
 #include "Component/AnimationData.hpp"
 #include "Config/PlayerConfig.hpp"
 #include "Config/ScenarioData.hpp"
@@ -27,6 +28,8 @@ static void RunTests() {
 #endif
 
 void Main() {
+  RegisterAssets();
+
 #if USE_TEST
   RunTests();
 #endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -139,3 +139,4 @@ Humble Object パターンで Siv3D 依存を `Main.cpp` に閉じ込める。
 | `src/System/AttachmentSystem.hpp/.cpp` | `AttachmentSystem` | 親子座標伝播システム |
 | `src/System/DrawSystem.hpp/.cpp` | `DrawSystem` | depth ソート後に Drawable を描画 |
 | `src/System/NameLookup.hpp` | `NameLookup`, `NameLookupSystem` | 名前→エンティティ参照コンテキスト。`on_destroy<Name>` シグナルで自動クリーンアップ |
+| `src/Asset.hpp` | `GetAssetList`, `AssetPath`, `RegisterAssets` | デバッグ/リリース切替のアセット列挙・登録ユーティリティ |


### PR DESCRIPTION
## 変更概要

Issue #58 の実装。デバッグ/リリースビルドの違いを呼び出し側に意識させないアセット管理ユーティリティを `src/Asset.hpp` に追加した。

- `GetAssetList()` — デバッグ時は `asset/` を再帰スキャンして `asset/asset_list` に書き出す。リリース時は埋め込みリソースから読む
- `AssetPath()` — デバッグ時はファイルパス、リリース時は `Resource()` パスを返すヘルパー
- `RegisterAssets()` — `GetAssetList()` を利用し `.png` を TextureAsset、`.mp3` を AudioAsset として登録する
- `Main()` の先頭で `RegisterAssets()` を呼び出すよう変更