### PR TITLE
Main 関数の構成変更（GameSetup 分離・例外キャッチ・コンソール出力）

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -122,6 +122,7 @@
   <ItemGroup>
     <ClCompile Include="src\Config\PlayerConfig.cpp" />
     <ClCompile Include="src\Config\ScenarioData.cpp" />
+    <ClCompile Include="src\GameSetup.cpp" />
     <ClCompile Include="src\Main.cpp" />
     <ClCompile Include="src\Phase\PhaseRegistration.cpp" />
     <ClCompile Include="src\Phase\ScenarioPhase.cpp" />
@@ -370,6 +371,7 @@
     <ClInclude Include="src\Phase\WaitPhase.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\Asset.hpp" />
+    <ClInclude Include="src\GameSetup.hpp" />
     <ClInclude Include="src\Component\WorldPos.hpp" />
     <ClInclude Include="src\Phase\DemoPhase.hpp" />
     <ClInclude Include="src\Phase\IPhase.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="System\DrawSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="GameSetup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -948,6 +951,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Asset.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GameSetup.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Component\WorldPos.hpp">

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -1,0 +1,48 @@
+#include <Siv3D.hpp>
+
+#include "GameSetup.hpp"
+
+#include "Asset.hpp"
+#include "Component/AnimationData.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "Config/ScenarioData.hpp"
+#include "Phase/PhaseRegistry.hpp"
+#include "System/NameLookup.hpp"
+
+namespace {
+
+void LoadAnimations(entt::registry& registry) {
+  assert(registry.ctx().find<AnimationDataRegistry>() != nullptr);
+  auto& animReg = registry.ctx().get<AnimationDataRegistry>();
+  animReg.clear();
+  for (const auto& path : GetAssetList()) {
+    if (FileSystem::Extension(path) != U"toml") continue;
+    if (!path.starts_with(U"assets/config/animation/")) continue;
+    animReg[FileSystem::BaseName(path)] =
+        AnimationData::FromToml(TOMLReader{AssetPath(path)});
+  }
+}
+
+}  // namespace
+
+void InitializeRegistry(entt::registry& registry) {
+  registry.ctx().emplace<NameLookup>();
+  NameLookupSystem::Connect(registry);
+
+  const TOMLReader playerToml(AssetPath(U"assets/config/player.toml"));
+  registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(playerToml));
+
+  registry.ctx().emplace<AnimationDataRegistry>();
+  LoadAnimations(registry);
+
+  const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
+  registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(scenarioToml));
+
+  registry.ctx().emplace<PhaseRegistry>(MakeDefaultPhaseRegistry());
+}
+
+void ReloadConfig(entt::registry& registry) {
+  const TOMLReader playerToml(AssetPath(U"assets/config/player.toml"));
+  registry.ctx().get<PlayerConfig>() = PlayerConfig::FromToml(playerToml);
+  LoadAnimations(registry);
+}

--- a/Ash2/src/GameSetup.hpp
+++ b/Ash2/src/GameSetup.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief registry のコンテキストを初期化する
+/// @param registry 対象レジストリ
+void InitializeRegistry(entt::registry& registry);
+
+/// @brief 設定をリロードする（Debug ビルド専用）
+/// @param registry 対象レジストリ
+void ReloadConfig(entt::registry& registry);

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -3,17 +3,13 @@
 #include <entt/entt.hpp>
 
 #include "Asset.hpp"
-#include "Component/AnimationData.hpp"
-#include "Config/PlayerConfig.hpp"
-#include "Config/ScenarioData.hpp"
+#include "GameSetup.hpp"
 #include "Input/PlayerInputAction.hpp"
 #include "Phase/FrameData.hpp"
-#include "Phase/PhaseRegistry.hpp"
 #include "Phase/PhaseStack.hpp"
 #include "Phase/ScenarioPhase.hpp"
 #include "System/AttachmentSystem.hpp"
 #include "System/DrawSystem.hpp"
-#include "System/NameLookup.hpp"
 
 #if USE_TEST
 #define CATCH_CONFIG_RUNNER
