### PR TITLE
APP_LOG をテスト実行時に自動無効化する

### DIFF
--- a/Ash2/src/Debug.hpp
+++ b/Ash2/src/Debug.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
-#ifndef NDEBUG
+#ifdef _DEBUG
+namespace AppDebug {
+/// テスト実行中は true にセットされる。APP_LOG
+/// はこのフラグが立っている間は無効化される
+inline bool testMode = false;
+}  // namespace AppDebug
 // 複数値の結合には << でなく + か Format() を使う: APP_LOG(U"n=" + Format(n))
-#define APP_LOG(msg) Console << (msg)
+#define APP_LOG(msg)                         \
+  (AppDebug::testMode ? static_cast<void>(0) \
+                      : static_cast<void>(Console << (msg)))
 #else
 #define APP_LOG(msg) static_cast<void>(0)
 #endif

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -24,6 +24,7 @@ void Main() {
 #ifdef _DEBUG
   size_t envLen = 0;
   if (getenv_s(&envLen, nullptr, 0, "ASH2_RUN_TESTS") == 0 && envLen > 0) {
+    AppDebug::testMode = true;
     const int result = RunTests();
     System::Exit();
     return;

--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -8,7 +8,6 @@
 #include "Component/Collider.hpp"
 #include "Component/Hp.hpp"
 #include "Component/WorldPos.hpp"
-#include "Debug.hpp"
 
 /// @brief ヒット判定システム
 class HitSystem {

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -63,3 +63,13 @@ TEST_CASE("WorldPos::ToScreen - far objects have smaller y")
 `run-tests.sh` 側に届かなくなる。
 
 テストコードおよびテストから呼ばれる実装コードでは `APP_LOG` を使わないこと。
+
+### `AppDebug::testMode` による自動無効化
+
+`Debug.hpp` は `AppDebug::testMode` フラグを持ち、テスト実行時に `APP_LOG` を
+自動的に無効化する。`Main.cpp` が `ASH2_RUN_TESTS` 環境変数を検出すると
+`AppDebug::testMode = true` をセットするため、**ゲームコード側に `APP_LOG` が
+残っていてもテスト時にコンソールウィンドウは開かない。**
+
+ただし、新たにシステムクラス（`System/` 配下）を実装するとき、テストから直接
+呼ばれる実装に `APP_LOG` を追加する際は、このフラグの存在を念頭に置くこと。


### PR DESCRIPTION
## 変更概要

`AppDebug::testMode` フラグを `Debug.hpp` に追加し、テスト実行時に `APP_LOG` を自動的に無効化する仕組みを導入した。

`Main.cpp` が `ASH2_RUN_TESTS` 環境変数を検出すると `AppDebug::testMode = true` をセットするため、ゲームコード側に `APP_LOG` が残っていてもテスト時にコンソールウィンドウが開かなくなる。

## 変更ファイル

- `Ash2/src/Debug.hpp`: `AppDebug::testMode` フラグと三項演算子による条件分岐を追加。ガードを `#ifdef _DEBUG` に統一
- `Ash2/src/Main.cpp`: テスト実行前に `AppDebug::testMode = true` をセット
- `Ash2/src/System/HitSystem.hpp`: 不要な `#include "Debug.hpp"` を削除
- `docs/TEST.md`: `AppDebug::testMode` による自動無効化の説明を追記

## 技術選択の理由

コンパイル時マクロ（`ASH2_TESTING` define）はビルドの仕組み上渡せないため、ランタイムフラグを採用した。`APP_LOG` マクロは三項演算子を使って式のまま保ち、`do {} while(0)` による文への変更を避けた。

close #126