### PR TITLE
遠距離攻撃の飛翔体実装 #119

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -9,6 +9,8 @@ radius    = 25.0
 damage    = 20
 
 [ranged]
-reach  = 200.0
-radius = 15.0
-damage = 15
+reach        = 200.0
+radius       = 15.0
+damage       = 15
+bullet_speed = 300.0
+spawn_height = 0.0

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -134,6 +134,7 @@
     <ClCompile Include="src\Component\Hierarchy.cpp" />
     <ClCompile Include="src\System\AnimationSystem.cpp" />
     <ClCompile Include="src\System\PlayerMovementSystem.cpp" />
+    <ClCompile Include="src\System\ProjectileSystem.cpp" />
     <ClCompile Include="src\System\AttachmentSystem.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\Phase\PhaseStack.cpp" />
@@ -144,6 +145,7 @@
     <ClCompile Include="tests\TestAnimationData.cpp" />
     <ClCompile Include="tests\TestAttachmentSystem.cpp" />
     <ClCompile Include="tests\TestHitSystem.cpp" />
+    <ClCompile Include="tests\TestProjectileSystem.cpp" />
     <ClCompile Include="tests\TestNameLookup.cpp" />
     <ClCompile Include="tests\TestPhaseStack.cpp" />
     <ClCompile Include="tests\TestPlayerConfig.cpp" />
@@ -396,8 +398,10 @@
     <ClInclude Include="src\Component\Attack.hpp" />
     <ClInclude Include="src\Component\Hp.hpp" />
     <ClInclude Include="src\Component\Stamina.hpp" />
+    <ClInclude Include="src\Component\Projectile.hpp" />
     <ClInclude Include="src\System\HitSystem.hpp" />
     <ClInclude Include="src\System\HudSystem.hpp" />
+    <ClInclude Include="src\System\ProjectileSystem.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="System\PlayerMovementSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\ProjectileSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="System\AttachmentSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
@@ -226,6 +229,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestHitSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\TestProjectileSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestAnimationData.cpp">
@@ -1034,10 +1040,16 @@
     <ClInclude Include="Component\Stamina.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
+    <ClInclude Include="Component\Projectile.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
     <ClInclude Include="System\HitSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="System\HudSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\ProjectileSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Ash2/src/Component/Projectile.hpp
+++ b/Ash2/src/Component/Projectile.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+/// @brief 飛翔体（弾）エンティティを示すタグコンポーネント（データなし）
+/// `WorldPos`+`Velocity`+`Collider`+`Attack`
+/// と組み合わせて使用し、`ProjectileSystem`
+/// が移動・消滅を管理する対象を識別する
+struct Projectile {};

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -19,6 +19,8 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .reach = r[U"reach"].get<double>(),
               .radius = r[U"radius"].get<double>(),
               .damage = r[U"damage"].get<int>(),
+              .bulletSpeed = r[U"bullet_speed"].get<double>(),
+              .spawnHeight = r[U"spawn_height"].get<double>(),
           },
   };
 }

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -17,10 +17,14 @@ struct MeleeConfig {
 struct RangedConfig {
   /// 攻撃リーチ（w 軸方向の距離）
   double reach;
-  /// 攻撃カプセルの半径
+  /// 攻撃カプセルの半径（弾コライダーの半径・CircleDrawable の表示半径と兼用）
   double radius;
   /// 与えるダメージ量
   int damage;
+  /// 弾の移動速度（横方向、ピクセル/秒）
+  double bulletSpeed;
+  /// 弾の発射高さ（プレイヤーの WorldPos.h からのオフセット）
+  double spawnHeight;
 };
 
 /// @brief プレイヤーの設定値

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -9,6 +9,7 @@
 #include "Component/LocalOffset.hpp"
 #include "Component/Name.hpp"
 #include "Component/Player.hpp"
+#include "Component/Projectile.hpp"
 #include "Component/SpriteAnimation.hpp"
 #include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
@@ -18,6 +19,7 @@
 #include "System/AnimationSystem.hpp"
 #include "System/HitSystem.hpp"
 #include "System/PlayerMovementSystem.hpp"
+#include "System/ProjectileSystem.hpp"
 
 constexpr double KDummyPosW = 150.0;
 constexpr s3d::SizeF KDummySize = {60.0, 80.0};
@@ -27,6 +29,7 @@ constexpr double KDummyCapHeight = 80.0;
 constexpr int KDummyMaxHp = 100;
 constexpr int KPlayerMaxHp = 100;
 constexpr int KPlayerMaxStamina = 100;
+constexpr s3d::ColorF KBulletColor = {0.9, 0.9, 0.3};
 
 void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   m_playerRoot = registry.create();
@@ -117,31 +120,37 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
             });
         registry.emplace<Attack>(m_attackEntity,
                                  Attack{.damage = cfg.melee.damage});