@@ -28,55 +24,45 @@ static void RunTests() {
 #endif
 
 void Main() {
-  RegisterAssets();
-
-#if USE_TEST
-  RunTests();
+#ifdef _DEBUG
+  Console.open();
+  Console << U"=== Debug Build ===";
 #endif
 
-  entt::registry registry;
-  registry.ctx().emplace<NameLookup>();
-  NameLookupSystem::Connect(registry);
+  try {
+    RegisterAssets();
 
-  const TOMLReader playerToml(AssetPath(U"assets/config/player.toml"));
-  registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(playerToml));
+#if USE_TEST
+    RunTests();
+#endif
 
-  registry.ctx().emplace<AnimationDataRegistry>();
-  const auto loadAnimations = [&registry]() {
-    auto& animReg = registry.ctx().get<AnimationDataRegistry>();
-    animReg.clear();
-    for (const auto& path : GetAssetList()) {
-      if (FileSystem::Extension(path) != U"toml") continue;
-      if (!path.starts_with(U"assets/config/animation/")) continue;
-      animReg[FileSystem::BaseName(path)] =
-          AnimationData::FromToml(TOMLReader{AssetPath(path)});
+    entt::registry registry;
+    InitializeRegistry(registry);
+
+    const PlayerInputAction actions = PlayerInputAction::Default();
+    PhaseStack phaseStack(std::make_unique<ScenarioPhase>(U"init"), registry);
+
+    while (System::Update()) {
+      const FrameData frameData{
+          .dt = Scene::DeltaTime(),
+          .input = actions.toInputState(),
+      };
+#ifdef _DEBUG
+      if (frameData.input.reloadConfig) {
+        ReloadConfig(registry);
+      }
+#endif
+      phaseStack.update(registry, frameData);
+      AttachmentSystem::UpdateTransform(registry);
+      DrawSystem::Draw(registry);
     }
-  };
-  loadAnimations();
 
-  const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
-  registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(scenarioToml));
-
-  registry.ctx().emplace<PhaseRegistry>(MakeDefaultPhaseRegistry());
-
-  const PlayerInputAction actions = PlayerInputAction::Default();
-  PhaseStack phaseStack(std::make_unique<ScenarioPhase>(U"init"), registry);
-
-  while (System::Update()) {
-    const FrameData frameData{
-        .dt = Scene::DeltaTime(),
-        .input = actions.toInputState(),
-    };
-    if (frameData.input.reloadConfig) {
-      const TOMLReader reloadedPlayerToml(
-          AssetPath(U"assets/config/player.toml"));
-      registry.ctx().get<PlayerConfig>() =
-          PlayerConfig::FromToml(reloadedPlayerToml);
-
-      loadAnimations();
-    }
-    phaseStack.update(registry, frameData);
-    AttachmentSystem::UpdateTransform(registry);
-    DrawSystem::Draw(registry);
+  } catch (const std::exception& e) {
+#ifdef _DEBUG
+    Console << U"[例外] " << Unicode::Widen(e.what());
+    Console << U"Enterキーで終了...";
+    static_cast<void>(std::getchar());
+#endif
+    throw;
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,7 @@
 ```
 Ash2/src/
 ├── Main.cpp             # エントリポイント・ゲームループ
+├── GameSetup.hpp/.cpp   # registry 初期化・設定リロード
 ├── Asset.hpp            # アセット登録・パス解決ユーティリティ
 ├── Component/           # ECS コンポーネント（データのみ）
 ├── Config/              # TOML 設定データ（FromToml 付き構造体）
@@ -50,19 +51,21 @@ Main.cpp
 ```
 while (System::Update()) {
     FrameData 生成（dt + InputState）
-    設定リロード（F5）
+    設定リロード（F5、Debug ビルドのみ）
     PhaseStack::update(registry, frameData)
     AttachmentSystem::UpdateTransform(registry)
     DrawSystem::Draw(registry)
 }
 ```
 
-起動時に `registry.ctx()` へ以下をセット：
+起動時に `InitializeRegistry()` が `registry.ctx()` へ以下をセット：
 - `NameLookup` — 名前→エンティティの逆引きテーブル
-- `PlayerConfig` — プレイヤー設定（F5 でホットリロード）
-- `AnimationDataRegistry` — アニメーション設定（F5 でホットリロード）
+- `PlayerConfig` — プレイヤー設定
+- `AnimationDataRegistry` — アニメーション設定
 - `ScenarioData` — シナリオデータ
 - `PhaseRegistry` — フェーズ名→ファクトリのマップ
+
+Debug ビルドでは `Console.open()` で起動し、未捕捉例外をコンソールに出力して待機する。
 
 ---
 

--- a/tools/run-lint.sh
+++ b/tools/run-lint.sh
@@ -93,7 +93,7 @@ if [[ $RUN_TIDY -eq 1 ]]; then
             "--header-filter=.*Ash2[\\/](src|tests)[\\/].*" \
             "$target_win" \
             -- \
-            --driver-mode=cl /std:c++latest /Zc:__cplusplus /utf-8 \
+            --driver-mode=cl /std:c++latest /Zc:__cplusplus /utf-8 /EHsc \
             "/FI${PROJECT_WIN}\\src\\stdafx.h" \
             -D_DEBUG -D_WINDOWS \
             -D_ENABLE_EXTENDED_ALIGNED_STORAGE \


### PR DESCRIPTION
## 変更概要

- `GameSetup.hpp/.cpp` を新規追加し、`InitializeRegistry`・`LoadAnimations`・`ReloadConfig` を切り出した
- `Main.cpp` を `Main()` 関数のみに整理
- Debug ビルドで `Console.open()` を呼び、起動メッセージを出力するようにした
- `try-catch` を追加し、Debug ビルドで未捕捉例外をコンソールに出力して待機する構成にした
- 設定リロード処理（F5）を `#ifdef _DEBUG` でガードし、Release ビルドでは実行されないようにした
- `run-lint.sh` に `/EHsc` フラグを追加（clang-tidy が例外無効と誤判定していたバグを修正）

## 技術選択の理由

- `ReloadConfig` を独立関数にしたことで、Config が増えても `Main.cpp` を変更せず `GameSetup.cpp` だけを更新すればよい
- リロード処理を `#ifdef _DEBUG` でガードするのは、ホットリロードは開発専用ツールであり Release では不要かつコードパスを減らすため

close #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)