### PR TITLE
コントローラー対応（XInput）

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -362,7 +362,9 @@
     <ClInclude Include="src\Component\LocalOffset.hpp" />
     <ClInclude Include="src\Component\Name.hpp" />
     <ClInclude Include="src\Input\InputState.hpp" />
-    <ClInclude Include="src\Input\PlayerInputAction.hpp" />
+    <ClInclude Include="src\Input\InputDeviceSelector.hpp" />
+    <ClInclude Include="src\Input\KeyboardInputAction.hpp" />
+    <ClInclude Include="src\Input\XInputAction.hpp" />
     <ClInclude Include="src\Phase\FrameData.hpp" />
     <ClInclude Include="src\Component\Player.hpp" />
     <ClInclude Include="src\Component\Velocity.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -914,7 +914,13 @@
     <ClInclude Include="Input\InputState.hpp">
       <Filter>Header Files\Input</Filter>
     </ClInclude>
-    <ClInclude Include="Input\PlayerInputAction.hpp">
+    <ClInclude Include="Input\InputDeviceSelector.hpp">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\KeyboardInputAction.hpp">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\XInputAction.hpp">
       <Filter>Header Files\Input</Filter>
     </ClInclude>
     <ClInclude Include="Phase\FrameData.hpp">

--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include "Input/InputState.hpp"
+#include "Input/KeyboardInputAction.hpp"
+#include "Input/XInputAction.hpp"
+
+/// @brief アクティブな入力デバイスを自動検出し InputState を返す
+struct InputDeviceSelector {
+  /// @brief 毎フレーム呼び出す。最後に入力があったデバイスの状態を返す
+  /// @return フレームの入力状態
+  [[nodiscard]] InputState update();
+
+ private:
+  enum class Device : std::uint8_t { Keyboard, Gamepad };
+
+  /// キーボード/マウス入力アクション
+  KeyboardInputAction m_keyboardAction = KeyboardInputAction::Default();
+  /// 現在アクティブなデバイス
+  Device m_activeDevice = Device::Keyboard;
+};
+
+inline InputState InputDeviceSelector::update() {
+  // 切断時は即座にキーボードへフォールバック
+  if (m_activeDevice == Device::Gamepad && !XInput(0).isConnected()) {
+    m_activeDevice = Device::Keyboard;
+  }
+  // 最後に入力があったデバイスへ切り替える
+  if (XInput(0).isConnected() &&
+      (XInput(0).buttonUp.down() || XInput(0).buttonDown.down() ||
+       XInput(0).buttonLeft.down() || XInput(0).buttonRight.down() ||
+       XInput(0).buttonA.down() || XInput(0).buttonB.down() ||
+       XInput(0).buttonY.down())) {
+    m_activeDevice = Device::Gamepad;
+  } else if (!Keyboard::GetAllInputs().isEmpty() ||
+             !Mouse::GetAllInputs().isEmpty()) {
+    m_activeDevice = Device::Keyboard;
+  }
+
+  return (m_activeDevice == Device::Gamepad) ? XInputAction::ToInputState()
+                                             : m_keyboardAction.toInputState();
+}

--- a/Ash2/src/Input/KeyboardInputAction.hpp
+++ b/Ash2/src/Input/KeyboardInputAction.hpp
@@ -3,8 +3,8 @@
 
 #include "Input/InputState.hpp"
 
