### PR TITLE
プレイヤー移動処理を System として切り出す

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="src\Component\AnimationData.cpp" />
     <ClCompile Include="src\Component\Hierarchy.cpp" />
     <ClCompile Include="src\System\AnimationSystem.cpp" />
+    <ClCompile Include="src\System\PlayerMovementSystem.cpp" />
     <ClCompile Include="src\System\AttachmentSystem.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\Phase\PhaseStack.cpp" />
@@ -365,6 +366,7 @@
     <ClInclude Include="src\Component\Player.hpp" />
     <ClInclude Include="src\Component\Velocity.hpp" />
     <ClInclude Include="src\System\AnimationSystem.hpp" />
+    <ClInclude Include="src\System\PlayerMovementSystem.hpp" />
     <ClInclude Include="src\System\AttachmentSystem.hpp" />
     <ClInclude Include="src\System\DrawSystem.hpp" />
     <ClInclude Include="src\System\HierarchySystem.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -189,6 +189,9 @@
     <ClCompile Include="System\AnimationSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\PlayerMovementSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="System\AttachmentSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
@@ -936,6 +939,9 @@
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="System\AnimationSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\PlayerMovementSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="System\AttachmentSystem.hpp">

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -10,6 +10,7 @@
 #include "Config/PlayerConfig.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
+#include "System/PlayerMovementSystem.hpp"
 
 void DemoPhase::onAfterPush(entt::registry& registry) {
   m_playerRoot = registry.create();
@@ -26,48 +27,7 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
 
 IPhase::PhaseCommand DemoPhase::update(entt::registry& registry,
                                        const FrameData& frameData) {
-  const auto& cfg = registry.ctx().get<PlayerConfig>();
-  const auto& input = frameData.input;
-
-  const double vw = input.moveRight  ? cfg.speed
-                    : input.moveLeft ? -cfg.speed
-                                     : 0.0;
-  const double vd = input.moveForward    ? cfg.speed
-                    : input.moveBackward ? -cfg.speed
-                                         : 0.0;
-
-  auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
-  for (auto [entity, pos, vel, anim] : view.each()) {
-    vel.w = vw;
-    vel.d = vd;
-    pos.w += vel.w * frameData.dt;
-    pos.d += vel.d * frameData.dt;
-
-    if (input.jumpDown && pos.isOnGround()) {
-      vel.h = cfg.jumpSpeed;
-    }
-
-    vel.h -= cfg.gravity * frameData.dt;
-    pos.h += vel.h * frameData.dt;
-
-    if (pos.h < 0.0) {
-      pos.h = 0.0;
-      vel.h = 0.0;
-    }
-
-    const s3d::String newClip = (pos.h > 0.0)                    ? U"jump"
-                                : (vel.w != 0.0 || vel.d != 0.0) ? U"move"
-                                                                 : U"idle";
-    if (newClip != anim.currentClip) {
-      anim.currentClip = newClip;
-      anim.elapsed = 0.0;
-    }
-    if (vel.w > 0.0) {
-      anim.facingRight = true;
-    } else if (vel.w < 0.0) {
-      anim.facingRight = false;
-    }
-  }
+  PlayerMovementSystem::Update(registry, frameData);
 
   AnimationSystem::Update(registry, frameData.dt);
 

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -16,6 +16,7 @@
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
 #include "System/HitSystem.hpp"
+#include "System/PlayerMovementSystem.hpp"
 
 constexpr double KDummyPosW = 150.0;
 constexpr s3d::SizeF KDummySize = {60.0, 80.0};
@@ -78,37 +79,13 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
     }
   }
 
+  PlayerMovementSystem::Update(registry, frameData, m_attackClip);
+
   const bool isAttacking = !m_attackClip.empty();
 
   auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
-  for (auto [entity, pos, vel, anim] : view.each()) {
-    // 移動・ジャンプ・重力（攻撃中は水平移動ロック）
-    if (isAttacking) {
-      vel.w = 0.0;
-      vel.d = 0.0;
-    } else {
-      vel.w = input.moveRight ? cfg.speed : input.moveLeft ? -cfg.speed : 0.0;
-      vel.d = input.moveForward    ? cfg.speed
-              : input.moveBackward ? -cfg.speed
-                                   : 0.0;
-    }
-
-    pos.w += vel.w * dt;
-    pos.d += vel.d * dt;
-
+  for (const auto& [entity, pos, vel, anim] : view.each()) {
     const bool onGround = pos.isOnGround();
-
-    if (input.jumpDown && onGround) {
-      vel.h = cfg.jumpSpeed;
-    }
-
-    vel.h -= cfg.gravity * dt;
-    pos.h += vel.h * dt;
-
-    if (pos.h < 0.0) {
-      pos.h = 0.0;
-      vel.h = 0.0;
-    }
 
     // 攻撃入力チェック（攻撃中でない、かつ地上にいるときのみ）
     if (!isAttacking && onGround) {
@@ -154,26 +131,6 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
         registry.emplace<Attack>(m_attackEntity,
                                  Attack{.damage = cfg.ranged.damage});
         HitSystem::Update(registry);
-      }
-    }
-
-    // クリップ決定（attack/ranged_attack > jump > move > idle）
-    const bool isAttackingNow = !m_attackClip.empty();
-    const s3d::String newClip = isAttackingNow                   ? m_attackClip
-                                : (pos.h > 0.0)                  ? U"jump"
-                                : (vel.w != 0.0 || vel.d != 0.0) ? U"move"
-                                                                 : U"idle";
-    if (newClip != anim.currentClip) {
-      anim.currentClip = newClip;
-      anim.elapsed = 0.0;
-    }
-
-    // 向き更新（攻撃中は変更しない）
-    if (!isAttackingNow) {
-      if (vel.w > 0.0) {
-        anim.facingRight = true;
-      } else if (vel.w < 0.0) {
-        anim.facingRight = false;
       }
     }
   }

