### PR TITLE
APP_LOG マクロの追加

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -9,11 +9,12 @@ description: Run the app (tools/run.sh) in the background and monitor output. Us
 
 1. `run_in_background: true` を指定して `./tools/run.sh` を Bash で起動する
 2. Monitor ツールでプロセスの出力ストリームを監視する
-3. ゲームが終了したら `logs/runtime.log` を確認してユーザーに報告する
+3. ゲームが終了したら Monitor の出力を確認してユーザーに報告する
    - `WARNING: App exited with non-zero status` が出ていればランタイムエラーあり
-   - ログが空の場合は正常終了（または #92 未解決によりキャプチャ不可）
+   - 例外・クラッシュ情報は `Ash2/App/crash.log` を確認する
 
 ## 注意
 
-- ゲームは GUI アプリのため、#92 解決前は `runtime.log` が空になる
+- `runtime.log` は常に空（Console.open() が stdout/stderr を Win32 コンソールへリダイレクトするため読まない）
+- 例外・クラッシュ情報は `Ash2/App/crash.log` に追記される
 - ユーザーがゲームを閉じるまでプロセスは終了しない

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -371,6 +371,7 @@
     <ClInclude Include="src\Phase\WaitPhase.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\Asset.hpp" />
+    <ClInclude Include="src\Debug.hpp" />
     <ClInclude Include="src\GameSetup.hpp" />
     <ClInclude Include="src\Component\WorldPos.hpp" />
     <ClInclude Include="src\Phase\DemoPhase.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -953,6 +953,9 @@
     <ClInclude Include="Asset.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Debug.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="GameSetup.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/Ash2/src/Debug.hpp
+++ b/Ash2/src/Debug.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#ifndef NDEBUG
+// 複数値の結合には << でなく + か Format() を使う: APP_LOG(U"n=" + Format(n))
+#define APP_LOG(msg) Console << (msg)
+#else
+#define APP_LOG(msg) static_cast<void>(0)
+#endif

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -3,6 +3,7 @@
 #include <entt/entt.hpp>
 
 #include "Asset.hpp"
+#include "Debug.hpp"
 #include "GameSetup.hpp"
 #include "Input/PlayerInputAction.hpp"
 #include "Phase/FrameData.hpp"
@@ -26,8 +27,8 @@ static void RunTests() {
 void Main() {
 #ifdef _DEBUG
   Console.open();
-  Console << U"=== Debug Build ===";
 #endif
+  APP_LOG(U"=== Debug Build ===");
 
   try {
     RegisterAssets();
@@ -58,9 +59,11 @@ void Main() {
     }
 
   } catch (const std::exception& e) {
+    const String message = U"[例外] " + Unicode::Widen(e.what());
+    TextWriter{U"crash.log", OpenMode::Append}.writeln(message);
+    APP_LOG(message);
+    APP_LOG(U"Enterキーで終了...");
 #ifdef _DEBUG
-    Console << U"[例外] " << Unicode::Widen(e.what());
-    Console << U"Enterキーで終了...";
     static_cast<void>(std::getchar());
 #endif
     throw;


### PR DESCRIPTION
## 変更概要

- `Ash2/src/Debug.hpp` を新規作成。`NDEBUG` 未定義時のみ `Console <<` に展開する `APP_LOG` マクロを定義
- `Main.cpp` に `#include "Debug.hpp"` を追加し、既存の `Console <<` を `APP_LOG` に置換
- 例外ハンドラに `crash.log` への書き出しを追加（`#ifdef _DEBUG` 外に置き、常にクラッシュ情報を記録）
- `Ash2.vcxproj` / `Ash2.vcxproj.filters` に `Debug.hpp` を追加
- `.claude/skills/run/SKILL.md` を更新：`runtime.log` が空になる理由を確定記述に変更し、`crash.log` 参照を追加

## 技術選択の理由

- 例外ハンドラの `crash.log` 書き出しに `s3d::TextWriter` を使用。Siv3D ネイティブ API で統一でき、`s3d::String` をそのまま書ける
- `crash.log` は `#ifdef _DEBUG` 外に置き、Release ビルドでもクラッシュ情報を残せるようにした
- `APP_LOG` の引数で `<<` チェーンを使うと `Console << (A << B)` に展開されてコンパイルエラーになるため、複数値の結合には `+` または `Format(...)` を使う

close #92