-/// @brief プレイヤー操作のキー割り当て
-struct PlayerInputAction {
+/// @brief キーボード・マウス操作のキー割り当て
+struct KeyboardInputAction {
   /// 左移動
   InputGroup moveLeft;
   /// 右移動
@@ -23,15 +23,15 @@ struct PlayerInputAction {
   InputGroup rangedAttack;
 
   /// @brief デフォルトのキー割り当てを返す
-  /// @return デフォルトの PlayerInputAction
-  [[nodiscard]] static PlayerInputAction Default();
+  /// @return デフォルトの KeyboardInputAction
+  [[nodiscard]] static KeyboardInputAction Default();
 
   /// @brief 現在のキー入力状態を InputState に変換して返す
   /// @return フレームの入力状態
   [[nodiscard]] InputState toInputState() const;
 };
 
-inline PlayerInputAction PlayerInputAction::Default() {
+inline KeyboardInputAction KeyboardInputAction::Default() {
   return {
       .moveLeft = KeyLeft | KeyA,
       .moveRight = KeyRight | KeyD,
@@ -44,7 +44,7 @@ inline PlayerInputAction PlayerInputAction::Default() {
   };
 }
 
-inline InputState PlayerInputAction::toInputState() const {
+inline InputState KeyboardInputAction::toInputState() const {
   return {
       .moveLeft = moveLeft.pressed(),
       .moveRight = moveRight.pressed(),

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include "Input/InputState.hpp"
+
+/// @brief XInput コントローラー（プレイヤー0）のボタン割り当て
+/// @note メンバ変数を持たない。ToInputState()
+/// は毎フレームコントローラー状態を直接参照する
+struct XInputAction {
+  /// @brief 現在のコントローラー入力状態を InputState に変換して返す
+  /// @return フレームの入力状態
+  [[nodiscard]] static InputState ToInputState();
+};
+
+inline InputState XInputAction::ToInputState() {
+  const auto& pad = XInput(0);
+  return {
+      .moveLeft = pad.buttonLeft.pressed(),
+      .moveRight = pad.buttonRight.pressed(),
+      .moveForward = pad.buttonUp.pressed(),
+      .moveBackward = pad.buttonDown.pressed(),
+      .jumpDown = pad.buttonA.down(),
+      .reloadConfig = false,
+      .attackDown = pad.buttonB.down(),
+      .rangedAttackDown = pad.buttonY.down(),
+  };
+}

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -5,7 +5,7 @@
 #include "Asset.hpp"
 #include "Debug.hpp"
 #include "GameSetup.hpp"
-#include "Input/PlayerInputAction.hpp"
+#include "Input/InputDeviceSelector.hpp"
 #include "Phase/FrameData.hpp"
 #include "Phase/PhaseStack.hpp"
 #include "Phase/ScenarioPhase.hpp"
@@ -39,7 +39,8 @@ void Main() {
     entt::registry registry;
     InitializeRegistry(registry);
 
-    const PlayerInputAction actions = PlayerInputAction::Default();
+    InputDeviceSelector inputSelector;
+
     PhaseStack phaseStack(std::make_unique<ScenarioPhase>(
                               ScenarioPhase::Param{.sectionName = U"init"}),
                           registry);
@@ -47,7 +48,7 @@ void Main() {
     while (System::Update()) {
       const FrameData frameData{
           .dt = Scene::DeltaTime(),
-          .input = actions.toInputState(),
+          .input = inputSelector.update(),
       };
 #ifdef _DEBUG
       if (frameData.input.reloadConfig) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,6 +50,7 @@ Main.cpp
 
 ```
 while (System::Update()) {
+    入力デバイス切り替え（キーボード/コントローラー自動検出）
     FrameData 生成（dt + InputState）
     設定リロード（F5、Debug ビルドのみ）
     PhaseStack::update(registry, frameData)
@@ -83,6 +84,18 @@ WorldPos { w, h, d }
 ```
 
 **制約：** `WorldPos` は常に絶対座標。子エンティティも `WorldPos` を持ち、`AttachmentSystem` が毎フレーム親の絶対座標 + `LocalOffset` で上書きする。
+
+---
+
+## 入力抽象化
+
+| クラス | 役割 |
+|---|---|
+| [`InputState`](../Ash2/src/Input/InputState.hpp) | フレームの論理入力（Siv3D 非依存） |
+| [`KeyboardInputAction`](../Ash2/src/Input/KeyboardInputAction.hpp) | キーボード/マウス → InputState 変換 |
+| [`XInputAction`](../Ash2/src/Input/XInputAction.hpp) | XInput コントローラー → InputState 変換（十字ボタンで移動、A/B/Y でジャンプ/近距離/遠距離） |
+
+`Main.cpp` が毎フレームデバイス入力を検出し、最後にアクティブだったデバイスに切り替える。切断時はキーボードへ自動フォールバック。
 
 ---
 


### PR DESCRIPTION
## 変更概要

-  を  にリネーム（ファイル名・クラス名）
-  を新規追加（ヘッダオンリー）。十字ボタンで移動、A=ジャンプ、B=近距離攻撃、Y=遠距離攻撃
- 最後にアクティブだったデバイスへ自動切り替え。コントローラー切断時はキーボードへ即フォールバック

## スコープ変更

- 回避・ロックの割り当ては別 Issue で対応予定
- 左スティックによる全方位移動は #137 で対応予定

close #135