### PR TITLE
PhaseStack のユニットテストを追加する

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -140,7 +140,12 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="tests\*.cpp" />
+    <ClCompile Include="tests\TestAttachmentSystem.cpp" />
+    <ClCompile Include="tests\TestNameLookup.cpp" />
+    <ClCompile Include="tests\TestPhaseStack.cpp" />
+    <ClCompile Include="tests\TestPlayerConfig.cpp" />
+    <ClCompile Include="tests\TestWaitPhase.cpp" />
+    <ClCompile Include="tests\TestWorldPos.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="App\engine\texture\box-shadow\128.png" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -213,19 +213,22 @@
     <ClCompile Include="stdafx.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="TestAttachmentSystem.cpp">
+    <ClCompile Include="tests\TestAttachmentSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="TestWorldPos.cpp">
+    <ClCompile Include="tests\TestWorldPos.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="TestPlayerConfig.cpp">
+    <ClCompile Include="tests\TestPlayerConfig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="TestWaitPhase.cpp">
+    <ClCompile Include="tests\TestWaitPhase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="TestNameLookup.cpp">
+    <ClCompile Include="tests\TestNameLookup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\TestPhaseStack.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Ash2/tests/TestPhaseStack.cpp
+++ b/Ash2/tests/TestPhaseStack.cpp
@@ -1,0 +1,120 @@
+#if USE_TEST
+#include <ThirdParty/Catch2/catch.hpp>
+#include <ThirdParty/entt/entt.hpp>
+
+#include "Phase/FrameData.hpp"
+#include "Phase/PhaseStack.hpp"
+
+namespace {
+
+struct PhaseSpy {
+  int afterPushCount = 0;
+  int beforePopCount = 0;
+  int updateCount = 0;
+};
+
+class MockPhase : public IPhase {
+ public:
+  explicit MockPhase(std::shared_ptr<PhaseSpy> spy,
+                     PhaseCommand::Type cmd = PhaseCommand::Type::None,
+                     std::unique_ptr<IPhase> next = nullptr)
+      : m_spy(std::move(spy)), m_cmd(cmd), m_next(std::move(next)) {}
+
+  void onAfterPush(entt::registry&) override { m_spy->afterPushCount++; }
+  void onBeforePop(entt::registry&) override { m_spy->beforePopCount++; }
+
+  PhaseCommand update(entt::registry&, const FrameData&) override {
+    m_spy->updateCount++;
+    switch (m_cmd) {
+      case PhaseCommand::Type::None:
+        return PhaseCommand::None();
+      case PhaseCommand::Type::Pop:
+        return PhaseCommand::Pop();
+      case PhaseCommand::Type::Push:
+        return PhaseCommand::Push(std::move(m_next));
+      case PhaseCommand::Type::Reset:
+        return PhaseCommand::Reset(std::move(m_next));
+    }
+    return PhaseCommand::None();
+  }
+
+ private:
+  std::shared_ptr<PhaseSpy> m_spy;
+  PhaseCommand::Type m_cmd;
+  std::unique_ptr<IPhase> m_next;
+};
+
+}  // namespace
+
+TEST_CASE("PhaseStack - None command leaves stack unchanged") {
+  entt::registry registry;
+  auto spy = std::make_shared<PhaseSpy>();
+  PhaseStack stack{std::make_unique<MockPhase>(spy), registry};
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy->updateCount == 1);
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy->updateCount == 2);
+}
+
+TEST_CASE("PhaseStack - Pop command calls onBeforePop and removes phase") {
+  entt::registry registry;
+  auto spy = std::make_shared<PhaseSpy>();
+  PhaseStack stack{
+      std::make_unique<MockPhase>(spy, IPhase::PhaseCommand::Type::Pop),
+      registry};
+
+  REQUIRE(spy->beforePopCount == 0);
+  stack.update(registry, FrameData{});
+  REQUIRE(spy->beforePopCount == 1);
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy->updateCount == 1);
+}
+
+TEST_CASE("PhaseStack - Push command calls onAfterPush on new phase") {
+  entt::registry registry;
+  auto spy1 = std::make_shared<PhaseSpy>();
+  auto spy2 = std::make_shared<PhaseSpy>();
+  PhaseStack stack{
+      std::make_unique<MockPhase>(spy1, IPhase::PhaseCommand::Type::Push,
+                                  std::make_unique<MockPhase>(spy2)),
+      registry};
+
+  REQUIRE(spy1->afterPushCount == 1);
+  REQUIRE(spy2->afterPushCount == 0);
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy2->afterPushCount == 1);
+}
+
+TEST_CASE("PhaseStack - Reset command pops all phases then pushes new phase") {
+  entt::registry registry;
+  auto spy1 = std::make_shared<PhaseSpy>();
+  auto spy2 = std::make_shared<PhaseSpy>();
+  PhaseStack stack{
+      std::make_unique<MockPhase>(spy1, IPhase::PhaseCommand::Type::Reset,
+                                  std::make_unique<MockPhase>(spy2)),
+      registry};
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy1->beforePopCount == 1);
+  REQUIRE(spy2->afterPushCount == 1);
+}
+
+TEST_CASE("PhaseStack - update on empty stack does nothing") {
+  entt::registry registry;
+  auto spy = std::make_shared<PhaseSpy>();
+  PhaseStack stack{
+      std::make_unique<MockPhase>(spy, IPhase::PhaseCommand::Type::Pop),
+      registry};
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy->updateCount == 1);
+
+  stack.update(registry, FrameData{});
+  REQUIRE(spy->updateCount == 1);
+}
+
+#endif


### PR DESCRIPTION
## 変更概要

- `tests/TestPhaseStack.cpp` を新規追加
  - モック用 `MockPhase` / `PhaseSpy` を定義し、5つのテストケースを実装
  - None / Pop / Push / Reset コマンド処理と空スタックへの update を検証
- `Ash2.vcxproj`: `tests\*.cpp` グロブを廃止し、テストファイルを個別に列挙
- `Ash2.vcxproj.filters`: テストファイルのパスを `tests\` プレフィックス付きに統一

close #81