### PR TITLE
ScenarioPhase の action を variant で型安全化し起動時バリデーションを追加

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -367,7 +367,9 @@
     <ClInclude Include="src\System\NameLookup.hpp" />
     <ClInclude Include="src\Config\PlayerConfig.hpp" />
     <ClInclude Include="src\Config\ScenarioData.hpp" />
+    <ClInclude Include="src\Phase\PhaseParam.hpp" />
     <ClInclude Include="src\Phase\PhaseRegistry.hpp" />
+    <ClInclude Include="src\Phase\ScenarioStep.hpp" />
     <ClInclude Include="src\Phase\ScenarioPhase.hpp" />
     <ClInclude Include="src\Phase\WaitPhase.hpp" />
     <ClInclude Include="src\stdafx.h" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -944,7 +944,13 @@
     <ClInclude Include="Config\ScenarioData.hpp">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
+    <ClInclude Include="Phase\PhaseParam.hpp">
+      <Filter>Header Files\Phase</Filter>
+    </ClInclude>
     <ClInclude Include="Phase\PhaseRegistry.hpp">
+      <Filter>Header Files\Phase</Filter>
+    </ClInclude>
+    <ClInclude Include="Phase\ScenarioStep.hpp">
       <Filter>Header Files\Phase</Filter>
     </ClInclude>
     <ClInclude Include="Phase\ScenarioPhase.hpp">

--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -1,11 +1,59 @@
 #include "Config/ScenarioData.hpp"
 
