### PR TITLE
SpriteAnimation: facingRight のコメントを明確化する #80

### DIFF
--- a/Ash2/src/Component/SpriteAnimation.hpp
+++ b/Ash2/src/Component/SpriteAnimation.hpp
@@ -9,6 +9,7 @@ struct SpriteAnimation {
   s3d::String currentClip;
   /// 現クリップの再生経過時間（秒）
   double elapsed = 0.0;
-  /// 右向きかどうか（true のとき左右反転して描画）
+  /// スプライトは左向きがデフォルト。右向きのとき true にし、AnimationSystem
+  /// が反転描画する
   bool facingRight = false;
 };


### PR DESCRIPTION
## 変更概要

`SpriteAnimation::facingRight` のコメントを、スプライトのデフォルト向きが左向きであることを明示した内容に更新した。

**変更前:** `右向きかどうか（true のとき左右反転して描画）`
**変更後:** `スプライトは左向きがデフォルト。右向きのとき true にし、AnimationSystem が反転描画する`

Closes #80