### PR TITLE
ビジュアルテストの仕組みを作る

### DIFF
--- a/Ash2/App/assets/config/scenario.toml
+++ b/Ash2/App/assets/config/scenario.toml
@@ -5,4 +5,4 @@ param = "GameStart"
 
 [[GameStart]]
 action = "push"
-phase = "demo"
+phase = "test_menu"

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -126,7 +126,9 @@
     <ClCompile Include="src\Main.cpp" />
     <ClCompile Include="src\Phase\PhaseRegistration.cpp" />
     <ClCompile Include="src\Phase\ScenarioPhase.cpp" />
-    <ClCompile Include="src\Phase\DemoPhase.cpp" />
+    <ClCompile Include="src\Phase\PlayerTestPhase.cpp" />
+    <ClCompile Include="src\Phase\TestMenuPhase.cpp" />
+    <ClCompile Include="src\Phase\AnimationViewerPhase.cpp" />
     <ClCompile Include="src\Phase\WaitPhase.cpp" />
     <ClCompile Include="src\Component\AnimationData.cpp" />
     <ClCompile Include="src\Component\Hierarchy.cpp" />
@@ -379,7 +381,9 @@
     <ClInclude Include="src\Debug.hpp" />
     <ClInclude Include="src\GameSetup.hpp" />
     <ClInclude Include="src\Component\WorldPos.hpp" />
-    <ClInclude Include="src\Phase\DemoPhase.hpp" />
+    <ClInclude Include="src\Phase\PlayerTestPhase.hpp" />
+    <ClInclude Include="src\Phase\TestMenuPhase.hpp" />
+    <ClInclude Include="src\Phase\AnimationViewerPhase.hpp" />
     <ClInclude Include="src\Phase\IPhase.hpp" />
     <ClInclude Include="src\Phase\PhaseStack.hpp" />
     <ClInclude Include="src\Util\Overloaded.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -201,7 +201,13 @@
     <ClCompile Include="Main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Phase\DemoPhase.cpp">
+    <ClCompile Include="Phase\PlayerTestPhase.cpp">
+      <Filter>Source Files\Phase</Filter>
+    </ClCompile>
+    <ClCompile Include="Phase\TestMenuPhase.cpp">
+      <Filter>Source Files\Phase</Filter>
+    </ClCompile>
+    <ClCompile Include="Phase\AnimationViewerPhase.cpp">
       <Filter>Source Files\Phase</Filter>
     </ClCompile>
     <ClCompile Include="Phase\WaitPhase.cpp">
@@ -980,7 +986,13 @@
     <ClInclude Include="Component\WorldPos.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
