### PR TITLE
TestScenarioData.cpp の clang-format 漏れを修正する

### DIFF
--- a/Ash2/tests/TestScenarioData.cpp
+++ b/Ash2/tests/TestScenarioData.cpp
@@ -16,7 +16,8 @@ TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
   REQUIRE(std::holds_alternative<StepPush>(data.sections.at(U"intro")[0]));
-  REQUIRE(std::get<StepPush>(data.sections.at(U"intro")[0]).phaseName == U"wait");
+  REQUIRE(std::get<StepPush>(data.sections.at(U"intro")[0]).phaseName ==
+          U"wait");
 }
 
 TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
@@ -31,7 +32,8 @@ TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
   REQUIRE(std::holds_alternative<StepReset>(data.sections.at(U"intro")[0]));
-  REQUIRE(std::get<StepReset>(data.sections.at(U"intro")[0]).phaseName == U"wait");
+  REQUIRE(std::get<StepReset>(data.sections.at(U"intro")[0]).phaseName ==
+          U"wait");
 }
 
 TEST_CASE("ScenarioData::FromToml - unknown phase name throws Error") {


### PR DESCRIPTION
## 変更概要

`TestScenarioData.cpp` に clang-format 違反が2箇所あったため修正した。

- 19行目・34行目の `REQUIRE` 文が行長制限を超えており、折り返しが必要だった