-        HitSystem::Update(registry);
       } else if (input.rangedAttackDown) {
         m_attackClip = U"ranged_attack";
         m_attackTimer = getClipDuration(U"ranged_attack");
 
         const double sign = anim.facingRight ? 1.0 : -1.0;
-        m_attackEntity = registry.create();
-        registry.emplace<WorldPos>(m_attackEntity,
-                                   registry.get<WorldPos>(m_playerRoot));
-        registry.emplace<LocalOffset>(m_attackEntity, LocalOffset{});
-        Hierarchy::Attach(registry, m_playerRoot, m_attackEntity);
-        registry.emplace<Collider>(
-            m_attackEntity,
-            Collider{
-                .segmentStart = Vec3{0.0, cfg.melee.capMidH, 0.0},
-                .segmentEnd =
-                    Vec3{sign * cfg.ranged.reach, cfg.melee.capMidH, 0.0},
-                .radius = cfg.ranged.radius,
-            });
-        registry.emplace<Attack>(m_attackEntity,
-                                 Attack{.damage = cfg.ranged.damage});
-        HitSystem::Update(registry);
+        const WorldPos playerPos = registry.get<WorldPos>(m_playerRoot);
+
+        const auto bullet = registry.create();
+        registry.emplace<WorldPos>(
+            bullet, WorldPos{.w = playerPos.w,
+                             .h = playerPos.h + cfg.ranged.spawnHeight,
+                             .d = playerPos.d});
+        registry.emplace<Velocity>(
+            bullet, Velocity{.w = sign * cfg.ranged.bulletSpeed});
+        registry.emplace<Collider>(bullet,
+                                   Collider{
+                                       .segmentStart = Vec3{0.0, 0.0, 0.0},
+                                       .segmentEnd = Vec3{0.0, 0.0, 0.0},
+                                       .radius = cfg.ranged.radius,
+                                   });
+        registry.emplace<Attack>(bullet, Attack{.damage = cfg.ranged.damage});
+        registry.emplace<Drawable>(
+            bullet,
+            CircleDrawable{.radius = cfg.ranged.radius, .color = KBulletColor});
+        registry.emplace<Projectile>(bullet);
       }
     }
   }
+
+  HitSystem::Update(registry);
+  ProjectileSystem::Update(registry, dt);
 
   AnimationSystem::Update(registry, dt);
 
@@ -174,5 +183,11 @@ void PlayerTestPhase::onBeforePop(entt::registry& registry) {
   if (m_dummyTarget != entt::null && registry.valid(m_dummyTarget)) {
     registry.destroy(m_dummyTarget);
     m_dummyTarget = entt::null;
+  }
+
+  // 弾は独立エンティティ（m_playerRoot の子孫ではない）なので、
+  // Projectile タグで検索して個別に破棄する
+  for (const auto entity : registry.view<Projectile>()) {
+    registry.destroy(entity);
   }
 }

--- a/Ash2/src/System/ProjectileSystem.cpp
+++ b/Ash2/src/System/ProjectileSystem.cpp
@@ -1,0 +1,36 @@
+#include "System/ProjectileSystem.hpp"
+
+#include "Component/Attack.hpp"
+#include "Component/Projectile.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+
+void ProjectileSystem::Update(entt::registry& registry, double dt) {
+  const Vec2 cameraOffset = Scene::Center();
+  const RectF screenRect = Scene::Rect();
+
+  s3d::Array<entt::entity> toDestroy;
+
+  auto view = registry.view<Projectile, WorldPos, Velocity, Attack>();
+  for (auto&& [entity, pos, vel, atk] : view.each()) {
+    pos.w += vel.w * dt;
+    pos.h += vel.h * dt;
+    pos.d += vel.d * dt;
+
+    // 着弾: HitSystem がヒットを記録した
+    if (!atk.hitTargets.empty()) {
+      toDestroy.push_back(entity);
+      continue;
+    }
+
+    // 画面外: 画面座標に変換した結果が Scene::Rect() の範囲外
+    const Vec2 screenPos = cameraOffset + pos.toScreen();
+    if (!screenRect.contains(screenPos)) {
+      toDestroy.push_back(entity);
+    }
+  }
+
+  for (const auto entity : toDestroy) {
+    registry.destroy(entity);
+  }
+}