--- a/Ash2/src/System/PlayerMovementSystem.cpp
+++ b/Ash2/src/System/PlayerMovementSystem.cpp
@@ -1,0 +1,66 @@
+#include "System/PlayerMovementSystem.hpp"
+
+#include "Component/Player.hpp"
+#include "Component/SpriteAnimation.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "Phase/FrameData.hpp"
+
+void PlayerMovementSystem::Update(entt::registry& registry,
+                                  const FrameData& frameData,
+                                  const s3d::String& attackClip) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& input = frameData.input;
+  const double dt = frameData.dt;
+  const bool isAttacking = !attackClip.empty();
+
+  auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
+  for (auto&& [entity, pos, vel, anim] : view.each()) {
+    if (isAttacking) {
+      vel.w = 0.0;
+      vel.d = 0.0;
+    } else {
+      vel.w = input.moveRight ? cfg.speed : input.moveLeft ? -cfg.speed : 0.0;
+      vel.d = input.moveForward    ? cfg.speed
+              : input.moveBackward ? -cfg.speed
+                                   : 0.0;
+    }
+
+    pos.w += vel.w * dt;
+    pos.d += vel.d * dt;
+
+    vel.h -= cfg.gravity * dt;
+    pos.h += vel.h * dt;
+
+    if (pos.h < 0.0) {
+      pos.h = 0.0;
+      vel.h = 0.0;
+    }
+
+    const bool onGround = pos.isOnGround();
+
+    if (input.jumpDown && onGround) {
+      vel.h = cfg.jumpSpeed;
+    }
+
+    // アニメーションクリップ決定（攻撃 > ジャンプ > 移動 > 待機）
+    const s3d::String newClip = isAttacking                      ? attackClip
+                                : (pos.h > 0.0)                  ? U"jump"
+                                : (vel.w != 0.0 || vel.d != 0.0) ? U"move"
+                                                                 : U"idle";
+    if (newClip != anim.currentClip) {
+      anim.currentClip = newClip;
+      anim.elapsed = 0.0;
+    }
+
+    // 向き更新（攻撃中は変更しない）
+    if (!isAttacking) {
+      if (vel.w > 0.0) {
+        anim.facingRight = true;
+      } else if (vel.w < 0.0) {
+        anim.facingRight = false;
+      }
+    }
+  }
+}

--- a/Ash2/src/System/PlayerMovementSystem.hpp
+++ b/Ash2/src/System/PlayerMovementSystem.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <entt/entt.hpp>
+
+struct FrameData;
+
+/// @brief プレイヤーの移動・ジャンプ・重力・アニメーションクリップ選択システム
+class PlayerMovementSystem {
+ public:
+  /// @brief Player コンポーネントを持つエンティティの移動処理を更新する
+  ///
+  /// 水平速度の決定・位置への速度適用・ジャンプ・重力・地面クランプ・
+  /// アニメーションクリップ選択・向き更新を行う。
+  /// `attackClip`
+  /// が空でない場合は水平移動をロックし、クリップも攻撃クリップを優先する。
+  ///
+  /// @param registry ECS レジストリ
+  /// @param frameData フレームデータ（dt と入力状態）
+  /// @param attackClip 現在の攻撃クリップ名。空文字列なら攻撃中でないとみなす
+  static void Update(entt::registry& registry, const FrameData& frameData,
+                     const s3d::String& attackClip = {});
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -139,6 +139,7 @@ WorldPos { w, h, d }
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算 |
+| [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase / DemoPhase） | Player の移動・ジャンプ・重力・クリップ選択・向き更新 |
 
 ---
 


### PR DESCRIPTION
## 変更概要

`PlayerTestPhase::update()` および `DemoPhase::update()` に直書きされていた移動・ジャンプ・重力処理を `PlayerMovementSystem` として ECS System レイヤーに切り出した。

## 実装内容

- `PlayerMovementSystem::Update(registry, frameData, attackClip = {})` を新設
- `attackClip` が非空の場合は水平移動をロックし、クリップも攻撃クリップを優先する設計
- `DemoPhase` は `attackClip` 省略で呼び出し（空文字列固定）
- 処理順序: 重力適用 → 垂直位置更新 → 地面クランプ → `onGround` 判定 → ジャンプ入力チェック（着地フレームでジャンプ可能）
- ループは `auto&&` で entt の structured bindings に対応

## 関連

close #121