### PR TITLE
左スティックによるアナログ全方位移動に対応

### DIFF
--- a/Ash2/src/Input/InputState.hpp
+++ b/Ash2/src/Input/InputState.hpp
@@ -1,15 +1,13 @@
 #pragma once
+#include <Siv3D.hpp>
 
-/// @brief フレームごとのプレイヤー入力状態（Siv3D 非依存）
+/// @brief フレームごとのプレイヤー入力状態
+/// @note `Key` や `TOMLValue` のようなテストしづらい型は持ち込まない方針だが、
+/// `Vec2` のような単純な数学型は許容する
 struct InputState {
-  /// 左移動キーが押されている
-  bool moveLeft = false;
-  /// 右移動キーが押されている
-  bool moveRight = false;
-  /// 奥移動キーが押されている
-  bool moveForward = false;
-  /// 手前移動キーが押されている
-  bool moveBackward = false;
+  /// 移動軸入力（x: 横方向 w 軸・右が正、y: 奥行き方向 d 軸・奥が正）。
+  /// 常に長さ 1.0 以下に正規化されていることが保証される
+  Vec2 moveAxis = Vec2::Zero();
   /// ジャンプキーが押された（1フレーム限り）
   bool jumpDown = false;
   /// 設定再読み込みキーが押された（1フレーム限り）

--- a/Ash2/src/Input/KeyboardInputAction.hpp
+++ b/Ash2/src/Input/KeyboardInputAction.hpp
@@ -45,11 +45,15 @@ inline KeyboardInputAction KeyboardInputAction::Default() {
 }
 
 inline InputState KeyboardInputAction::toInputState() const {
+  const Vec2 rawAxis{
+      (moveRight.pressed() ? 1.0 : 0.0) - (moveLeft.pressed() ? 1.0 : 0.0),
+      (moveForward.pressed() ? 1.0 : 0.0) -
+          (moveBackward.pressed() ? 1.0 : 0.0),
+  };
+  const Vec2 moveAxis = rawAxis.limitLength(1.0);
+
   return {
-      .moveLeft = moveLeft.pressed(),
-      .moveRight = moveRight.pressed(),
-      .moveForward = moveForward.pressed(),
-      .moveBackward = moveBackward.pressed(),
+      .moveAxis = moveAxis,
       .jumpDown = jump.down(),
       .reloadConfig = reloadConfig.down(),
       .attackDown = attack.down(),

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -14,11 +14,28 @@ struct XInputAction {
 
 inline InputState XInputAction::ToInputState() {
   const auto& pad = XInput(0);
+
+  // 左スティックの軸入力にデッドゾーン処理を適用する
+  // （`XInput(0)` は const 参照のため `setLeftThumbDeadZone()` を直接呼べず、
+  // ここで明示的にデッドゾーンを適用する）
+  constexpr DeadZone LeftThumbDeadZone{
+      .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular};
+  const Vec2 stickAxis =
+      LeftThumbDeadZone(Vec2{pad.leftThumbX, pad.leftThumbY});
+
+  // 十字ボタンの入力を軸ベクトルに変換する
+  const Vec2 dpadAxis{
+      (pad.buttonRight.pressed() ? 1.0 : 0.0) -
+          (pad.buttonLeft.pressed() ? 1.0 : 0.0),
+      (pad.buttonUp.pressed() ? 1.0 : 0.0) -
+          (pad.buttonDown.pressed() ? 1.0 : 0.0),
+  };
+
+  // スティックと十字ボタンの両方を同時に有効として扱い、合成してから正規化する
+  const Vec2 moveAxis = (stickAxis + dpadAxis).limitLength(1.0);
+
   return {
-      .moveLeft = pad.buttonLeft.pressed(),
-      .moveRight = pad.buttonRight.pressed(),
-      .moveForward = pad.buttonUp.pressed(),
-      .moveBackward = pad.buttonDown.pressed(),
+      .moveAxis = moveAxis,
       .jumpDown = pad.buttonA.down(),
       .reloadConfig = false,
       .attackDown = pad.buttonB.down(),

--- a/Ash2/src/System/PlayerMovementSystem.cpp
+++ b/Ash2/src/System/PlayerMovementSystem.cpp
@@ -21,10 +21,8 @@ void PlayerMovementSystem::Update(entt::registry& registry,
       vel.w = 0.0;
       vel.d = 0.0;
     } else {
-      vel.w = input.moveRight ? cfg.speed : input.moveLeft ? -cfg.speed : 0.0;
-      vel.d = input.moveForward    ? cfg.speed
-              : input.moveBackward ? -cfg.speed
-                                   : 0.0;
+      vel.w = input.moveAxis.x * cfg.speed;
+      vel.d = input.moveAxis.y * cfg.speed;
     }
 
     pos.w += vel.w * dt;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,11 +91,13 @@ WorldPos { w, h, d }
 
 | クラス | 役割 |
 |---|---|
-| [`InputState`](../Ash2/src/Input/InputState.hpp) | フレームの論理入力（Siv3D 非依存） |
+| [`InputState`](../Ash2/src/Input/InputState.hpp) | フレームの論理入力（`Key`/`TOMLValue` 等のテストしづらい型は持ち込まないが、`Vec2` 等の単純な数学型は許容） |
 | [`KeyboardInputAction`](../Ash2/src/Input/KeyboardInputAction.hpp) | キーボード/マウス → InputState 変換 |
-| [`XInputAction`](../Ash2/src/Input/XInputAction.hpp) | XInput コントローラー → InputState 変換（十字ボタンで移動、A/B/Y でジャンプ/近距離/遠距離） |
+| [`XInputAction`](../Ash2/src/Input/XInputAction.hpp) | XInput コントローラー → InputState 変換（左スティック+十字ボタンで移動、A/B/Y でジャンプ/近距離/遠距離） |
 
 `Main.cpp` が毎フレームデバイス入力を検出し、最後にアクティブだったデバイスに切り替える。切断時はキーボードへ自動フォールバック。
+
+**移動入力の正規化方針：** `InputState::moveAxis`（`Vec2`、x=横方向/y=奥行き方向）は「常に長さ 1.0 以下に正規化済み」という不変条件を持つ。この保証の責任は `toInputState()` を実装する各入力レイヤー側にあり、`PlayerMovementSystem` は無条件にこの値を信頼してそのまま速度計算に使う（System 側で正規化やクランプを行わない）。`XInputAction` は左スティックにデッドゾーン処理（`DeadZone`）を適用し、十字ボタンの軸ベクトルと加算したうえで `limitLength(1.0)` により正規化する。
 
 ---
 


### PR DESCRIPTION
## 概要

XInput コントローラーの左スティックによるアナログ全方位移動に対応する（close #137）。

- `InputState` の4方向ブール値（`moveLeft/moveRight/moveForward/moveBackward`）を、正規化済みの `Vec2 moveAxis` に置き換え
- `KeyboardInputAction` / `XInputAction` の `toInputState()` で `moveAxis` を構築・正規化（`limitLength(1.0)`）して返す
- `XInputAction` は左スティック（デッドゾーン処理あり）と十字ボタンの両方を入力として受け付け、合成してから正規化する
- `PlayerMovementSystem` は `moveAxis` をそのまま速度計算に使用（正規化は行わず、入力レイヤーの保証を信頼する）

## 実装判断の理由

- **正規化の責任を入力レイヤーに集約**：「`moveAxis` は常に長さ1.0以下に正規化済み」という不変条件を `toInputState()` 側の責任とし、`PlayerMovementSystem` 側では正規化やクランプを一切行わない設計とした。これによりデバイス固有の入力特性（デジタル/アナログ、デッドゾーンなど）を System 側に漏らさずに済む
- **斜め移動速度の変更（仕様修正）**：従来のキーボード操作では斜め移動時に `vel.w`/`vel.d` が独立に `±speed` となり、合成速度が `√2 倍` になっていた。今回 `moveAxis` を正規化したことで、斜め移動も直交移動と同じ速度になる。これは「斜め移動が不自然に速い」という既存の挙動を修正する意図的な変更である
- **`Vec2::clampLength` ではなく `limitLength` を使用**：プラン段階では `clampLength` を想定していたが、Siv3D v0.6.16 には存在しないため、同等の挙動を持つ `limitLength(maxLength)`（長さが上限を超える場合のみ縮小し、ゼロベクトルでも安全）を採用した
- **デッドゾーン処理を手動で適用**：`XInput(0)` は `const XInput_impl&` を返すため `setLeftThumbDeadZone()`（非const）を直接呼べない。そのため `DeadZone{ .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular }`（Siv3D のデフォルト相当）をローカルに定義し、明示的に適用した
- **D-pad とスティックの併存**：Issue はスティック対応の追加であり D-pad を置き換えるものではないため、両方を同時に有効として軸ベクトルを加算後に正規化する方式とした

## テスト計画

- [x] CI（format / tidy / build / test）通過
- [x] コードレビュー通過
- [x] 実機でのビジュアルチェック（左スティック・十字キーの両方で移動を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)