### PR TITLE
アセット参照を TextureAsset キーに統一する #73

### DIFF
--- a/Ash2/src/Component/AnimationData.cpp
+++ b/Ash2/src/Component/AnimationData.cpp
@@ -1,11 +1,9 @@
 #include "Component/AnimationData.hpp"
 
-#include "Asset.hpp"
-
 AnimationData AnimationData::FromToml(const s3d::TOMLValue& toml) {
   const auto& off = toml[U"draw_offset"];
   AnimationData data{
-      .texture = s3d::Texture{AssetPath(toml[U"texture"].getString())},
+      .textureKey = toml[U"texture"].getString(),
       .size = {toml[U"width"].get<int>(), toml[U"height"].get<int>()},
       .drawOffset = {off[U"x"].get<double>(), off[U"y"].get<double>()},
   };

--- a/Ash2/src/Component/AnimationData.hpp
+++ b/Ash2/src/Component/AnimationData.hpp
@@ -13,8 +13,8 @@ struct AnimationClip {
 
 /// @brief アニメーション共有データ（エンティティ種別ごとに1つ）
 struct AnimationData {
-  /// スプライトシートテクスチャ
-  s3d::Texture texture;
+  /// TextureAsset キー（例: `asset/image/player.png`）
+  s3d::String textureKey;
   /// 1コマのサイズ（幅・高さ）
   s3d::Size size;
   /// 描画オフセット（中心座標からのずれ）

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -15,8 +15,8 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
     anim.elapsed += dt;
 
     const int col = static_cast<int>(anim.elapsed * clip.speed) % clip.count;
-    auto region = data.texture(col * data.size.x, clip.row * data.size.y,
-                               data.size.x, data.size.y);
+    auto region = TextureAsset{data.textureKey}(
+        col * data.size.x, clip.row * data.size.y, data.size.x, data.size.y);
 
     if (anim.facingRight) {
       region = region.mirrored();


### PR DESCRIPTION
## 変更概要

`AnimationData` が `Texture` オブジェクトを直接保持していた箇所を、TextureAsset のキー文字列に変更する。

- `AnimationData.texture`（`s3d::Texture`）→ `textureKey`（`s3d::String`）
- `AnimationData::FromToml()` で `AssetPath()` を使って直接テクスチャを生成していた箇所を削除し、TOML から読んだキー文字列をそのまま格納するように変更
- `AnimationSystem` の描画時に `TextureAsset{data.textureKey}` でルックアップするように変更

テクスチャの所有を TextureAsset に一元化し、`AnimationData` はデータのみ保持する設計に統一した。