### PR TITLE
ホットリロード時に削除済みアニメーションエントリが残存するバグを修正

### DIFF
--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -44,6 +44,7 @@ void Main() {
   registry.ctx().emplace<AnimationDataRegistry>();
   const auto loadAnimations = [&registry]() {
     auto& animReg = registry.ctx().get<AnimationDataRegistry>();
+    animReg.clear();
     for (const auto& path : GetAssetList()) {
       if (FileSystem::Extension(path) != U"toml") continue;
       if (!path.starts_with(U"asset/config/animation/")) continue;


### PR DESCRIPTION
## 変更概要

- `loadAnimations()` の先頭で `animReg.clear()` を呼ぶようにした
- これにより、ホットリロード時にファイルが削除されたアニメーションのエントリが `AnimationDataRegistry` に残存しなくなる

close #75