--- a/Ash2/src/System/ProjectileSystem.hpp
+++ b/Ash2/src/System/ProjectileSystem.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <entt/entt.hpp>
+
+struct FrameData;
+
+/// @brief 飛翔体（弾）の移動・消滅を管理するシステム
+class ProjectileSystem {
+ public:
+  /// @brief Projectile
+  /// を持つエンティティを移動させ、消滅条件を満たしたものを破棄する
+  ///
+  /// `Velocity` に従って `WorldPos` を更新したのち、以下のいずれかを満たす
+  /// エンティティを `registry.destroy()` する。
+  /// - 着弾: `Attack.hitTargets` が空でなくなった（`HitSystem`
+  /// がヒットを記録した）
+  /// - 画面外: `WorldPos` を画面座標に変換した結果が `Scene::Rect()` の範囲外
+  ///
+  /// 着弾判定が正しく行われるよう、`HitSystem::Update` の後に呼び出すこと。
+  ///
+  /// @param registry ECS レジストリ
+  /// @param dt 1フレームあたりの経過時間（秒）
+  static void Update(entt::registry& registry, double dt);
+};

--- a/Ash2/tests/TestProjectileSystem.cpp
+++ b/Ash2/tests/TestProjectileSystem.cpp
@@ -1,0 +1,88 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/Attack.hpp"
+#include "Component/Collider.hpp"
+#include "Component/Projectile.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+#include "System/ProjectileSystem.hpp"
+
+namespace {
+
+/// @brief テスト用の弾エンティティを生成する
+/// @param registry ECS レジストリ
+/// @param pos 初期ワールド座標
+/// @param vel 速度
+/// @return 生成した弾エンティティ
+entt::entity MakeBullet(entt::registry& registry, const WorldPos& pos,
+                        const Velocity& vel) {
+  const auto bullet = registry.create();
+  registry.emplace<Projectile>(bullet);
+  registry.emplace<WorldPos>(bullet, pos);
+  registry.emplace<Velocity>(bullet, vel);
+  registry.emplace<Collider>(bullet, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 5.0});
+  registry.emplace<Attack>(bullet, Attack{.damage = 10});
+  return bullet;
+}
+
+}  // namespace
+
+TEST_CASE("ProjectileSystem - moves bullet by velocity each frame") {
+  // Velocity に従って WorldPos が更新される
+  entt::registry registry;
+
+  const auto bullet =
+      MakeBullet(registry, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0},
+                 Velocity{.w = 100.0, .h = 0.0, .d = 0.0});
+
+  ProjectileSystem::Update(registry, 0.5);
+
+  REQUIRE(registry.valid(bullet));
+  REQUIRE(registry.get<WorldPos>(bullet).w == Approx(50.0));
+
+  ProjectileSystem::Update(registry, 0.5);
+
+  REQUIRE(registry.valid(bullet));
+  REQUIRE(registry.get<WorldPos>(bullet).w == Approx(100.0));
+}
+
+TEST_CASE(
+    "ProjectileSystem - destroys bullet on impact (hitTargets non-empty)") {
+  // Attack.hitTargets が空でなくなった（HitSystem
+  // がヒットを記録した）場合は破棄される
+  entt::registry registry;
+
+  const auto bullet =
+      MakeBullet(registry, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0},
+                 Velocity{.w = 100.0, .h = 0.0, .d = 0.0});
+
+  // HitSystem が記録したことを模してダミーのターゲットを hitTargets に追加
+  const auto dummyTarget = registry.create();
+  registry.get<Attack>(bullet).hitTargets.emplace(dummyTarget);
+
+  ProjectileSystem::Update(registry, 1.0 / 60.0);
+
+  REQUIRE_FALSE(registry.valid(bullet));
+}
+
+TEST_CASE("ProjectileSystem - destroys bullet when off-screen") {
+  // WorldPos を画面座標に変換した結果が Scene::Rect()
+  // の範囲外の場合は破棄される
+  entt::registry registry;
+
+  // 実行環境の画面サイズに依存しないよう、十分に遠い座標を使う
+  constexpr double KFarAway = 1.0e9;
+  const auto bullet =
+      MakeBullet(registry, WorldPos{.w = KFarAway, .h = 0.0, .d = 0.0},
+                 Velocity{.w = 0.0, .h = 0.0, .d = 0.0});
+
+  ProjectileSystem::Update(registry, 1.0 / 60.0);
+
+  REQUIRE_FALSE(registry.valid(bullet));
+}
+
+#endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,6 +117,7 @@ WorldPos { w, h, d }
 | [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる）。`root` で複数コライダー構成のルートを指定し、`hitTargets` で攻撃生存期間中の重複ヒットを防ぐ |
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
+| [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`ProjectileSystem` が移動・消滅を管理する対象を識別する |
 
 ---
 
@@ -158,6 +159,7 @@ WorldPos { w, h, d }
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算 |
 | [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase / DemoPhase） | Player の移動・ジャンプ・重力・クリップ選択・向き更新 |
+| [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の移動、着弾（hitTargets 非空）/ 画面外での破棄 |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画 |
 
 ---


### PR DESCRIPTION
## 概要

遠距離攻撃を「攻撃入力と同フレームで即座にレンジチェックする仮実装」から、「弾エンティティを生成し、毎フレーム移動・ヒット判定し、着弾または画面外で消滅する」本実装に差し替える。

close #119

## 変更内容

- `Projectile`（弾を識別する空のタグコンポーネント）を新設
- `ProjectileSystem::Update` を新設し、弾を毎フレーム移動させ、「着弾」（`Attack.hitTargets` が空でなくなった）または「画面外」で破棄する
- `PlayerTestPhase` の遠距離攻撃を、独立エンティティ（`WorldPos`+`Velocity`+`Collider`+`Attack`+`Drawable`+`Projectile`）の生成に置き換え
- `HitSystem::Update` → `ProjectileSystem::Update` の順で毎フレーム呼び出すよう変更（弾が複数フレームにわたって判定が必要なため）
- 弾速度・発射高さを `RangedConfig`（`player.toml` の `[ranged]`）で管理し、再ビルドなしに調整可能に
- `PlayerTestPhase::onBeforePop` で `Projectile` タグエンティティを破棄し、フェーズ終了時の弾の残留を防止
- `TestProjectileSystem` を追加（移動・着弾消滅・画面外消滅を検証）

## 実装判断・技術選択の理由

- **消滅条件の変更**: Issue では「画面外・壁到達時の消滅」とされていたが、「壁」の概念が現状コードベースに未実装のため、計画段階での相談の結果「着弾・画面外」の2条件に変更した（Issue にコメントで補足済み）。これにより「命中後に貫通させるか」という仕様の曖昧さも同時に解消できた。
- **`Projectile` を空のタグコンポーネントとした**: 消滅条件が「着弾・画面外」のみで完結するため、寿命や最大距離などのデータを持つ必要がなく、ECS の流儀（データのみの Component、ロジックは System）に沿って最小構成にした。
- **弾を独立エンティティとして生成**: `m_playerRoot` の子にすると `Hierarchy`/`LocalOffset` の仕組み上、発射後も親に追従してしまうため、独立エンティティとした。一方で `Hierarchy::DestroyWithChildren` の対象外になるため、`onBeforePop` で個別に破棄する処理を追加した。

## 関連

- close #119
- 副産物として、ビジュアルチェック中に既存コードの「描画と当たり判定（Collider）の基準点のずれ」を発見したため、別Issue #140 として切り出した

## テスト計画

- [x] `tools/build.sh` でビルド成功
- [x] `tools/run-tests.sh` で全テスト通過
- [x] `/run` でゲームを起動し、遠距離攻撃で弾が発射・移動・消滅することを目視確認