### PR TITLE
HitSystem の重複ヒット防止機構を改善する

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -143,6 +143,7 @@
     </ClCompile>
     <ClCompile Include="tests\TestAnimationData.cpp" />
     <ClCompile Include="tests\TestAttachmentSystem.cpp" />
+    <ClCompile Include="tests\TestHitSystem.cpp" />
     <ClCompile Include="tests\TestNameLookup.cpp" />
     <ClCompile Include="tests\TestPhaseStack.cpp" />
     <ClCompile Include="tests\TestPlayerConfig.cpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClCompile Include="tests\TestAttachmentSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tests\TestHitSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="tests\TestAnimationData.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Ash2/src/Component/Attack.hpp
+++ b/Ash2/src/Component/Attack.hpp
@@ -1,9 +1,19 @@
 #pragma once
+#include <Siv3D.hpp>
+
+#include <entt/entt.hpp>
 
 /// @brief 攻撃中コンポーネント（タグ兼攻撃力）
 /// このコンポーネントを持つエンティティが Collider
 /// も持つとき、攻撃判定が有効になる
 struct Attack {
   /// 与えるダメージ量
-  int damage;
+  int damage = 0;
+
+  /// ルートエンティティ（複数コライダー構成の場合に設定する。単体の場合は
+  /// entt::null）
+  entt::entity root = entt::null;
+
+  /// 攻撃の生存期間中にヒット済みのターゲットエンティティ一覧（重複ヒット防止用）
+  s3d::HashSet<entt::entity> hitTargets;
 };

--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -27,28 +27,12 @@ class HitSystem {
     s3d::Vec3 end;
   };
 
-  /// @brief エンティティID のシフト量（上位32bit に attacker を格納するため）
-  static constexpr int KEntityIdShift = 32;
-
   /// @brief 2線分間の距離の二乗を返す
   /// @param segA 線分1
   /// @param segB 線分2
   /// @return 最近接距離の二乗
   [[nodiscard]] static double SegmentDistSq(Segment segA, Segment segB);
-
-  /// @brief attacker と target のペアを uint64_t キーに変換する
-  /// @param attacker 攻撃側エンティティ
-  /// @param target 被弾側エンティティ
-  /// @return 上位32bit=attacker、下位32bit=target の uint64_t
-  [[nodiscard]] static uint64_t PairKey(entt::entity attacker,
-                                        entt::entity target);
 };
-
-inline uint64_t HitSystem::PairKey(entt::entity attacker, entt::entity target) {
-  return (static_cast<uint64_t>(entt::to_integral(attacker))
-          << KEntityIdShift) |
-         static_cast<uint64_t>(entt::to_integral(target));
-}
 
 inline double HitSystem::SegmentDistSq(Segment segA, Segment segB) {
   // 線分の長さの二乗がこの値以下のとき点とみなす
@@ -94,20 +78,22 @@ inline double HitSystem::SegmentDistSq(Segment segA, Segment segB) {
 }
 
 inline void HitSystem::Update(entt::registry& registry) {
-  // attacker と target のペアを uint64_t キーで管理（重複ヒット防止）
-  s3d::HashSet<uint64_t> processed;
-
   auto attackers = registry.view<WorldPos, Collider, Attack>();
   auto targets = registry.view<WorldPos, Collider, Hp>();
 
   for (auto&& [attacker, aPos, aCol, atk] : attackers.each()) {
+    // root が設定されている場合はルートの Attack を参照してヒット管理する
+    const auto rootEntity = (atk.root != entt::null) ? atk.root : attacker;
+    auto& rootAtk = registry.get<Attack>(rootEntity);
+
     const s3d::Vec3 worldA{aPos.w, aPos.h, aPos.d};
     const s3d::Vec3 ap1 = worldA + aCol.segmentStart;
     const s3d::Vec3 ap2 = worldA + aCol.segmentEnd;
 
     for (auto&& [target, tPos, tCol, hp] : targets.each()) {
       if (attacker == target) continue;
-      if (processed.contains(PairKey(attacker, target))) continue;
+      if (rootEntity == target) continue;
+      if (rootAtk.hitTargets.contains(target)) continue;
 
       const s3d::Vec3 worldT{tPos.w, tPos.h, tPos.d};
       const s3d::Vec3 tp1 = worldT + tCol.segmentStart;
@@ -118,9 +104,8 @@ inline void HitSystem::Update(entt::registry& registry) {
                         Segment{.start = tp1, .end = tp2}) >= sumR * sumR)
         continue;
 
-      hp.current = std::max(0, hp.current - atk.damage);
-      processed.emplace(PairKey(attacker, target));
-      APP_LOG(U"Hit! HP: " + Format(hp.current) + U"/" + Format(hp.max));
+      rootAtk.hitTargets.emplace(target);
+      hp.current = std::max(0, hp.current - rootAtk.damage);
     }
   }
 }

