### PR TITLE
NameLookup への挿入をシグナルで自動化する

### DIFF
--- a/Ash2/src/Component/Name.hpp
+++ b/Ash2/src/Component/Name.hpp
@@ -8,5 +8,7 @@ struct Name {
 
   /// @brief コンストラクタ
   /// @param v エンティティ名
-  explicit Name(s3d::String v) noexcept : value(std::move(v)) {}
+  explicit Name(s3d::String v) : value(std::move(v)) {}
+
+  Name(const Name&) = default;
 };

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -10,7 +10,6 @@
 #include "Config/PlayerConfig.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
-#include "System/NameLookup.hpp"
 
 void DemoPhase::onAfterPush(entt::registry& registry) {
   m_playerRoot = registry.create();
@@ -22,7 +21,6 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<SpriteAnimation>(
       m_playerRoot,
       SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
-  registry.ctx().get<NameLookup>()[U"player"] = m_playerRoot;
   AnimationSystem::Update(registry, 0.0);
 }
 

--- a/Ash2/src/System/NameLookup.hpp
+++ b/Ash2/src/System/NameLookup.hpp
@@ -11,6 +11,13 @@ using NameLookup = s3d::HashTable<s3d::String, entt::entity>;
 
 namespace NameLookupSystem {
 
+/// @brief Name コンポーネント追加時に NameLookup
+/// へエントリを挿入するシグナルハンドラ
+inline void OnNameConstructed(entt::registry& registry, entt::entity entity) {
+  assert(registry.ctx().find<NameLookup>() != nullptr);
+  registry.ctx().get<NameLookup>()[registry.get<Name>(entity).value] = entity;
+}
+
 /// @brief Name コンポーネント削除時に NameLookup
 /// のエントリを削除するシグナルハンドラ
 inline void OnNameDestroyed(entt::registry& registry, entt::entity entity) {
@@ -18,9 +25,10 @@ inline void OnNameDestroyed(entt::registry& registry, entt::entity entity) {
   registry.ctx().get<NameLookup>().erase(registry.get<Name>(entity).value);
 }
 
-/// @brief registry に Name 削除シグナルを登録する
+/// @brief registry に Name 追加・削除シグナルを登録する
 /// @param registry 対象レジストリ
 inline void Connect(entt::registry& registry) {
+  registry.on_construct<Name>().connect<&OnNameConstructed>();
   registry.on_destroy<Name>().connect<&OnNameDestroyed>();
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,7 @@ WorldPos { w, h, d }
 | [`AttachmentSystem::UpdateTransform`](../Ash2/src/System/AttachmentSystem.hpp) | 毎フレーム（フェーズ後） | Hierarchy ルートから子孫へ WorldPos 伝播 |
 | [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（最後） | WorldPos+Drawable を奥行き順にソートして描画 |
 | [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（DemoPhase） | SpriteAnimation の elapsed を進め Drawable を更新 |
-| [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 削除時に NameLookup を自動同期するシグナル登録 |
+| [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 
 ---
@@ -152,5 +152,5 @@ WorldPos { w, h, d }
 - `Drawable` の型変更は `std::visit` を使い、DrawSystem と AnimationSystem の両方への影響を確認する。
 - 新クラス追加時は `Ash2.vcxproj` と `Ash2.vcxproj.filters` にも追加が必要。
 - 新フェーズ追加時は `Phase/PhaseRegistration.cpp` の `MakeDefaultPhaseRegistry()` にもエントリを追加する必要がある。
-- `NameLookup` への挿入は**手動**（`Name` コンポーネント追加後に `NameLookup[key] = entity` を自分で書く）。削除は `NameLookupSystem::Connect` で自動化されている。
+- `NameLookup` への挿入・削除は `NameLookupSystem::Connect` で自動化されている（`Name` コンポーネントの追加・削除に連動）。手動での `NameLookup[key] = entity` 登録は不要。
 - このドキュメントは 200 行上限。超過する場合はコード例→実装詳細→未使用の設計説明の順で削る。


### PR DESCRIPTION
## 概要

`NameLookupSystem::Connect` に `on_construct<Name>` シグナルを追加し、`Name` コンポーネント追加時に `NameLookup` へ自動挿入されるようにした。これにより追加・削除の両方がシグナルで対称的に管理される。

## 変更内容

- `NameLookup.hpp`: `OnNameConstructed` ハンドラを追加し、`Connect` 内で `on_construct<Name>` シグナルを登録
- `DemoPhase.cpp`: `onAfterPush` の手動登録行と不要な `#include` を削除
- `Name.hpp`: clang-tidy `bugprone-exception-escape` 対応として `noexcept` を削除し、`Name(const Name&) = default` を明示宣言（暗黙ムーブコンストラクタの生成を抑制）
- `ARCHITECTURE.md`: システム一覧・主要な制約の記述を更新

## 技術的判断

`Name::value` が `const s3d::String` であるため、暗黙ムーブコンストラクタはコピーを呼び出して `noexcept` にならない。コピーコンストラクタを明示宣言することで暗黙ムーブコンストラクタの生成を抑制し、警告を解消した。ムーブ式はコピーにフォールバックするため EnTT の動作に影響しない。

close #105