### PR TITLE
clang-tidy 警告を解消する（/EHsc復元・signed/unsigned比較修正）

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -47,6 +47,7 @@ jobs:
 
           $compileFlags = @(
             "--driver-mode=cl",
+            "/EHsc",
             "/std:c++latest",
             "/Zc:__cplusplus",
             "/utf-8",

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -1,5 +1,7 @@
 #include "Phase/TestMenuPhase.hpp"
 
+#include <utility>
+
 #include "Phase/AnimationViewerPhase.hpp"
 #include "Phase/PlayerTestPhase.hpp"
 
@@ -50,7 +52,7 @@ IPhase::PhaseCommand TestMenuPhase::update(entt::registry& registry,
   s3d::Scene::SetBackground(s3d::ColorF{KBgBrightness});
   m_font(U"Test Menu").draw(KTitleX, KTitleY);
 
-  for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
+  for (int i = 0; std::cmp_less(i, m_items.size()); ++i) {
     const s3d::ColorF color =
         (i == m_selectedIndex) ? s3d::Palette::Yellow : s3d::Palette::White;
     m_font(m_items[i].label).draw(KItemX, KItemBaseY + i * KItemSpacing, color);


### PR DESCRIPTION
## 概要

Issue #149（clang-tidy 警告レポート）への対応です。

- `Ash2/src/Phase/TestMenuPhase.cpp`: `for`ループの比較を `i < static_cast<int>(m_items.size())` から `std::cmp_less(i, m_items.size())` に変更し、`modernize-use-integer-sign-comparison` 警告を解消
- `.github/workflows/clang-tidy.yml`: `$compileFlags` に `/EHsc` を追加

## 技術的な選択の理由

`/EHsc` は過去のコミット（`cb4c20e`）で一度追加されていたが、ワークフローを `$compileFlags` 配列形式に書き換えた際（`004e955`）に引き継がれず脱落していた。これにより clang-cl が「例外無効」前提で解析し、`Main.cpp` / `ScenarioData.cpp` / `PhaseRegistration.cpp` / `TestScenarioData.cpp` 内の正当な `try`/`throw` がすべて `clang-diagnostic-error` として誤検出されていた。今回の変更は、過去に意図的に追加された設定の復元である。

## 動作確認

- `tools/build.sh` でビルド・テスト成功（95 assertions, 40 test cases）を確認済み
- clang-tidy CIワークフローの変更自体はローカル環境で完全に再現できないため、マージ後に `workflow_dispatch` で手動実行し、警告が解消されることを確認する
- Issue #149 は clang-tidy CI が次回成功実行時に自動クローズする仕組みのため、本PRでは `close` を付けていない