--- a/Ash2/tests/TestHitSystem.cpp
+++ b/Ash2/tests/TestHitSystem.cpp
@@ -1,0 +1,83 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/Attack.hpp"
+#include "Component/Collider.hpp"
+#include "Component/Hp.hpp"
+#include "Component/WorldPos.hpp"
+#include "System/HitSystem.hpp"
+
+TEST_CASE("HitSystem - no repeated damage from multi-frame attack") {
+  // 複数フレーム持続する攻撃で2回目以降ダメージが入らない
+  entt::registry registry;
+
+  // 攻撃エンティティ（WorldPos 原点、半径10の球コライダー）
+  auto attacker = registry.create();
+  registry.emplace<WorldPos>(attacker, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(attacker, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                                .segmentEnd = {0.0, 0.0, 0.0},
+                                                .radius = 10.0});
+  registry.emplace<Attack>(attacker, Attack{.damage = 5});
+
+  // 被弾エンティティ（隣接、重なる位置）
+  auto target = registry.create();
+  registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 10.0});
+  registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
+
+  // 1フレーム目：ヒットしてダメージが入る
+  HitSystem::Update(registry);
+  REQUIRE(registry.get<Hp>(target).current == 95);
+
+  // 2フレーム目：同じ攻撃が持続しているが hitTargets
+  // に登録済みなのでダメージなし
+  HitSystem::Update(registry);
+  REQUIRE(registry.get<Hp>(target).current == 95);
+
+  // 3フレーム目：同上
+  HitSystem::Update(registry);
+  REQUIRE(registry.get<Hp>(target).current == 95);
+}
+
+TEST_CASE("HitSystem - multi-collider attack hits target only once") {
+  // 複数コライダー構成でターゲットへのダメージが1回だけ
+  entt::registry registry;
+
+  // ルートエンティティ（Attack を持つ、Collider は持たない想定だが root
+  // 参照用に Attack を保持）
+  auto root = registry.create();
+  registry.emplace<Attack>(root, Attack{.damage = 10});
+
+  // 子コライダー1（root を参照）
+  auto child1 = registry.create();
+  registry.emplace<WorldPos>(child1, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(child1, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 10.0});
+  registry.emplace<Attack>(child1, Attack{.damage = 10, .root = root});
+
+  // 子コライダー2（同じ root を参照）
+  auto child2 = registry.create();
+  registry.emplace<WorldPos>(child2, WorldPos{.w = 3.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(child2, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 10.0});
+  registry.emplace<Attack>(child2, Attack{.damage = 10, .root = root});
+
+  // 被弾エンティティ（両コライダーと重なる位置）
+  auto target = registry.create();
+  registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 10.0});
+  registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
+
+  // 1回の Update で child1 と child2 が両方ヒットしても、ダメージは1回分のみ
+  HitSystem::Update(registry);
+  REQUIRE(registry.get<Hp>(target).current == 90);
+}
+
+#endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,7 +99,7 @@ WorldPos { w, h, d }
 | [`Name`](../Ash2/src/Component/Name.hpp) | エンティティ名（不変、NameLookup と対応） |
 | [`Player`](../Ash2/src/Component/Player.hpp) | プレイヤータグ（データなし） |
 | [`Collider`](../Ash2/src/Component/Collider.hpp) | カプセル形状の当たり判定（形状のみ、役割はコンポーネントの組み合わせで表現） |
-| [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる） |
+| [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる）。`root` で複数コライダー構成のルートを指定し、`hitTargets` で攻撃生存期間中の重複ヒットを防ぐ |
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 


### PR DESCRIPTION
## 変更概要

- `Attack` コンポーネントに `root`（ルートエンティティ参照）と `hitTargets`（ヒット済みターゲットの HashSet）を追加
- `HitSystem::Update` を `hitTargets` ベースのロジックに切り替え、攻撃の生存期間全体で重複ヒットを防ぐ
- 複数コライダー構成では `Attack::root` を参照することで `hitTargets` を共有し、同一ターゲットへのダメージを1回に抑える

## 技術判断

- 「ヒット時に Hierarchy を辿る」案ではなく「生成時に root を持たせる」案を採用。O(1) ルックアップになり HitSystem 側のロジックもシンプルに保てる
- 被弾側の複数コライダー構成は今回スコープ外（現状 Hp は根エンティティが直接保持しているため実用上問題なし）
- `PairKey` / `KEntityIdShift` は不要になったため削除
- `HitSystem::Update` 内の `APP_LOG` を削除（Console が自動 open してテスト出力が取得できなくなる問題への対処。詳細 #126）

## テスト

`TestHitSystem.cpp` を追加。以下の2ケースを検証：
- 複数フレーム持続する攻撃で2回目以降ダメージが入らないこと
- 複数コライダー構成でターゲットへのダメージが1回だけであること