-ScenarioData ScenarioData::FromToml(const s3d::TOMLValue& toml) {
+#include "Phase/PhaseParam.hpp"
+#include "Phase/PhaseRegistry.hpp"
+#include "Phase/ScenarioStep.hpp"
+
+namespace {
+
+/// @brief TOML の 1 ステップ値を ScenarioStep に変換する
+/// @param step TOML ステップ値
+/// @param registry フェーズ名 → PhaseEntry の対応表
+/// @return ScenarioStep（StepPush または StepReset）
+/// @note "make" アクションは別 Issue で対応予定のためエラーとする
+ScenarioStep ParseStep(const s3d::TOMLValue& step,
+                       const PhaseRegistry& registry) {
+  const auto action = step[U"action"].get<s3d::String>();
+
+  if (action == U"push") {
+    const auto phaseName = step[U"phase"].get<s3d::String>();
+    if (!registry.contains(phaseName)) {
+      throw s3d::Error{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
+                       phaseName + U"\""};
+    }
+    return StepPush{.phaseName = phaseName,
+                    .param = registry.at(phaseName).parseParam(step)};
+  }
+
+  if (action == U"reset") {
+    const auto phaseName = step[U"phase"].get<s3d::String>();
+    if (!registry.contains(phaseName)) {
+      throw s3d::Error{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
+                       phaseName + U"\""};
+    }
+    return StepReset{.phaseName = phaseName,
+                     .param = registry.at(phaseName).parseParam(step)};
+  }
+
+  if (action == U"make") {
+    throw s3d::Error{
+        U"ScenarioData::FromToml: \"make\" アクションは未対応です（Issue #67 "
+        U"スコープ外）"};
+  }
+
+  throw s3d::Error{U"ScenarioData::FromToml: 不明なアクション \"" + action +
+                   U"\""};
+}
+
+}  // namespace
+
+ScenarioData ScenarioData::FromToml(const s3d::TOMLValue& toml,
+                                    const PhaseRegistry& registry) {
   ScenarioData data;
   for (const auto& member : toml.tableView()) {
-    s3d::Array<s3d::TOMLValue> steps;
+    s3d::Array<ScenarioStep> steps;
     for (const auto& step : member.value.tableArrayView()) {
-      steps.push_back(step);
+      steps.push_back(ParseStep(step, registry));
     }
     data.sections[member.name] = std::move(steps);
   }

--- a/Ash2/src/Config/ScenarioData.hpp
+++ b/Ash2/src/Config/ScenarioData.hpp
@@ -1,13 +1,18 @@
 #pragma once
 #include <Siv3D.hpp>
 
+#include "Phase/PhaseRegistry.hpp"
+#include "Phase/ScenarioStep.hpp"
+
 /// @brief シナリオデータ（ロード時に全セクションを変換済み）
 struct ScenarioData {
   /// セクション名 → ステップ一覧のテーブル
-  s3d::HashTable<s3d::String, s3d::Array<s3d::TOMLValue>> sections;
+  s3d::HashTable<s3d::String, s3d::Array<ScenarioStep>> sections;
 
   /// @brief TOML からシナリオデータを生成する
   /// @param toml シナリオ TOML のルート値
+  /// @param registry フェーズ名 → PhaseEntry の対応表
   /// @return ScenarioData
-  [[nodiscard]] static ScenarioData FromToml(const s3d::TOMLValue& toml);
+  [[nodiscard]] static ScenarioData FromToml(const s3d::TOMLValue& toml,
+                                             const PhaseRegistry& registry);
 };

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -37,10 +37,11 @@ void InitializeRegistry(entt::registry& registry) {
   registry.ctx().emplace<AnimationDataRegistry>();
   LoadAnimations(registry);
 
-  const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
-  registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(scenarioToml));
-
   registry.ctx().emplace<PhaseRegistry>(MakeDefaultPhaseRegistry());
+
+  const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
+  registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(
+      scenarioToml, registry.ctx().get<PhaseRegistry>()));
 }
 
 void ReloadConfig(entt::registry& registry) {

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -38,7 +38,9 @@ void Main() {
     InitializeRegistry(registry);
 
     const PlayerInputAction actions = PlayerInputAction::Default();
-    PhaseStack phaseStack(std::make_unique<ScenarioPhase>(U"init"), registry);
+    PhaseStack phaseStack(std::make_unique<ScenarioPhase>(
+                              ScenarioPhase::Param{.sectionName = U"init"}),
+                          registry);
 
     while (System::Update()) {
       const FrameData frameData{

--- a/Ash2/src/Phase/DemoPhase.hpp
+++ b/Ash2/src/Phase/DemoPhase.hpp
@@ -5,6 +5,16 @@
 /// @brief プレイヤー操作デモシーン
 class DemoPhase : public IPhase {
  public:
+  /// @brief DemoPhase の生成パラメータ（引数なし）
+  struct Param {};
+
+  /// @brief デフォルトコンストラクタ
+  DemoPhase() = default;
+
+  /// @brief コンストラクタ（Param 受け取り版）
+  /// @param param 生成パラメータ（未使用）
+  explicit DemoPhase(const Param& /*param*/) : DemoPhase() {}
+
   /// @brief プレイヤーエンティティ（ルート）を生成する
   /// @param registry ECS レジストリ
   void onAfterPush(entt::registry& registry) override;

--- a/Ash2/src/Phase/PhaseParam.hpp
+++ b/Ash2/src/Phase/PhaseParam.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <variant>
+
+#include "Phase/DemoPhase.hpp"
+#include "Phase/ScenarioPhase.hpp"
+#include "Phase/WaitPhase.hpp"
+
+/// @brief 各フェーズの生成パラメータをまとめた variant 型
+using PhaseParam =
+    std::variant<WaitPhase::Param, ScenarioPhase::Param, DemoPhase::Param>;

--- a/Ash2/src/Phase/PhaseRegistration.cpp
+++ b/Ash2/src/Phase/PhaseRegistration.cpp
@@ -1,20 +1,48 @@
 #include <Siv3D.hpp>
 
 #include "Phase/DemoPhase.hpp"
+#include "Phase/PhaseParam.hpp"
 #include "Phase/PhaseRegistry.hpp"
 #include "Phase/ScenarioPhase.hpp"
 #include "Phase/WaitPhase.hpp"
 
+namespace {
+
+/// @brief 型 T に対する PhaseEntry を生成するヘルパー
+/// @tparam T IPhase を継承するフェーズクラス（T::Param を持つこと）
+/// @param parse TOML 値から T::Param を生成するラムダ
+/// @return PhaseEntry（parseParam + createPhase を持つ）
+template <typename T, typename F>
+PhaseEntry MakeEntry(F&& parse) {
+  return PhaseEntry{
+      .parseParam = [p = std::forward<F>(parse)](
+                        const s3d::TOMLValue& v) -> PhaseParam { return p(v); },
+      .createPhase = [](const PhaseParam& param) -> std::unique_ptr<IPhase> {
+        const auto* p = std::get_if<typename T::Param>(&param);
+        if (!p) {
+          throw s3d::Error{
+              U"PhaseEntry::createPhase: param の型が一致しません"};
+        }
+        return std::make_unique<T>(*p);
+      },
+  };
+}
+
+}  // namespace
+
 PhaseRegistry MakeDefaultPhaseRegistry() {
   return {
-      {U"demo", [](const TOMLValue&) { return std::make_unique<DemoPhase>(); }},
-      {U"scenario",
-       [](const TOMLValue& step) {
-         return std::make_unique<ScenarioPhase>(step[U"param"].get<String>());
-       }},
-      {U"wait",
-       [](const TOMLValue& step) {
-         return std::make_unique<WaitPhase>(step[U"duration"].get<double>());
-       }},
+      {U"demo", MakeEntry<DemoPhase>(
+                    [](const s3d::TOMLValue&) { return DemoPhase::Param{}; })},
+      {U"scenario", MakeEntry<ScenarioPhase>([](const s3d::TOMLValue& step) {
+         return ScenarioPhase::Param{
+             .sectionName = step[U"param"].get<s3d::String>(),
+         };
+       })},
+      {U"wait", MakeEntry<WaitPhase>([](const s3d::TOMLValue& step) {
+         return WaitPhase::Param{
+             .duration = step[U"duration"].get<double>(),
+         };
+       })},
   };
 }

--- a/Ash2/src/Phase/PhaseRegistry.hpp
+++ b/Ash2/src/Phase/PhaseRegistry.hpp
@@ -2,15 +2,25 @@
 
 #include <Siv3D.hpp>
 
+#include <functional>
+#include <memory>
+
+#include "Phase/PhaseParam.hpp"
+
 class IPhase;
 
-/// @brief フェーズ名とファクトリ関数の対応表
-using PhaseFactory =
-    std::function<std::unique_ptr<IPhase>(const s3d::TOMLValue&)>;
+/// @brief フェーズ名とパース・生成関数の対応エントリ
+struct PhaseEntry {
+  /// @brief TOML 値からフェーズパラメータを生成する関数
+  std::function<PhaseParam(const s3d::TOMLValue&)> parseParam;
 
-/// @brief フェーズ名 → ファクトリ関数のマップ
-using PhaseRegistry = s3d::HashTable<s3d::String, PhaseFactory>;
+  /// @brief フェーズパラメータから IPhase インスタンスを生成する関数
+  std::function<std::unique_ptr<IPhase>(const PhaseParam&)> createPhase;
+};
+
+/// @brief フェーズ名 → PhaseEntry のマップ
+using PhaseRegistry = s3d::HashTable<s3d::String, PhaseEntry>;
 
 /// @brief ゲームで使用するフェーズの登録情報を生成する
-/// @return フェーズ名とファクトリ関数の対応表
+/// @return フェーズ名と PhaseEntry の対応表
 [[nodiscard]] PhaseRegistry MakeDefaultPhaseRegistry();

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -1,17 +1,23 @@
 #include "Phase/ScenarioPhase.hpp"
 
-#include "Component/Drawable.hpp"
-#include "Component/Hierarchy.hpp"
-#include "Component/Name.hpp"
-#include "Component/WorldPos.hpp"
 #include "Config/ScenarioData.hpp"
+#include "Phase/PhaseParam.hpp"
 #include "Phase/PhaseRegistry.hpp"
-#include "System/NameLookup.hpp"
+#include "Phase/ScenarioStep.hpp"
 
-ScenarioPhase::ScenarioPhase(s3d::String sectionName)
-    : m_sectionName(std::move(sectionName)) {}
+ScenarioPhase::ScenarioPhase(const Param& param)
+    : m_sectionName(param.sectionName) {}
 
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
+
+namespace {
+
+template <class... Ts>
+struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+
+}  // namespace
 
 IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
                                            const FrameData& /*frameData*/) {
@@ -23,54 +29,18 @@ IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
 
   const auto& step = steps[m_currentStep];
   ++m_currentStep;
-  const auto action = step[U"action"].get<String>();
+
   const auto& factories = registry.ctx().get<PhaseRegistry>();
 
-  if (action == U"push") {
-    return PhaseCommand::Push(factories.at(step[U"phase"].get<String>())(step));
-  }
-
-  if (action == U"reset") {
-    return PhaseCommand::Reset(
-        factories.at(step[U"phase"].get<String>())(step));
-  }
-
-  if (action == U"make") {
-    const auto name = step[U"name"].get<String>();
-    const auto wp = step[U"worldPos"];
-    const auto dr = step[U"drawable"];
-
-    auto entity = registry.create();
-    m_createdEntities.push_back(entity);
-
-    registry.emplace<Name>(entity, name);
-    registry.emplace<WorldPos>(entity, WorldPos{
-                                           .w = wp[U"w"].get<double>(),
-                                           .h = wp[U"h"].get<double>(),
-                                           .d = wp[U"d"].get<double>(),
-                                       });
-    registry.emplace<Drawable>(
-        entity,
-        RectDrawable{
-            .size = SizeF{dr[U"w"].get<double>(), dr[U"h"].get<double>()},
-            .color = ColorF{dr[U"r"].get<double>(), dr[U"g"].get<double>(),
-                            dr[U"b"].get<double>()},
-        });
-
-    auto& lookup = registry.ctx().get<NameLookup>();
-    lookup[name] = entity;
-
-    return PhaseCommand::None();
-  }
-
-  return PhaseCommand::None();
-}
-
-void ScenarioPhase::onBeforePop(entt::registry& registry) {
-  for (auto entity : m_createdEntities) {
-    if (registry.valid(entity)) {
-      Hierarchy::DestroyWithChildren(registry, entity);
-    }
-  }
-  m_createdEntities.clear();
+  return std::visit(Overloaded{
+                        [&](const StepPush& s) {
+                          return PhaseCommand::Push(
+                              factories.at(s.phaseName).createPhase(s.param));
+                        },
+                        [&](const StepReset& s) {
+                          return PhaseCommand::Reset(
+                              factories.at(s.phaseName).createPhase(s.param));
+                        },
+                    },
+                    step);
 }

--- a/Ash2/src/Phase/ScenarioPhase.hpp
+++ b/Ash2/src/Phase/ScenarioPhase.hpp
@@ -6,9 +6,15 @@
 /// @brief TOML シナリオに従ってエンティティ生成・フェーズ遷移を進めるフェーズ
 class ScenarioPhase : public IPhase {
  public:
-  /// @brief コンストラクタ
-  /// @param sectionName 処理するシナリオセクション名
-  explicit ScenarioPhase(s3d::String sectionName);
+  /// @brief ScenarioPhase の生成パラメータ
+  struct Param {
+    /// 処理するシナリオセクション名
+    s3d::String sectionName;
+  };
+
+  /// @brief コンストラクタ（Param 受け取り版）
+  /// @param param 生成パラメータ
+  explicit ScenarioPhase(const Param& param);
 
   /// @brief currentStep_ を初期化する
   /// @param registry ECS レジストリ
@@ -21,15 +27,9 @@ class ScenarioPhase : public IPhase {
   [[nodiscard]] PhaseCommand update(entt::registry& registry,
                                     const FrameData& frameData) override;
 
-  /// @brief 生成したエンティティと NameLookup エントリを削除する
-  /// @param registry ECS レジストリ
-  void onBeforePop(entt::registry& registry) override;
-
  private:
   /// シナリオセクション名
   s3d::String m_sectionName;
   /// 現在のステップインデックス
   size_t m_currentStep = 0;
-  /// このフェーズで生成したエンティティ一覧
-  s3d::Array<entt::entity> m_createdEntities;
 };

--- a/Ash2/src/Phase/ScenarioStep.hpp
+++ b/Ash2/src/Phase/ScenarioStep.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Siv3D.hpp>
+
+#include <variant>
+
+#include "Phase/PhaseParam.hpp"
+
+/// @brief シナリオのステップ：フェーズをスタックに積む
+struct StepPush {
+  /// フェーズ名（PhaseRegistry のキー）
+  s3d::String phaseName;
+  /// フェーズの生成パラメータ
+  PhaseParam param;
+};
+
+/// @brief シナリオのステップ：スタックをリセットして新フェーズを積む
+struct StepReset {
+  /// フェーズ名（PhaseRegistry のキー）
+  s3d::String phaseName;
+  /// フェーズの生成パラメータ
+  PhaseParam param;
+};
+
+/// @brief シナリオの 1 ステップを表す variant 型
+using ScenarioStep = std::variant<StepPush, StepReset>;

--- a/Ash2/src/Phase/WaitPhase.cpp
+++ b/Ash2/src/Phase/WaitPhase.cpp
@@ -1,6 +1,6 @@
 #include "Phase/WaitPhase.hpp"
 
-WaitPhase::WaitPhase(double duration) : m_duration(duration) {}
+WaitPhase::WaitPhase(const Param& param) : m_duration(param.duration) {}
 
 IPhase::PhaseCommand WaitPhase::update(entt::registry&,
                                        const FrameData& frameData) {

--- a/Ash2/src/Phase/WaitPhase.hpp
+++ b/Ash2/src/Phase/WaitPhase.hpp
@@ -5,9 +5,15 @@
 /// @brief 指定秒数待機してから Pop するフェーズ
 class WaitPhase : public IPhase {
  public:
+  /// @brief WaitPhase の生成パラメータ
+  struct Param {
+    /// 待機時間（秒）
+    double duration;
+  };
+
   /// @brief コンストラクタ
-  /// @param duration 待機時間（秒）
-  explicit WaitPhase(double duration);
+  /// @param param 生成パラメータ
+  explicit WaitPhase(const Param& param);
 
   /// @brief 経過時間を積算し、duration を超えたら Pop を返す
   /// @param registry ECS レジストリ

--- a/Ash2/tests/TestWaitPhase.cpp
+++ b/Ash2/tests/TestWaitPhase.cpp
@@ -7,21 +7,21 @@
 
 TEST_CASE("WaitPhase - returns None before duration elapses") {
   entt::registry registry;
-  WaitPhase phase{2.0};
+  WaitPhase phase{WaitPhase::Param{.duration = 2.0}};
   auto cmd = phase.update(registry, FrameData{.dt = 1.0});
   REQUIRE(cmd.type == IPhase::PhaseCommand::Type::None);
 }
 
 TEST_CASE("WaitPhase - returns Pop when duration is reached exactly") {
   entt::registry registry;
-  WaitPhase phase{1.0};
+  WaitPhase phase{WaitPhase::Param{.duration = 1.0}};
   auto cmd = phase.update(registry, FrameData{.dt = 1.0});
   REQUIRE(cmd.type == IPhase::PhaseCommand::Type::Pop);
 }
 
 TEST_CASE("WaitPhase - returns Pop after accumulated dt exceeds duration") {
   entt::registry registry;
-  WaitPhase phase{1.0};
+  WaitPhase phase{WaitPhase::Param{.duration = 1.0}};
   auto first = phase.update(registry, FrameData{.dt = 0.6});
   REQUIRE(first.type == IPhase::PhaseCommand::Type::None);
   auto second = phase.update(registry, FrameData{.dt = 0.6});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,11 +115,11 @@ WorldPos { w, h, d }
 
 | フェーズ | 役割 |
 |---|---|
-| [`ScenarioPhase`](../Ash2/src/Phase/ScenarioPhase.hpp) | TOML シナリオを 1 ステップずつ実行（make/push/reset） |
+| [`ScenarioPhase`](../Ash2/src/Phase/ScenarioPhase.hpp) | TOML シナリオを 1 ステップずつ実行（push/reset） |
 | [`DemoPhase`](../Ash2/src/Phase/DemoPhase.hpp) | プレイヤー操作・物理・アニメーションを処理するゲームプレイ本体 |
 | [`WaitPhase`](../Ash2/src/Phase/WaitPhase.hpp) | 指定秒数待機して Pop |
 
-`PhaseRegistry`（registry.ctx に格納）がフェーズ名→ファクトリを管理し、シナリオ TOML から動的にフェーズを生成できる。
+`PhaseRegistry`（registry.ctx に格納）がフェーズ名→`PhaseEntry`（parseParam + createPhase）を管理し、シナリオロード時にパラメータを型安全な `ScenarioStep` に変換する。
 
 ---
 


### PR DESCRIPTION
## 変更概要

Issue #67 の対応。`ScenarioPhase` の action を文字列比較から `std::variant` ベースの型安全な構造へ移行し、シナリオロード時に不正な action を検出できるようにした。

## 主な変更

- `PhaseParam.hpp` を新規追加：各フェーズの `Param` を束ねる `std::variant` を定義
- `ScenarioStep.hpp` を新規追加：`StepPush` / `StepReset` を `std::variant` で定義
- `PhaseRegistry.hpp`：`PhaseFactory` を `PhaseEntry`（parseParam + createPhase）に置き換え
- `PhaseRegistration.cpp`：`MakeEntry<T, F>` テンプレートヘルパーで各エントリを自動生成
- `ScenarioData::FromToml`：`PhaseRegistry` を受け取り、ロード時に `ParseStep` で型変換・バリデーションを実施
- `ScenarioPhase::update()`：文字列比較を `std::visit` による `ScenarioStep` 処理に置き換え
- `GameSetup.cpp`：`PhaseRegistry` を `ScenarioData::FromToml` より先に初期化するよう順序変更
- 各 Phase クラスに `struct Param` と対応コンストラクタを追加、後方互換コンストラクタは削除
- `make` アクションは別 Issue で対応予定のため、ロード時に `s3d::Error` で即検出する形に

## スコープ外

- `make` アクション（ECS エンティティ生成）は Factory 系整備後に別 Issue で対応