### PR TITLE
Hierarchy: on_destroy フックで連結リストの整合を自動保証する

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -363,6 +363,7 @@
     <ClInclude Include="src\System\AnimationSystem.hpp" />
     <ClInclude Include="src\System\AttachmentSystem.hpp" />
     <ClInclude Include="src\System\DrawSystem.hpp" />
+    <ClInclude Include="src\System\HierarchySystem.hpp" />
     <ClInclude Include="src\System\NameLookup.hpp" />
     <ClInclude Include="src\Config\PlayerConfig.hpp" />
     <ClInclude Include="src\Config\ScenarioData.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -929,6 +929,9 @@
     <ClInclude Include="System\DrawSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
+    <ClInclude Include="System\HierarchySystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
     <ClInclude Include="System\NameLookup.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>

--- a/Ash2/src/Component/Hierarchy.cpp
+++ b/Ash2/src/Component/Hierarchy.cpp
@@ -69,6 +69,5 @@ void Hierarchy::DestroyWithChildren(entt::registry& registry,
       child = next;
     }
   }
-  Detach(registry, entity);
   registry.destroy(entity);
 }

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -7,6 +7,7 @@
 #include "Config/PlayerConfig.hpp"
 #include "Config/ScenarioData.hpp"
 #include "Phase/PhaseRegistry.hpp"
+#include "System/HierarchySystem.hpp"
 #include "System/NameLookup.hpp"
 
 namespace {
@@ -28,6 +29,7 @@ void LoadAnimations(entt::registry& registry) {
 void InitializeRegistry(entt::registry& registry) {
   registry.ctx().emplace<NameLookup>();
   NameLookupSystem::Connect(registry);
+  HierarchySystem::Connect(registry);
 
   const TOMLReader playerToml(AssetPath(U"assets/config/player.toml"));
   registry.ctx().emplace<PlayerConfig>(PlayerConfig::FromToml(playerToml));

--- a/Ash2/src/System/HierarchySystem.hpp
+++ b/Ash2/src/System/HierarchySystem.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <entt/entt.hpp>
+
+#include "Component/Hierarchy.hpp"
+
+namespace HierarchySystem {
+
+/// @brief registry に Hierarchy 削除シグナルを登録する
+/// @details Hierarchy コンポーネントが削除されるタイミングで自動的に
+///          Hierarchy::Detach
+///          が呼ばれ、親・兄弟の連結リストが常に整合状態に保たれる
+/// @param registry 対象レジストリ
+inline void Connect(entt::registry& registry) {
+  registry.on_destroy<Hierarchy>().connect<&Hierarchy::Detach>();
+}
+
+}  // namespace HierarchySystem

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,6 +131,7 @@ WorldPos { w, h, d }
 | [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（最後） | WorldPos+Drawable を奥行き順にソートして描画 |
 | [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（DemoPhase） | SpriteAnimation の elapsed を進め Drawable を更新 |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 削除時に NameLookup を自動同期するシグナル登録 |
+| [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 
 ---
 


### PR DESCRIPTION
## 変更概要

EnTT の `on_destroy` シグナルを使い、`Hierarchy` コンポーネント削除時に `Detach` が自動で呼ばれるようにした。

- `HierarchySystem::Connect` を新規作成（`NameLookupSystem::Connect` と同じパターン）
- `InitializeRegistry` で `HierarchySystem::Connect(registry)` を呼ぶよう `GameSetup.cpp` を修正
- `registry.destroy()` が `on_destroy` フック経由で `Detach` を自動呼び出しするため、`DestroyWithChildren` 末尾の明示的な `Detach` 呼び出しを削除

これにより `registry.destroy()` を誰が呼んでも連結リストの整合性が保証され、#79 の暫定対応を本来あるべき設計で置き換える。

close #101