### PR TITLE
ScenarioPhase のセクション名検証と Overloaded ヘルパーの整理

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -382,6 +382,7 @@
     <ClInclude Include="src\Phase\DemoPhase.hpp" />
     <ClInclude Include="src\Phase\IPhase.hpp" />
     <ClInclude Include="src\Phase\PhaseStack.hpp" />
+    <ClInclude Include="src\Util\Overloaded.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -30,6 +30,9 @@
     <Filter Include="Header Files\System">
       <UniqueIdentifier>{c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Util">
+      <UniqueIdentifier>{f5a6b7c8-d9e0-1f2a-3b4c-5d6e7f8a9b0c}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source Files\Component">
       <UniqueIdentifier>{e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b}</UniqueIdentifier>
     </Filter>
@@ -988,6 +991,9 @@
     </ClInclude>
     <ClInclude Include="Phase\PhaseStack.hpp">
       <Filter>Header Files\Phase</Filter>
+    </ClInclude>
+    <ClInclude Include="Util\Overloaded.hpp">
+      <Filter>Header Files\Util</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -50,6 +50,8 @@ ScenarioStep ParseStep(const s3d::TOMLValue& step,
 ScenarioData ScenarioData::FromToml(const s3d::TOMLValue& toml,
                                     const PhaseRegistry& registry) {
   ScenarioData data;
+
+  // パス1: 全セクションをパースして data.sections に格納
   for (const auto& member : toml.tableView()) {
     s3d::Array<ScenarioStep> steps;
     for (const auto& step : member.value.tableArrayView()) {
@@ -57,5 +59,20 @@ ScenarioData ScenarioData::FromToml(const s3d::TOMLValue& toml,
     }
     data.sections[member.name] = std::move(steps);
   }
+
+  // パス2: 全セクション確定後、ScenarioPhase の sectionName が実在するか検証
+  for (const auto& [_, steps] : data.sections) {
+    for (const auto& step : steps) {
+      const PhaseParam* param = std::visit(
+          [](const auto& s) -> const PhaseParam* { return &s.param; }, step);
+      if (const auto* p = std::get_if<ScenarioPhase::Param>(param)) {
+        if (!data.sections.contains(p->sectionName)) {
+          throw s3d::Error{U"ScenarioData::FromToml: 未定義のセクション名 \"" +
+                           p->sectionName + U"\""};
+        }
+      }
+    }
+  }
+
   return data;
 }

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -4,20 +4,12 @@
 #include "Phase/PhaseParam.hpp"
 #include "Phase/PhaseRegistry.hpp"
 #include "Phase/ScenarioStep.hpp"
+#include "Util/Overloaded.hpp"
 
 ScenarioPhase::ScenarioPhase(const Param& param)
     : m_sectionName(param.sectionName) {}
 
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
-
-namespace {
-
-template <class... Ts>
-struct Overloaded : Ts... {
-  using Ts::operator()...;
-};
-
-}  // namespace
 
 IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
                                            const FrameData& /*frameData*/) {

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -2,13 +2,7 @@
 
 #include "Component/Drawable.hpp"
 #include "Component/WorldPos.hpp"
-
-namespace {
-template <class... Ts>
-struct Overloaded : Ts... {
-  using Ts::operator()...;
-};
-}  // namespace
+#include "Util/Overloaded.hpp"
 
 void DrawSystem::Draw(const entt::registry& registry) {
   const Vec2 cameraOffset = Scene::Center();

--- a/Ash2/src/Util/Overloaded.hpp
+++ b/Ash2/src/Util/Overloaded.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+/// @brief std::visit に複数のラムダを渡すためのヘルパー構造体
+/// @tparam Ts ラムダまたは関数オブジェクトの型リスト
+/// @note 各 Ts の operator() を継承することで、variant のすべての型に対応した
+/// visitor を構成する
+template <class... Ts>
+struct Overloaded : Ts... {
+  using Ts::operator()...;
+};


### PR DESCRIPTION
## 変更概要

Issue #106 の対応。

### Overloaded ヘルパーの共通化

`ScenarioPhase.cpp` と `DrawSystem.cpp` の匿名 namespace に重複定義されていた `Overloaded` テンプレートを `src/Util/Overloaded.hpp` に切り出し、両ファイルからインクルードする形に整理した。

配置先を `src/Util/` としたのは、`Overloaded` がゲーム固有のロジックを持たない純粋な C++ ユーティリティであり、`Asset.hpp` / `Debug.hpp` と性質が異なるため。

### セクション名のロード時検証

`ScenarioData::FromToml` を 2 パス構成に変更した。

- **パス1**（既存）: 全セクションをパースして `data.sections` に格納
- **パス2**（新規）: 全セクション確定後、各ステップの `PhaseParam` を `std::get_if<ScenarioPhase::Param>` で検査し、`sectionName` が `data.sections` に存在しない場合は `s3d::Error` を投げる

`ScenarioData.cpp` は既存の include チェーン（`ScenarioStep.hpp` → `PhaseParam.hpp` → `ScenarioPhase.hpp`）を通じて `ScenarioPhase::Param` にアクセスできるため、新たな依存関係の追加は不要。パス2 は全セクション確定後に実行するため、TOML の記述順に影響されない。