### PR TITLE
描画アンカー（DrawAnchor）を導入し、見た目とColliderの基準点を統一

### DIFF
--- a/Ash2/src/Component/AnimationData.hpp
+++ b/Ash2/src/Component/AnimationData.hpp
@@ -15,7 +15,7 @@ struct AnimationData {
   /// TextureAsset キー（例: `assets/images/player.png`）
   s3d::String textureKey;
   s3d::Size size;
-  /// 中心座標からのずれ
+  /// TextureDrawable::anchor が示す位置からのずれ
   s3d::Vec2 drawOffset;
   /// クリップ名 → AnimationClip の対応表
   s3d::HashTable<s3d::String, AnimationClip> clips;

--- a/Ash2/src/Component/Drawable.hpp
+++ b/Ash2/src/Component/Drawable.hpp
@@ -9,6 +9,14 @@ struct BorderStyle {
   double thickness;
 };
 
+/// @brief WorldPos を描画形状内のどの点に合わせるか
+enum class DrawAnchor : std::uint8_t {
+  /// 形状の中心
+  Center,
+  /// 形状の下端中央
+  BottomCenter,
+};
+
 /// @brief 矩形描画データ
 struct RectDrawable {
   /// 描画サイズ（幅・高さ）
@@ -16,6 +24,7 @@ struct RectDrawable {
   ColorF color;
   /// none = 枠線なし
   Optional<BorderStyle> border;
+  DrawAnchor anchor = DrawAnchor::Center;
 };
 
 /// @brief 円描画データ
@@ -41,8 +50,9 @@ struct PieDrawable {
 /// @brief テクスチャ描画データ
 struct TextureDrawable {
   TextureRegion region;
-  /// 中心座標からのずれ（アンカー調整用）
+  /// anchor が示す位置からのずれ
   Vec2 drawOffset{0, 0};
+  DrawAnchor anchor = DrawAnchor::Center;
 };
 
 /// @brief 描画コンポーネント（描画形状の variant）

--- a/Ash2/src/Component/WorldPos.hpp
+++ b/Ash2/src/Component/WorldPos.hpp
@@ -2,6 +2,9 @@
 #include <Siv3D.hpp>
 
 /// @brief ワールド座標
+/// @note 描画（Drawable の DrawAnchor）・当たり判定（Collider のオフセット）の
+///       共通基準点。基準点が「中心」か「接地点」かはエンティティごとに異なり、
+///       Drawable/Collider 側をその意味づけに合わせて設定する。
 struct WorldPos {
   /// 横位置
   double w = 0.0;

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -38,7 +38,8 @@ void AnimationViewerPhase::onAfterPush(entt::registry& registry) {
 
   m_entity = registry.create();
   registry.emplace<WorldPos>(m_entity);
-  registry.emplace<Drawable>(m_entity, TextureDrawable{});
+  registry.emplace<Drawable>(
+      m_entity, TextureDrawable{.anchor = DrawAnchor::BottomCenter});
   registry.emplace<SpriteAnimation>(
       m_entity,
       SpriteAnimation{.dataKey = m_dataKey,

--- a/Ash2/src/Phase/DemoPhase.cpp
+++ b/Ash2/src/Phase/DemoPhase.cpp
@@ -18,7 +18,8 @@ void DemoPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<WorldPos>(m_playerRoot);
   registry.emplace<Velocity>(m_playerRoot);
   registry.emplace<Name>(m_playerRoot, Name{U"player"});
-  registry.emplace<Drawable>(m_playerRoot, TextureDrawable{});
+  registry.emplace<Drawable>(
+      m_playerRoot, TextureDrawable{.anchor = DrawAnchor::BottomCenter});
   registry.emplace<SpriteAnimation>(
       m_playerRoot,
       SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -37,7 +37,8 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<WorldPos>(m_playerRoot);
   registry.emplace<Velocity>(m_playerRoot);
   registry.emplace<Name>(m_playerRoot, Name{U"player"});
-  registry.emplace<Drawable>(m_playerRoot, TextureDrawable{});
+  registry.emplace<Drawable>(
+      m_playerRoot, TextureDrawable{.anchor = DrawAnchor::BottomCenter});
   registry.emplace<SpriteAnimation>(
       m_playerRoot,
       SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
@@ -51,8 +52,10 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   // ダミーターゲット（縦カプセル: 足元〜高さ80、半径30）
   m_dummyTarget = registry.create();
   registry.emplace<WorldPos>(m_dummyTarget, WorldPos{.w = KDummyPosW});
-  registry.emplace<Drawable>(
-      m_dummyTarget, RectDrawable{.size = KDummySize, .color = KDummyColor});
+  registry.emplace<Drawable>(m_dummyTarget,
+                             RectDrawable{.size = KDummySize,
+                                          .color = KDummyColor,
+                                          .anchor = DrawAnchor::BottomCenter});
   registry.emplace<Collider>(m_dummyTarget,
                              Collider{
                                  .segmentStart = Vec3{0.0, 0.0, 0.0},

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -27,8 +27,17 @@ void DrawSystem::Draw(const entt::registry& registry) {
     std::visit(
         Overloaded{
             [&screenPos](const RectDrawable& shape) {
-              const RectF rect{Arg::center(screenPos), shape.size.x,
-                               shape.size.y};
+              const RectF rect = [&] {
+                switch (shape.anchor) {
+                  case DrawAnchor::BottomCenter:
+                    return RectF{Arg::bottomCenter(screenPos), shape.size.x,
+                                 shape.size.y};
+                  case DrawAnchor::Center:
+                  default:
+                    return RectF{Arg::center(screenPos), shape.size.x,
+                                 shape.size.y};
+                }
+              }();
               rect.draw(shape.color);
               if (shape.border) {
                 rect.drawFrame(shape.border->thickness, shape.border->color);
@@ -58,7 +67,16 @@ void DrawSystem::Draw(const entt::registry& registry) {
               }
             },
             [&screenPos](const TextureDrawable& shape) {
-              shape.region.drawAt(screenPos + shape.drawOffset);
+              const Vec2 anchorPos = screenPos + shape.drawOffset;
+              switch (shape.anchor) {
+                case DrawAnchor::BottomCenter:
+                  shape.region.draw(Arg::bottomCenter(anchorPos));
+                  break;
+                case DrawAnchor::Center:
+                default:
+                  shape.region.draw(Arg::center(anchorPos));
+                  break;
+              }
             },
         },
         entry.drawable.get());

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,8 @@ WorldPos { w, h, d }
 
 **制約：** `WorldPos` は常に絶対座標。子エンティティも `WorldPos` を持ち、`AttachmentSystem` が毎フレーム親の絶対座標 + `LocalOffset` で上書きする。
 
+**描画・判定の基準点：** `WorldPos` は `Drawable`（`DrawAnchor`）と `Collider`（オフセット）の共通基準点だが、「中心」か「接地点」かはエンティティごとに異なる。`DrawAnchor` のデフォルトは `Center`、接地キャラクター（プレイヤー等、`Collider` を「足元からのカプセル」として持つエンティティ）は生成時に `BottomCenter` を明示する。
+
 ---
 
 ## 入力抽象化
@@ -109,7 +111,7 @@ WorldPos { w, h, d }
 | [`Velocity`](../Ash2/src/Component/Velocity.hpp) | 速度ベクトル（w/h/d、ピクセル/秒） |
 | [`LocalOffset`](../Ash2/src/Component/LocalOffset.hpp) | 親からの相対座標（Hierarchy 付きエンティティのみ） |
 | [`Hierarchy`](../Ash2/src/Component/Hierarchy.hpp) | 親子関係（双方向連結リスト、static メンバで操作） |
-| [`Drawable`](../Ash2/src/Component/Drawable.hpp) | 描画形状（`variant<RectDrawable/CircleDrawable/PieDrawable/TextureDrawable>`） |
+| [`Drawable`](../Ash2/src/Component/Drawable.hpp) | 描画形状（`variant<RectDrawable/CircleDrawable/PieDrawable/TextureDrawable>`）。`RectDrawable`/`TextureDrawable` は `DrawAnchor` で `WorldPos` の合わせ位置（`Center`/`BottomCenter`）を指定する |
 | [`SpriteAnimation`](../Ash2/src/Component/SpriteAnimation.hpp) | アニメーション再生状態（per-entity） |
 | [`Name`](../Ash2/src/Component/Name.hpp) | エンティティ名（不変、NameLookup と対応） |
 | [`Player`](../Ash2/src/Component/Player.hpp) | プレイヤータグ（データなし） |


### PR DESCRIPTION
## 概要
Issue #140 の対応。`DrawSystem` が常に `WorldPos` を中心として描画していた一方、
`Collider` は `WorldPos` からのオフセットとして定義されていたため、見た目の範囲と
判定の範囲が一致していなかった問題を修正する。

## 変更内容
- `RectDrawable`/`TextureDrawable` に明示的な `DrawAnchor`（`Center`/`BottomCenter`、
  デフォルト `Center`）フィールドを追加
- `DrawSystem` は `shape.anchor` に応じて `Arg::center`/`Arg::bottomCenter` を
  使い分けて描画するよう変更
- 接地キャラクター（プレイヤー・ダミーターゲット・アニメーションビューア用エンティティ）の
  生成箇所で `BottomCenter` を明示的に指定し、`WorldPos`（足元）と見た目の基準点を一致させた
- `WorldPos`/`AnimationData` のコメントと `docs/ARCHITECTURE.md` を新しい方針に合わせて更新

## 技術選択の理由
当初案（PR #142、クローズ済み）は「形状の種類でアンカーを固定する」方式だったが、
レビューで「形状の都合」と「`WorldPos` の意味づけ」が混同される課題が指摘された。
そのため各 `Drawable` インスタンス（＝エンティティ生成側の意図）でアンカーを選べる方式に変更し、
将来 `Collider` の基準が異なるエンティティが同じ形状を使っても整合を保てるようにした。
`Arg::center_<T>`/`Arg::bottomCenter_<T>` はコンパイル時に区別される別タグ型のため、
`enum` 値による実行時 `switch` でオーバーロードを呼び分けている（手動オフセット計算は避けた）。

close #140