-    <ClInclude Include="Phase\DemoPhase.hpp">
+    <ClInclude Include="Phase\PlayerTestPhase.hpp">
+      <Filter>Header Files\Phase</Filter>
+    </ClInclude>
+    <ClInclude Include="Phase\TestMenuPhase.hpp">
+      <Filter>Header Files\Phase</Filter>
+    </ClInclude>
+    <ClInclude Include="Phase\AnimationViewerPhase.hpp">
       <Filter>Header Files\Phase</Filter>
     </ClInclude>
     <ClInclude Include="Phase\WaitPhase.hpp">

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -1,0 +1,104 @@
+#include "Phase/AnimationViewerPhase.hpp"
+
+#include "Component/AnimationData.hpp"
+#include "Component/Drawable.hpp"
+#include "Component/Hierarchy.hpp"
+#include "Component/SpriteAnimation.hpp"
+#include "Component/WorldPos.hpp"
+#include "Phase/FrameData.hpp"
+#include "System/AnimationSystem.hpp"
+
+namespace {
+constexpr double KBgBrightness = 0.15;
+constexpr int KTitleX = 20;
+constexpr int KTitleY = 20;
+constexpr int KClipInfoY = 50;
+constexpr int KHintY = 80;
+}  // namespace
+
+AnimationViewerPhase::AnimationViewerPhase(const Param& param)
+    : m_dataKey(param.dataKey) {
+  (void)param.initialClip;
+}
+
+void AnimationViewerPhase::onAfterPush(entt::registry& registry) {
+  const auto& animRegistry = registry.ctx().get<AnimationDataRegistry>();
+  const auto it = animRegistry.find(m_dataKey);
+  if (it == animRegistry.end()) {
+    return;
+  }
+
+  const auto& data = it->second;
+  m_clips.clear();
+  for (const auto& [name, _] : data.clips) {
+    m_clips.push_back(name);
+  }
+  m_clips.sort();
+  m_clipIndex = 0;
+
+  m_entity = registry.create();
+  registry.emplace<WorldPos>(m_entity);
+  registry.emplace<Drawable>(m_entity, TextureDrawable{});
+  registry.emplace<SpriteAnimation>(
+      m_entity,
+      SpriteAnimation{.dataKey = m_dataKey,
+                      .currentClip = m_clips.empty() ? U"" : m_clips[0]});
+  AnimationSystem::Update(registry, 0.0);
+}
+
+IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
+                                                  const FrameData& frameData) {
+  if (s3d::KeyEscape.down()) {
+    return PhaseCommand::Pop();
+  }
+
+  if (!m_clips.empty()) {
+    bool changed = false;
+    if (s3d::KeyLeft.down()) {
+      m_clipIndex = (m_clipIndex - 1 + static_cast<int>(m_clips.size())) %
+                    static_cast<int>(m_clips.size());
+      changed = true;
+    }
+    if (s3d::KeyRight.down()) {
+      m_clipIndex = (m_clipIndex + 1) % static_cast<int>(m_clips.size());
+      changed = true;
+    }
+
+    if (changed && m_entity != entt::null) {
+      auto* anim = registry.try_get<SpriteAnimation>(m_entity);
+      if (anim) {
+        anim->currentClip = m_clips[m_clipIndex];
+        anim->elapsed = 0.0;
+      }
+    }
+
+    if (s3d::KeyF.down() && m_entity != entt::null) {
+      auto* anim = registry.try_get<SpriteAnimation>(m_entity);
+      if (anim) {
+        anim->facingRight = !anim->facingRight;
+      }
+    }
+  }
+
+  AnimationSystem::Update(registry, frameData.dt);
+
+  s3d::Scene::SetBackground(s3d::ColorF{KBgBrightness});
+  m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(KTitleX, KTitleY);
+  if (!m_clips.empty()) {
+    m_font(U"Clip [{}/{}]: {}"_fmt(m_clipIndex + 1, m_clips.size(),
+                                   m_clips[m_clipIndex]))
+        .draw(KTitleX, KClipInfoY);
+  }
+  m_font(U"← → : clip  F : flip  Esc : back")
+      .draw(KTitleX, KHintY, s3d::Palette::Gray);
+
+  return PhaseCommand::None();
+}
+
+void AnimationViewerPhase::onBeforePop(entt::registry& registry) {
+  if (m_entity == entt::null) {
+    return;
+  }
+  Hierarchy::DestroyWithChildren(registry, m_entity);
+  m_entity = entt::null;
+}

--- a/Ash2/src/Phase/AnimationViewerPhase.hpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <Siv3D.hpp>
+
+#include "IPhase.hpp"
+
+/// @brief アニメーション再生確認フェーズ
+class AnimationViewerPhase : public IPhase {
+ public:
+  /// @brief AnimationViewerPhase の生成パラメータ
+  struct Param {
+    /// AnimationDataRegistry のキー（エンティティ種別名）
+    s3d::String dataKey;
+    /// 初期クリップ名（空文字の場合は最初のクリップを使用）
+    s3d::String initialClip;
+  };
+
+  /// @brief コンストラクタ
+  /// @param param 生成パラメータ
+  explicit AnimationViewerPhase(const Param& param);
+
+  /// @brief 一時エンティティを生成する
+  /// @param registry ECS レジストリ
+  void onAfterPush(entt::registry& registry) override;
+
+  /// @brief 毎フレームの更新処理
+  /// @param registry ECS レジストリ
+  /// @param frameData フレームごとの更新データ
+  /// @return フェーズスタックへの操作
+  [[nodiscard]] PhaseCommand update(entt::registry& registry,
+                                    const FrameData& frameData) override;
+
+  /// @brief 一時エンティティを破棄する
+  /// @param registry ECS レジストリ
+  void onBeforePop(entt::registry& registry) override;
+
+ private:
+  static constexpr int KFontSize = 20;
+
+  /// AnimationDataRegistry のキー
+  s3d::String m_dataKey;
+  /// 表示対象エンティティ
+  entt::entity m_entity = entt::null;
+  /// クリップ名の配列（ソート済み）
+  s3d::Array<s3d::String> m_clips;
+  /// 現在のクリップインデックス
+  int m_clipIndex = 0;
+  /// 描画フォント
+  s3d::Font m_font{KFontSize};
+};

--- a/Ash2/src/Phase/PhaseParam.hpp
+++ b/Ash2/src/Phase/PhaseParam.hpp
@@ -2,10 +2,13 @@
 
 #include <variant>
 
