### PR TITLE
簡易HUDの実装（HP / スタミナ）

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -392,7 +392,9 @@
     <ClInclude Include="src\Component\Collider.hpp" />
     <ClInclude Include="src\Component\Attack.hpp" />
     <ClInclude Include="src\Component\Hp.hpp" />
+    <ClInclude Include="src\Component\Stamina.hpp" />
     <ClInclude Include="src\System\HitSystem.hpp" />
+    <ClInclude Include="src\System\HudSystem.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -1022,7 +1022,13 @@
     <ClInclude Include="Component\Hp.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
+    <ClInclude Include="Component\Stamina.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
     <ClInclude Include="System\HitSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\HudSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Ash2/src/Component/Stamina.hpp
+++ b/Ash2/src/Component/Stamina.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+/// @brief スタミナコンポーネント
+/// このコンポーネントを持つエンティティのスタミナ状態を表す
+struct Stamina {
+  /// 最大スタミナ
+  int max;
+  /// 現在スタミナ
+  int current;
+};

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -11,6 +11,7 @@
 #include "Phase/ScenarioPhase.hpp"
 #include "System/AttachmentSystem.hpp"
 #include "System/DrawSystem.hpp"
+#include "System/HudSystem.hpp"
 
 #ifdef _DEBUG
 #define CATCH_CONFIG_RUNNER
@@ -55,6 +56,7 @@ void Main() {
       phaseStack.update(registry, frameData);
       AttachmentSystem::UpdateTransform(registry);
       DrawSystem::Draw(registry);
+      HudSystem::Draw(registry);
     }
 
   } catch (const std::exception& e) {

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -10,6 +10,7 @@
 #include "Component/Name.hpp"
 #include "Component/Player.hpp"
 #include "Component/SpriteAnimation.hpp"
+#include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/PlayerConfig.hpp"
@@ -24,6 +25,8 @@ constexpr s3d::ColorF KDummyColor = {0.8, 0.2, 0.2};
 constexpr double KDummyCapRadius = 30.0;
 constexpr double KDummyCapHeight = 80.0;
 constexpr int KDummyMaxHp = 100;
+constexpr int KPlayerMaxHp = 100;
+constexpr int KPlayerMaxStamina = 100;
 
 void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   m_playerRoot = registry.create();
@@ -35,6 +38,11 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<SpriteAnimation>(
       m_playerRoot,
       SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
+  registry.emplace<Hp>(m_playerRoot,
+                       Hp{.max = KPlayerMaxHp, .current = KPlayerMaxHp});
+  registry.emplace<Stamina>(
+      m_playerRoot,
+      Stamina{.max = KPlayerMaxStamina, .current = KPlayerMaxStamina});
   AnimationSystem::Update(registry, 0.0);
 
   // ダミーターゲット（縦カプセル: 足元〜高さ80、半径30）

--- a/Ash2/src/System/HudSystem.hpp
+++ b/Ash2/src/System/HudSystem.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <entt/entt.hpp>
+
+#include "Component/Hp.hpp"
+#include "Component/Player.hpp"
+#include "Component/Stamina.hpp"
+
+/// @brief 画面固定 HUD 描画システム
+/// ワールド座標と無関係に画面左上にゲージを描画する
+class HudSystem {
+ public:
+  /// @brief Player + Hp + Stamina を持つエンティティの HP /
+  /// スタミナゲージを画面左上に描画する
+  /// @param registry ECS レジストリ
+  static void Draw(const entt::registry& registry) {
+    constexpr double KBarX = 16.0;
+    constexpr double KHpBarY = 16.0;
+    constexpr double KStaminaBarY = 40.0;
+    constexpr double KBarWidth = 200.0;
+    constexpr double KBarHeight = 18.0;
+    constexpr s3d::ColorF KBgColor{0.2, 0.2, 0.2, 0.7};
+    constexpr s3d::ColorF KHpColor{0.2, 0.8, 0.2};
+    constexpr s3d::ColorF KStaminaColor{0.9, 0.8, 0.1};
+
+    auto view = registry.view<const Player, const Hp, const Stamina>();
+    for (const auto& [entity, hp, stamina] : view.each()) {
+      // HP ゲージ
+      s3d::RectF{KBarX, KHpBarY, KBarWidth, KBarHeight}.draw(KBgColor);
+      if (hp.max > 0) {
+        const double hpRatio =
+            s3d::Clamp(static_cast<double>(hp.current) / hp.max, 0.0, 1.0);
+        s3d::RectF{KBarX, KHpBarY, KBarWidth * hpRatio, KBarHeight}.draw(
+            KHpColor);
+      }
+
+      // スタミナゲージ
+      s3d::RectF{KBarX, KStaminaBarY, KBarWidth, KBarHeight}.draw(KBgColor);
+      if (stamina.max > 0) {
+        const double staminaRatio = s3d::Clamp(
+            static_cast<double>(stamina.current) / stamina.max, 0.0, 1.0);
+        s3d::RectF{KBarX, KStaminaBarY, KBarWidth * staminaRatio, KBarHeight}
+            .draw(KStaminaColor);
+      }
+
+      // Player タグを持つエンティティは 1
+      // 体のみ想定のため最初のものだけ描画する
+      break;
+    }
+  }
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,7 @@ while (System::Update()) {
     PhaseStack::update(registry, frameData)
     AttachmentSystem::UpdateTransform(registry)
     DrawSystem::Draw(registry)
+    HudSystem::Draw(registry)
 }
 ```
 
@@ -100,6 +101,7 @@ WorldPos { w, h, d }
 | [`Collider`](../Ash2/src/Component/Collider.hpp) | カプセル形状の当たり判定（形状のみ、役割はコンポーネントの組み合わせで表現） |
 | [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる） |
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
+| [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 
 ---
 
@@ -140,6 +142,7 @@ WorldPos { w, h, d }
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算 |
 | [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase / DemoPhase） | Player の移動・ジャンプ・重力・クリップ選択・向き更新 |
+| [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画 |
 
 ---
 


### PR DESCRIPTION
## 概要

- `Stamina` コンポーネントを新規追加（`Hp` と同構造の `max` / `current` フィールド）
- `HudSystem` を新規追加し、画面左上に HP ゲージ（緑）・スタミナゲージ（黄）を描画
- `PlayerTestPhase` のプレイヤーエンティティに `Hp` / `Stamina` を付与

## 技術的な判断

`HudSystem` は `DrawSystem` に追加せず独立したクラスとして実装した。`DrawSystem` はワールド座標ベースの描画（カメラオフセット適用）を担っており、画面固定の HUD を混在させると座標変換が干渉するため。

## 備考

スタミナの消費・回復ロジックは Issue #117 のスコープ外。ゲージ幅は `current / max` の比率計算で実装しており、値が変化すれば正しく追従するが、現時点で消費ギミックがないため目視確認は表示のみ。

close #117