### PR TITLE
ScenarioPhase: m_createdEntities の多重破棄リスクを修正

### DIFF
--- a/Ash2/src/Component/Hierarchy.cpp
+++ b/Ash2/src/Component/Hierarchy.cpp
@@ -60,6 +60,7 @@ void Hierarchy::Detach(entt::registry& registry, entt::entity child) {
 
 void Hierarchy::DestroyWithChildren(entt::registry& registry,
                                     entt::entity entity) {
+  if (!registry.valid(entity)) return;
   if (registry.all_of<Hierarchy>(entity)) {
     auto child = registry.get<const Hierarchy>(entity).m_firstChild;
     while (child != entt::null) {
@@ -68,5 +69,6 @@ void Hierarchy::DestroyWithChildren(entt::registry& registry,
       child = next;
     }
   }
+  Detach(registry, entity);
   registry.destroy(entity);
 }

--- a/Ash2/src/Component/Name.hpp
+++ b/Ash2/src/Component/Name.hpp
@@ -5,4 +5,8 @@
 struct Name {
   /// エンティティを識別する名前（不変）
   const s3d::String value;
+
+  /// @brief コンストラクタ
+  /// @param v エンティティ名
+  explicit Name(s3d::String v) noexcept : value(std::move(v)) {}
 };

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -68,7 +68,9 @@ IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
 
 void ScenarioPhase::onBeforePop(entt::registry& registry) {
   for (auto entity : m_createdEntities) {
-    Hierarchy::DestroyWithChildren(registry, entity);
+    if (registry.valid(entity)) {
+      Hierarchy::DestroyWithChildren(registry, entity);
+    }
   }
   m_createdEntities.clear();
 }

--- a/Ash2/tests/TestAttachmentSystem.cpp
+++ b/Ash2/tests/TestAttachmentSystem.cpp
@@ -148,4 +148,20 @@ TEST_CASE("AttachmentSystem - re-attaching child to different parent") {
           entt::entity{entt::null});
 }
 
+TEST_CASE(
+    "Hierarchy - DestroyWithChildren on already-destroyed entity is safe") {
+  entt::registry registry;
+  auto parent = registry.create();
+  auto child = registry.create();
+  Hierarchy::Attach(registry, parent, child);
+
+  // 親を破棄（子も巻き込まれる）
+  Hierarchy::DestroyWithChildren(registry, parent);
+  // 破棄済みエンティティを再度呼んでもクラッシュしない
+  Hierarchy::DestroyWithChildren(registry, parent);
+  Hierarchy::DestroyWithChildren(registry, child);
+  REQUIRE_FALSE(registry.valid(parent));
+  REQUIRE_FALSE(registry.valid(child));
+}
+
 #endif


### PR DESCRIPTION
closes #79

## 変更概要

- `ScenarioPhase::onBeforePop`: ループ内に `registry.valid(entity)` ガードを追加し、破棄済みエンティティへの再破棄を防止
- `Hierarchy::DestroyWithChildren`: 先頭に `valid` ガードを追加。`registry.destroy` 直前に `Detach` を追加し、親・兄弟の連結リストを整合状態に保つ
- `Name`: clang-tidy `bugprone-exception-escape` を解消するため `noexcept` コンストラクタを追加
- `TestAttachmentSystem`: 破棄済みエンティティへの `DestroyWithChildren` 再呼び出しが安全であることを検証するテストを追加

## 技術選択の理由

Issue の提案（`valid` ガード vs ルートエンティティのみ保持）のうち、前者を採用。後者は `make` アクションの設計変更を伴うため、スコープを最小限に保つ判断をした。

`DestroyWithChildren` への `Detach` 追加は本来あるべき副作用の補完。ただし `registry.destroy` 直接呼び出しでの不整合は残るため、根本対応は #101 で実施予定（Issue コメント記載）。