-#include "Phase/DemoPhase.hpp"
+#include "Phase/AnimationViewerPhase.hpp"
+#include "Phase/PlayerTestPhase.hpp"
 #include "Phase/ScenarioPhase.hpp"
+#include "Phase/TestMenuPhase.hpp"
 #include "Phase/WaitPhase.hpp"
 
 /// @brief 各フェーズの生成パラメータをまとめた variant 型
 using PhaseParam =
-    std::variant<WaitPhase::Param, ScenarioPhase::Param, DemoPhase::Param>;
+    std::variant<WaitPhase::Param, ScenarioPhase::Param, PlayerTestPhase::Param,
+                 TestMenuPhase::Param, AnimationViewerPhase::Param>;

--- a/Ash2/src/Phase/PhaseRegistration.cpp
+++ b/Ash2/src/Phase/PhaseRegistration.cpp
@@ -1,9 +1,11 @@
 #include <Siv3D.hpp>
 
-#include "Phase/DemoPhase.hpp"
+#include "Phase/AnimationViewerPhase.hpp"
 #include "Phase/PhaseParam.hpp"
 #include "Phase/PhaseRegistry.hpp"
+#include "Phase/PlayerTestPhase.hpp"
 #include "Phase/ScenarioPhase.hpp"
+#include "Phase/TestMenuPhase.hpp"
 #include "Phase/WaitPhase.hpp"
 
 namespace {
@@ -32,8 +34,19 @@ PhaseEntry MakeEntry(F&& parse) {
 
 PhaseRegistry MakeDefaultPhaseRegistry() {
   return {
-      {U"demo", MakeEntry<DemoPhase>(
-                    [](const s3d::TOMLValue&) { return DemoPhase::Param{}; })},
+      {U"player_test", MakeEntry<PlayerTestPhase>([](const s3d::TOMLValue&) {
+         return PlayerTestPhase::Param{};
+       })},
+      {U"test_menu", MakeEntry<TestMenuPhase>([](const s3d::TOMLValue&) {
+         return TestMenuPhase::Param{};
+       })},
+      {U"animation_viewer",
+       MakeEntry<AnimationViewerPhase>([](const s3d::TOMLValue& step) {
+         return AnimationViewerPhase::Param{
+             .dataKey = step[U"param"].get<s3d::String>(),
+             .initialClip = U"",
+         };
+       })},
       {U"scenario", MakeEntry<ScenarioPhase>([](const s3d::TOMLValue& step) {
          return ScenarioPhase::Param{
              .sectionName = step[U"param"].get<s3d::String>(),

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -1,0 +1,96 @@
+#include "Phase/PlayerTestPhase.hpp"
+
+#include "Component/Drawable.hpp"
+#include "Component/Hierarchy.hpp"
+#include "Component/Name.hpp"
+#include "Component/Player.hpp"
+#include "Component/SpriteAnimation.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "Phase/FrameData.hpp"
+#include "System/AnimationSystem.hpp"
+
+void PlayerTestPhase::onAfterPush(entt::registry& registry) {
+  m_playerRoot = registry.create();
+  registry.emplace<Player>(m_playerRoot);
+  registry.emplace<WorldPos>(m_playerRoot);
+  registry.emplace<Velocity>(m_playerRoot);
+  registry.emplace<Name>(m_playerRoot, Name{U"player"});
+  registry.emplace<Drawable>(m_playerRoot, TextureDrawable{});
+  registry.emplace<SpriteAnimation>(
+      m_playerRoot,
+      SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
+  AnimationSystem::Update(registry, 0.0);
+}
+
+IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
+                                             const FrameData& frameData) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& input = frameData.input;
+
+  const double vw = input.moveRight  ? cfg.speed
+                    : input.moveLeft ? -cfg.speed
+                                     : 0.0;
+  const double vd = input.moveForward    ? cfg.speed
+                    : input.moveBackward ? -cfg.speed
+                                         : 0.0;
+
+  auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
+  for (auto [entity, pos, vel, anim] : view.each()) {
+    vel.w = vw;
+    vel.d = vd;
+    pos.w += vel.w * frameData.dt;
+    pos.d += vel.d * frameData.dt;
+
+    if (input.jumpDown && pos.isOnGround()) {
+      vel.h = cfg.jumpSpeed;
+    }
+
+    vel.h -= cfg.gravity * frameData.dt;
+    pos.h += vel.h * frameData.dt;
+
+    if (pos.h < 0.0) {
+      pos.h = 0.0;
+      vel.h = 0.0;
+    }
+
+    const s3d::String newClip = (pos.h > 0.0)                    ? U"jump"
+                                : (vel.w != 0.0 || vel.d != 0.0) ? U"move"
+                                                                 : U"idle";
+    if (newClip != anim.currentClip) {
+      anim.currentClip = newClip;
+      anim.elapsed = 0.0;
+    }
+    if (vel.w > 0.0) {
+      anim.facingRight = true;
+    } else if (vel.w < 0.0) {
+      anim.facingRight = false;
+    }
+  }
+
+  AnimationSystem::Update(registry, frameData.dt);
+
+  if (frameData.input.reloadConfig) {
+    reloadPlayer(registry);
+  }
+
+  if (s3d::KeyEscape.down()) {
+    return PhaseCommand::Pop();
+  }
+
+  return PhaseCommand::None();
+}
+
+void PlayerTestPhase::reloadPlayer(entt::registry& registry) {
+  onBeforePop(registry);
+  onAfterPush(registry);
+}
+
+void PlayerTestPhase::onBeforePop(entt::registry& registry) {
+  if (m_playerRoot == entt::null) {
+    return;
+  }
+  Hierarchy::DestroyWithChildren(registry, m_playerRoot);
+  m_playerRoot = entt::null;
+}

--- a/Ash2/src/Phase/PlayerTestPhase.hpp
+++ b/Ash2/src/Phase/PlayerTestPhase.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "IPhase.hpp"
+
+/// @brief プレイヤー操作テストフェーズ
+class PlayerTestPhase : public IPhase {
+ public:
+  /// @brief PlayerTestPhase の生成パラメータ（引数なし）
+  struct Param {};
+
+  /// @brief デフォルトコンストラクタ
+  PlayerTestPhase() = default;
+
+  /// @brief コンストラクタ（Param 受け取り版）
+  /// @param param 生成パラメータ（未使用）
+  explicit PlayerTestPhase(const Param& /*param*/) : PlayerTestPhase() {}
+
+  /// @brief プレイヤーエンティティ（ルート）を生成する
+  /// @param registry ECS レジストリ
+  void onAfterPush(entt::registry& registry) override;
+
+  /// @brief 毎フレームの更新処理
+  /// @param registry ECS レジストリ
+  /// @param frameData フレームごとの更新データ
+  /// @return フェーズスタックへの操作
+  [[nodiscard]] PhaseCommand update(entt::registry& registry,
+                                    const FrameData& frameData) override;
+
+  /// @brief プレイヤーエンティティ（ルート＋子孫）を破棄する
+  /// @param registry ECS レジストリ
+  void onBeforePop(entt::registry& registry) override;
+
+ private:
+  /// @brief プレイヤーを破棄して最新の設定で再生成する
+  /// @param registry ECS レジストリ
+  void reloadPlayer(entt::registry& registry);
+
+  /// プレイヤーのルートエンティティ
+  entt::entity m_playerRoot = entt::null;
+};

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -1,0 +1,60 @@
+#include "Phase/TestMenuPhase.hpp"
+
+#include "Phase/AnimationViewerPhase.hpp"
+#include "Phase/PlayerTestPhase.hpp"
+
+namespace {
+constexpr double KBgBrightness = 0.1;
+constexpr int KTitleX = 40;
+constexpr int KTitleY = 40;
+constexpr int KItemX = 60;
+constexpr int KItemBaseY = 100;
+constexpr int KItemSpacing = 40;
+}  // namespace
+
+void TestMenuPhase::onAfterPush(entt::registry& /*registry*/) {
+  m_items = {
+      MenuItem{
+          .label = U"PlayerTest",
+          .create = [](entt::registry&) -> std::unique_ptr<IPhase> {
+            return std::make_unique<PlayerTestPhase>();
+          },
+      },
+      MenuItem{
+          .label = U"AnimationViewer (player)",
+          .create = [](entt::registry&) -> std::unique_ptr<IPhase> {
+            return std::make_unique<AnimationViewerPhase>(
+                AnimationViewerPhase::Param{.dataKey = U"player",
+                                            .initialClip = U""});
+          },
+      },
+  };
+  m_selectedIndex = 0;
+}
+
+IPhase::PhaseCommand TestMenuPhase::update(entt::registry& registry,
+                                           const FrameData& /*frameData*/) {
+  if (s3d::KeyUp.down()) {
+    m_selectedIndex = (m_selectedIndex - 1 + static_cast<int>(m_items.size())) %
+                      static_cast<int>(m_items.size());
+  }
+  if (s3d::KeyDown.down()) {
+    m_selectedIndex = (m_selectedIndex + 1) % static_cast<int>(m_items.size());
+  }
+
+  if (s3d::KeyEnter.down() && !m_items.empty()) {
+    auto phase = m_items[m_selectedIndex].create(registry);
+    return PhaseCommand::Push(std::move(phase));
+  }
+
+  s3d::Scene::SetBackground(s3d::ColorF{KBgBrightness});
+  m_font(U"Test Menu").draw(KTitleX, KTitleY);
+
+  for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
+    const s3d::ColorF color =
+        (i == m_selectedIndex) ? s3d::Palette::Yellow : s3d::Palette::White;
+    m_font(m_items[i].label).draw(KItemX, KItemBaseY + i * KItemSpacing, color);
+  }
+
+  return PhaseCommand::None();
+}

--- a/Ash2/src/Phase/TestMenuPhase.hpp
+++ b/Ash2/src/Phase/TestMenuPhase.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <Siv3D.hpp>
+
+#include "IPhase.hpp"
+
+/// @brief テストフェーズ一覧メニュー
+class TestMenuPhase : public IPhase {
+ public:
+  /// @brief TestMenuPhase の生成パラメータ（引数なし）
+  struct Param {};
+
+  /// @brief デフォルトコンストラクタ
+  TestMenuPhase() = default;
+
+  /// @brief コンストラクタ（Param 受け取り版）
+  /// @param param 生成パラメータ（未使用）
+  explicit TestMenuPhase(const Param& /*param*/) : TestMenuPhase() {}
+
+  /// @brief メニュー項目を初期化する
+  /// @param registry ECS レジストリ
+  void onAfterPush(entt::registry& registry) override;
+
+  /// @brief 毎フレームの更新処理
+  /// @param registry ECS レジストリ
+  /// @param frameData フレームごとの更新データ
+  /// @return フェーズスタックへの操作
+  [[nodiscard]] PhaseCommand update(entt::registry& registry,
+                                    const FrameData& frameData) override;
+
+ private:
+  /// メニュー項目（表示名 + 生成ラムダ）
+  struct MenuItem {
+    /// 表示名
+    s3d::String label;
+    /// フェーズ生成ラムダ
+    std::function<std::unique_ptr<IPhase>(entt::registry&)> create;
+  };
+
+  static constexpr int KFontSize = 24;
+
+  /// メニュー項目リスト
+  s3d::Array<MenuItem> m_items;
+  /// 現在の選択インデックス
+  int m_selectedIndex = 0;
+  /// 描画フォント
+  s3d::Font m_font{KFontSize};
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,9 @@ WorldPos { w, h, d }
 | フェーズ | 役割 |
 |---|---|
 | [`ScenarioPhase`](../Ash2/src/Phase/ScenarioPhase.hpp) | TOML シナリオを 1 ステップずつ実行（push/reset） |
-| [`DemoPhase`](../Ash2/src/Phase/DemoPhase.hpp) | プレイヤー操作・物理・アニメーションを処理するゲームプレイ本体 |
+| [`TestMenuPhase`](../Ash2/src/Phase/TestMenuPhase.hpp) | テストフェーズ一覧メニュー（↑↓選択、Enter で Push） |
+| [`PlayerTestPhase`](../Ash2/src/Phase/PlayerTestPhase.hpp) | プレイヤー操作・物理・アニメーションのビジュアルテスト |
+| [`AnimationViewerPhase`](../Ash2/src/Phase/AnimationViewerPhase.hpp) | アニメーションクリップ単体確認（←→切替、F反転） |
 | [`WaitPhase`](../Ash2/src/Phase/WaitPhase.hpp) | 指定秒数待機して Pop |
 
 `PhaseRegistry`（registry.ctx に格納）がフェーズ名→`PhaseEntry`（parseParam + createPhase）を管理し、シナリオロード時にパラメータを型安全な `ScenarioStep` に変換する。


### PR DESCRIPTION
## 変更概要

- `DemoPhase` を `PlayerTestPhase` にリネーム
- `TestMenuPhase` を新規作成（↑↓選択・Enter で遷移するメニューフェーズ）
- `AnimationViewerPhase` を新規作成（←→ でクリップ切り替え・F で反転）
- 起動フローを `ScenarioPhase` → `TestMenuPhase` → 各テストフェーズに変更

## 実装判断

Issue では PlayerTestPhase の Tab キーから TestMenuPhase を呼び出す設計だったが、将来的にテストフェーズが増えることを考慮し、ScenarioPhase が直接 TestMenuPhase を起動する構成を採用した。これにより PlayerTestPhase は純粋にメニューの一選択肢となり、エントリポイントの責務が TestMenuPhase に集約される。

Closes #16