### PR TITLE
AnimationSystem のキー不存在クラッシュと elapsed 蓄積 UB を修正 #66

### DIFF
--- a/Ash2/src/Component/SpriteAnimation.hpp
+++ b/Ash2/src/Component/SpriteAnimation.hpp
@@ -7,7 +7,7 @@ struct SpriteAnimation {
   s3d::String dataKey;
   /// 現在再生中のクリップ名
   s3d::String currentClip;
-  /// 現クリップの再生経過時間（秒）
+  /// 現クリップ内の位相（秒）。[0, count/speed) の範囲にラップされる
   double elapsed = 0.0;
   /// スプライトは左向きがデフォルト。右向きのとき true にし、AnimationSystem
   /// が反転描画する

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -1,5 +1,8 @@
 #include "System/AnimationSystem.hpp"
 
+#include <cassert>
+#include <cmath>
+
 #include "Component/AnimationData.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/SpriteAnimation.hpp"
@@ -9,11 +12,19 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
 
   auto view = registry.view<SpriteAnimation, Drawable>();
   for (auto [entity, anim, drawable] : view.each()) {
+    assert(dataRegistry.contains(anim.dataKey) &&
+           "AnimationDataRegistry にキーが存在しない");
     const auto& data = dataRegistry.at(anim.dataKey);
+    assert(data.clips.contains(anim.currentClip) &&
+           "clips にクリップが存在しない");
     const auto& clip = data.clips.at(anim.currentClip);
 
     anim.elapsed += dt;
 
+    assert(clip.count > 0 && "clip.count は正の値でなければならない");
+    assert(clip.speed > 0.0 && "clip.speed は正の値でなければならない");
+    const double cycleDuration = clip.count / clip.speed;
+    anim.elapsed = std::fmod(anim.elapsed, cycleDuration);
     const int col = static_cast<int>(anim.elapsed * clip.speed) % clip.count;
     auto region = TextureAsset{data.textureKey}(
         col * data.size.x, clip.row * data.size.y, data.size.x, data.size.y);


### PR DESCRIPTION
## 変更概要

Issue #66 で報告された `AnimationSystem` の2つのバグを修正する。

## 修正内容

### 問題1: `at()` によるキー不存在クラッシュ

`dataRegistry.at()` / `data.clips.at()` でキーが存在しない場合、例外でクラッシュしエラー原因が不明だった。`contains()` + `assert` に変更し、デバッグビルド時にキー不存在を即座に検知できるようにした。

### 問題2: `elapsed` 無制限増加による UB

`elapsed * clip.speed` が `INT_MAX` を超えると `static_cast<int>` が未定義動作になる問題を、`std::fmod` でクリップ周期にラップすることで解消した。