### PR TITLE
NeutralState/AttackStateコンポーネントの導入と状態遷移システムへの分割

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -133,6 +133,8 @@
     <ClCompile Include="src\Component\Hierarchy.cpp" />
     <ClCompile Include="src\System\AnimationSystem.cpp" />
     <ClCompile Include="src\System\PlayerMovementSystem.cpp" />
+    <ClCompile Include="src\System\NeutralStateSystem.cpp" />
+    <ClCompile Include="src\System\AttackStateSystem.cpp" />
     <ClCompile Include="src\System\ProjectileSystem.cpp" />
     <ClCompile Include="src\System\AttachmentSystem.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
@@ -143,7 +145,9 @@
     </ClCompile>
     <ClCompile Include="tests\TestAnimationData.cpp" />
     <ClCompile Include="tests\TestAttachmentSystem.cpp" />
+    <ClCompile Include="tests\TestAttackStateSystem.cpp" />
     <ClCompile Include="tests\TestHitSystem.cpp" />
+    <ClCompile Include="tests\TestNeutralStateSystem.cpp" />
     <ClCompile Include="tests\TestProjectileSystem.cpp" />
     <ClCompile Include="tests\TestNameLookup.cpp" />
     <ClCompile Include="tests\TestPhaseStack.cpp" />
@@ -371,6 +375,8 @@
     <ClInclude Include="src\Component\Velocity.hpp" />
     <ClInclude Include="src\System\AnimationSystem.hpp" />
     <ClInclude Include="src\System\PlayerMovementSystem.hpp" />
+    <ClInclude Include="src\System\NeutralStateSystem.hpp" />
+    <ClInclude Include="src\System\AttackStateSystem.hpp" />
     <ClInclude Include="src\System\AttachmentSystem.hpp" />
     <ClInclude Include="src\System\DrawSystem.hpp" />
     <ClInclude Include="src\System\HierarchySystem.hpp" />
@@ -394,6 +400,8 @@
     <ClInclude Include="src\Component\Attack.hpp" />
     <ClInclude Include="src\Component\Hp.hpp" />
     <ClInclude Include="src\Component\Stamina.hpp" />
+    <ClInclude Include="src\Component\NeutralState.hpp" />
+    <ClInclude Include="src\Component\AttackState.hpp" />
     <ClInclude Include="src\Component\Projectile.hpp" />
     <ClInclude Include="src\System\HitSystem.hpp" />
     <ClInclude Include="src\System\HudSystem.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -189,6 +189,12 @@
     <ClCompile Include="System\PlayerMovementSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\NeutralStateSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
+    <ClCompile Include="System\AttackStateSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="System\ProjectileSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
@@ -229,6 +235,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestProjectileSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\TestNeutralStateSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\TestAttackStateSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestAnimationData.cpp">
@@ -956,6 +968,12 @@
     <ClInclude Include="System\PlayerMovementSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
+    <ClInclude Include="System\NeutralStateSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\AttackStateSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
     <ClInclude Include="System\AttachmentSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
@@ -1026,6 +1044,12 @@
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="Component\Stamina.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="Component\NeutralState.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="Component\AttackState.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="Component\Projectile.hpp">

--- a/Ash2/src/Component/AttackState.hpp
+++ b/Ash2/src/Component/AttackState.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <entt/entt.hpp>
+
+/// @brief プレイヤーが攻撃状態であることを示すコンポーネント
+struct AttackState {
+  /// 現在再生中の攻撃クリップ名
+  s3d::String clip;
+  /// 攻撃モーション残り時間（秒）
+  double timer = 0.0;
+  /// 攻撃判定の子エンティティ（遠距離攻撃時は entt::null）
+  entt::entity entity = entt::null;
+};

--- a/Ash2/src/Component/NeutralState.hpp
+++ b/Ash2/src/Component/NeutralState.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+/// @brief
+/// プレイヤーが通常状態（移動・ジャンプ可能）であることを示すタグコンポーネント
+struct NeutralState {};

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -1,23 +1,22 @@
 #include "Phase/PlayerTestPhase.hpp"
 
-#include "Component/AnimationData.hpp"
-#include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Hierarchy.hpp"
 #include "Component/Hp.hpp"
-#include "Component/LocalOffset.hpp"
 #include "Component/Name.hpp"
+#include "Component/NeutralState.hpp"
 #include "Component/Player.hpp"
 #include "Component/Projectile.hpp"
 #include "Component/SpriteAnimation.hpp"
 #include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
-#include "Config/PlayerConfig.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
+#include "System/AttackStateSystem.hpp"
 #include "System/HitSystem.hpp"
+#include "System/NeutralStateSystem.hpp"
 #include "System/PlayerMovementSystem.hpp"
 #include "System/ProjectileSystem.hpp"
 
@@ -29,7 +28,6 @@ constexpr double KDummyCapHeight = 80.0;
 constexpr int KDummyMaxHp = 100;
 constexpr int KPlayerMaxHp = 100;
 constexpr int KPlayerMaxStamina = 100;
-constexpr s3d::ColorF KBulletColor = {0.9, 0.9, 0.3};
 
 void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   m_playerRoot = registry.create();
@@ -47,6 +45,7 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<Stamina>(
       m_playerRoot,
       Stamina{.max = KPlayerMaxStamina, .current = KPlayerMaxStamina});
+  registry.emplace<NeutralState>(m_playerRoot);
   AnimationSystem::Update(registry, 0.0);
 
   // ダミーターゲット（縦カプセル: 足元〜高さ80、半径30）
@@ -68,89 +67,11 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
 
 IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
                                              const FrameData& frameData) {
-  const auto& cfg = registry.ctx().get<PlayerConfig>();
-  const auto& input = frameData.input;
   const double dt = frameData.dt;
 
-  // AnimationDataRegistry からクリップ期間を取得
-  const auto& animReg = registry.ctx().get<AnimationDataRegistry>();
-  const auto& playerData = animReg.at(U"player");
-  const auto getClipDuration = [&](const s3d::String& clipName) -> double {
-    const auto it = playerData.clips.find(clipName);
-    if (it == playerData.clips.end()) return 0.0;
-    return static_cast<double>(it->second.count) / it->second.speed;
-  };
-
-  // 攻撃タイマー更新（0以下で攻撃終了）
-  if (!m_attackClip.empty()) {
-    m_attackTimer -= dt;
-    if (m_attackTimer <= 0.0) {
-      m_attackClip = U"";
-      if (m_attackEntity != entt::null) {
-        Hierarchy::DestroyWithChildren(registry, m_attackEntity);
-        m_attackEntity = entt::null;
-      }
-    }
-  }
-
-  PlayerMovementSystem::Update(registry, frameData, m_attackClip);
-
-  const bool isAttacking = !m_attackClip.empty();
-
-  auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
-  for (const auto& [entity, pos, vel, anim] : view.each()) {
-    const bool onGround = pos.isOnGround();
-
-    // 攻撃入力チェック（攻撃中でない、かつ地上にいるときのみ）
-    if (!isAttacking && onGround) {
-      if (input.attackDown) {
-        m_attackClip = U"attack";
-        m_attackTimer = getClipDuration(U"attack");
-
-        const double sign = anim.facingRight ? 1.0 : -1.0;
-        m_attackEntity = registry.create();
-        registry.emplace<WorldPos>(m_attackEntity,
-                                   registry.get<WorldPos>(m_playerRoot));
-        registry.emplace<LocalOffset>(m_attackEntity, LocalOffset{});
-        Hierarchy::Attach(registry, m_playerRoot, m_attackEntity);
-        registry.emplace<Collider>(
-            m_attackEntity,
-            Collider{
-                .segmentStart = Vec3{0.0, cfg.melee.capMidH, 0.0},
-                .segmentEnd =
-                    Vec3{sign * cfg.melee.reach, cfg.melee.capMidH, 0.0},
-                .radius = cfg.melee.radius,
-            });
-        registry.emplace<Attack>(m_attackEntity,
-                                 Attack{.damage = cfg.melee.damage});
-      } else if (input.rangedAttackDown) {
-        m_attackClip = U"ranged_attack";
-        m_attackTimer = getClipDuration(U"ranged_attack");
-
-        const double sign = anim.facingRight ? 1.0 : -1.0;
-        const WorldPos playerPos = registry.get<WorldPos>(m_playerRoot);
-
-        const auto bullet = registry.create();
-        registry.emplace<WorldPos>(
-            bullet, WorldPos{.w = playerPos.w,
-                             .h = playerPos.h + cfg.ranged.spawnHeight,
-                             .d = playerPos.d});
-        registry.emplace<Velocity>(
-            bullet, Velocity{.w = sign * cfg.ranged.bulletSpeed});
-        registry.emplace<Collider>(bullet,
-                                   Collider{
-                                       .segmentStart = Vec3{0.0, 0.0, 0.0},
-                                       .segmentEnd = Vec3{0.0, 0.0, 0.0},
-                                       .radius = cfg.ranged.radius,
-                                   });
-        registry.emplace<Attack>(bullet, Attack{.damage = cfg.ranged.damage});
-        registry.emplace<Drawable>(
-            bullet,
-            CircleDrawable{.radius = cfg.ranged.radius, .color = KBulletColor});
-        registry.emplace<Projectile>(bullet);
-      }
-    }
-  }
+  AttackStateSystem::Update(registry, frameData);
+  PlayerMovementSystem::Update(registry, frameData);
+  NeutralStateSystem::Update(registry, frameData);
 
   HitSystem::Update(registry);
   ProjectileSystem::Update(registry, dt);
@@ -170,19 +91,16 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
 
 void PlayerTestPhase::reloadPlayer(entt::registry& registry) {
   onBeforePop(registry);
-  m_attackClip = U"";
-  m_attackTimer = 0.0;
   onAfterPush(registry);
 }
 
 void PlayerTestPhase::onBeforePop(entt::registry& registry) {
-  // m_attackEntity は m_playerRoot の子孫なので DestroyWithChildren
-  // で連動して破棄される
+  // 攻撃判定エンティティ（AttackState.entity）は m_playerRoot
+  // の子孫なので DestroyWithChildren で連動して破棄される
   if (m_playerRoot != entt::null) {
     Hierarchy::DestroyWithChildren(registry, m_playerRoot);
     m_playerRoot = entt::null;
   }
-  m_attackEntity = entt::null;
   if (m_dummyTarget != entt::null && registry.valid(m_dummyTarget)) {
     registry.destroy(m_dummyTarget);
     m_dummyTarget = entt::null;

--- a/Ash2/src/Phase/PlayerTestPhase.hpp
+++ b/Ash2/src/Phase/PlayerTestPhase.hpp
@@ -26,11 +26,5 @@ class PlayerTestPhase : public IPhase {
   void reloadPlayer(entt::registry& registry);
 
   entt::entity m_playerRoot = entt::null;
-  /// 現在の攻撃クリップ名（空文字=攻撃中でない）
-  s3d::String m_attackClip;
-  /// 攻撃モーション残り時間（秒）
-  double m_attackTimer = 0.0;
   entt::entity m_dummyTarget = entt::null;
-  /// 攻撃判定の子エンティティ（攻撃中のみ生成、終了時に destroy）
-  entt::entity m_attackEntity = entt::null;
 };

--- a/Ash2/src/System/AttackStateSystem.cpp
+++ b/Ash2/src/System/AttackStateSystem.cpp
@@ -1,0 +1,36 @@
+#include <Siv3D.hpp>
+
+#include "System/AttackStateSystem.hpp"
+
+#include "Component/AttackState.hpp"
+#include "Component/Hierarchy.hpp"
+#include "Component/NeutralState.hpp"
+#include "Component/Player.hpp"
+#include "Component/WorldPos.hpp"
+#include "Phase/FrameData.hpp"
+
+void AttackStateSystem::Update(entt::registry& registry,
+                               const FrameData& frameData) {
+  const double dt = frameData.dt;
+
+  s3d::Array<entt::entity> finished;
+
+  auto view = registry.view<Player, WorldPos, AttackState>();
+  for (const auto entity : view) {
+    auto& attackState = view.get<AttackState>(entity);
+    attackState.timer -= dt;
+    if (attackState.timer <= 0.0) {
+      finished.push_back(entity);
+    }
+  }
+
+  for (const auto entity : finished) {
+    const auto attackEntity = registry.get<AttackState>(entity).entity;
+    registry.erase<AttackState>(entity);
+    registry.emplace<NeutralState>(entity);
+
+    if (attackEntity != entt::null) {
+      Hierarchy::DestroyWithChildren(registry, attackEntity);
+    }
+  }
+}

--- a/Ash2/src/System/AttackStateSystem.hpp
+++ b/Ash2/src/System/AttackStateSystem.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <entt/entt.hpp>
+
+struct FrameData;
+
+/// @brief プレイヤーの攻撃状態（AttackState）の終了処理を行うシステム
+class AttackStateSystem {
+ public:
+  /// @brief AttackState を持つエンティティのタイマーを減算し、終了処理を行う
+  ///
+  /// `timer` を `frameData.dt` だけ減算し、0以下になったら `AttackState`
+  /// を `erase` して `NeutralState` を `emplace` する（Attack → Neutral
+  /// 遷移）。`AttackState.entity` が `entt::null` でない場合は
+  /// `Hierarchy::DestroyWithChildren` で攻撃判定エンティティを破棄する。
+  static void Update(entt::registry& registry, const FrameData& frameData);
+};

--- a/Ash2/src/System/NeutralStateSystem.cpp
+++ b/Ash2/src/System/NeutralStateSystem.cpp
@@ -1,0 +1,128 @@
+#include <Siv3D.hpp>
+
+#include "System/NeutralStateSystem.hpp"
+
+#include "Component/AnimationData.hpp"
+#include "Component/Attack.hpp"
+#include "Component/AttackState.hpp"
+#include "Component/Collider.hpp"
+#include "Component/Drawable.hpp"
+#include "Component/Hierarchy.hpp"
+#include "Component/LocalOffset.hpp"
+#include "Component/NeutralState.hpp"
+#include "Component/Player.hpp"
+#include "Component/Projectile.hpp"
+#include "Component/SpriteAnimation.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "Phase/FrameData.hpp"
+
+namespace {
+
+constexpr s3d::ColorF KBulletColor = {0.9, 0.9, 0.3};
+
+/// @brief 攻撃入力の種類
+enum class AttackKind : std::uint8_t { Melee, Ranged };
+
+/// @brief Neutral → Attack 遷移対象のエンティティとその開始時のスナップショット
+struct PendingAttack {
+  entt::entity entity;
+  AttackKind kind;
+  WorldPos pos;
+  bool facingRight;
+};
+
+/// @brief 指定クリップの再生時間（秒）を返す
+/// @return クリップが見つからない場合は 0.0
+double GetClipDuration(const AnimationData& playerData,
+                       const s3d::String& clipName) {
+  const auto it = playerData.clips.find(clipName);
+  if (it == playerData.clips.end()) return 0.0;
+  return static_cast<double>(it->second.count) / it->second.speed;
+}
+
+}  // namespace
+
+void NeutralStateSystem::Update(entt::registry& registry,
+                                const FrameData& frameData) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& input = frameData.input;
+  const auto& animReg = registry.ctx().get<AnimationDataRegistry>();
+  const auto& playerData = animReg.at(U"player");
+
+  s3d::Array<PendingAttack> pending;
+
+  auto view = registry.view<Player, WorldPos, NeutralState, SpriteAnimation>();
+  for (const auto entity : view) {
+    const auto& pos = view.get<WorldPos>(entity);
+    const auto& anim = view.get<SpriteAnimation>(entity);
+
+    if (!pos.isOnGround()) continue;
+
+    if (input.attackDown) {
+      pending.push_back(PendingAttack{.entity = entity,
+                                      .kind = AttackKind::Melee,
+                                      .pos = pos,
+                                      .facingRight = anim.facingRight});
+    } else if (input.rangedAttackDown) {
+      pending.push_back(PendingAttack{.entity = entity,
+                                      .kind = AttackKind::Ranged,
+                                      .pos = pos,
+                                      .facingRight = anim.facingRight});
+    }
+  }
+
+  for (const auto& attack : pending) {
+    const double sign = attack.facingRight ? 1.0 : -1.0;
+
+    if (attack.kind == AttackKind::Melee) {
+      const auto attackEntity = registry.create();
+      registry.emplace<WorldPos>(attackEntity, attack.pos);
+      registry.emplace<LocalOffset>(attackEntity, LocalOffset{});
+      Hierarchy::Attach(registry, attack.entity, attackEntity);
+      registry.emplace<Collider>(
+          attackEntity, Collider{
+                            .segmentStart = Vec3{0.0, cfg.melee.capMidH, 0.0},
+                            .segmentEnd = Vec3{sign * cfg.melee.reach,
+                                               cfg.melee.capMidH, 0.0},
+                            .radius = cfg.melee.radius,
+                        });
+      registry.emplace<Attack>(attackEntity,
+                               Attack{.damage = cfg.melee.damage});
+
+      registry.erase<NeutralState>(attack.entity);
+      registry.emplace<AttackState>(
+          attack.entity,
+          AttackState{.clip = U"attack",
+                      .timer = GetClipDuration(playerData, U"attack"),
+                      .entity = attackEntity});
+    } else {
+      const auto bullet = registry.create();
+      registry.emplace<WorldPos>(
+          bullet, WorldPos{.w = attack.pos.w,
+                           .h = attack.pos.h + cfg.ranged.spawnHeight,
+                           .d = attack.pos.d});
+      registry.emplace<Velocity>(bullet,
+                                 Velocity{.w = sign * cfg.ranged.bulletSpeed});
+      registry.emplace<Collider>(bullet,
+                                 Collider{
+                                     .segmentStart = Vec3{0.0, 0.0, 0.0},
+                                     .segmentEnd = Vec3{0.0, 0.0, 0.0},
+                                     .radius = cfg.ranged.radius,
+                                 });
+      registry.emplace<Attack>(bullet, Attack{.damage = cfg.ranged.damage});
+      registry.emplace<Drawable>(
+          bullet,
+          CircleDrawable{.radius = cfg.ranged.radius, .color = KBulletColor});
+      registry.emplace<Projectile>(bullet);
+
+      registry.erase<NeutralState>(attack.entity);
+      registry.emplace<AttackState>(
+          attack.entity,
+          AttackState{.clip = U"ranged_attack",
+                      .timer = GetClipDuration(playerData, U"ranged_attack"),
+                      .entity = entt::null});
+    }
+  }
+}

--- a/Ash2/src/System/NeutralStateSystem.hpp
+++ b/Ash2/src/System/NeutralStateSystem.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <entt/entt.hpp>
+
+struct FrameData;
+
+/// @brief プレイヤーの通常状態（NeutralState）での攻撃入力処理を行うシステム
+class NeutralStateSystem {
+ public:
+  /// @brief NeutralState
+  /// を持つエンティティの攻撃入力をチェックし、開始処理を行う
+  ///
+  /// 地上にいる状態で近距離・遠距離攻撃の入力があった場合、`NeutralState`
+  /// を `erase` して `AttackState` を `emplace` する（Neutral → Attack
+  /// 遷移）。近距離攻撃時は攻撃判定の子エンティティを、遠距離攻撃時は弾エンティティを生成する。
+  static void Update(entt::registry& registry, const FrameData& frameData);
+};

--- a/Ash2/src/System/PlayerMovementSystem.cpp
+++ b/Ash2/src/System/PlayerMovementSystem.cpp
@@ -1,5 +1,7 @@
 #include "System/PlayerMovementSystem.hpp"
 
+#include "Component/AttackState.hpp"
+#include "Component/NeutralState.hpp"
 #include "Component/Player.hpp"
 #include "Component/SpriteAnimation.hpp"
 #include "Component/Velocity.hpp"
@@ -8,16 +10,16 @@
 #include "Phase/FrameData.hpp"
 
 void PlayerMovementSystem::Update(entt::registry& registry,
-                                  const FrameData& frameData,
-                                  const s3d::String& attackClip) {
+                                  const FrameData& frameData) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& input = frameData.input;
   const double dt = frameData.dt;
-  const bool isAttacking = !attackClip.empty();
 
   auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
   for (auto&& [entity, pos, vel, anim] : view.each()) {
-    if (isAttacking) {
+    const bool canMove = registry.all_of<NeutralState>(entity);
+
+    if (!canMove) {
       vel.w = 0.0;
       vel.d = 0.0;
     } else {
@@ -43,17 +45,24 @@ void PlayerMovementSystem::Update(entt::registry& registry,
     }
 
     // アニメーションクリップ決定（攻撃 > ジャンプ > 移動 > 待機）
-    const s3d::String newClip = isAttacking                      ? attackClip
-                                : (pos.h > 0.0)                  ? U"jump"
-                                : (vel.w != 0.0 || vel.d != 0.0) ? U"move"
-                                                                 : U"idle";
+    s3d::String newClip;
+    if (!canMove) {
+      const auto* attackState = registry.try_get<AttackState>(entity);
+      newClip = (attackState != nullptr) ? attackState->clip : s3d::String{};
+    } else if (pos.h > 0.0) {
+      newClip = U"jump";
+    } else if (vel.w != 0.0 || vel.d != 0.0) {
+      newClip = U"move";
+    } else {
+      newClip = U"idle";
+    }
     if (newClip != anim.currentClip) {
       anim.currentClip = newClip;
       anim.elapsed = 0.0;
     }
 
     // 向き更新（攻撃中は変更しない）
-    if (!isAttacking) {
+    if (canMove) {
       if (vel.w > 0.0) {
         anim.facingRight = true;
       } else if (vel.w < 0.0) {

--- a/Ash2/src/System/PlayerMovementSystem.hpp
+++ b/Ash2/src/System/PlayerMovementSystem.hpp
@@ -11,11 +11,8 @@ class PlayerMovementSystem {
   /// @brief Player コンポーネントを持つエンティティの移動処理を更新する
   ///
   /// 水平速度の決定・位置への速度適用・ジャンプ・重力・地面クランプ・
-  /// アニメーションクリップ選択・向き更新を行う。
-  ///
-  /// @param attackClip
-  /// 現在の攻撃クリップ名。空文字列でない場合は水平移動をロックし、
-  ///                   クリップ選択も攻撃クリップを優先する
-  static void Update(entt::registry& registry, const FrameData& frameData,
-                     const s3d::String& attackClip = {});
+  /// アニメーションクリップ選択・向き更新を行う。`NeutralState`
+  /// を持つエンティティのみ移動・ジャンプを許可し、持たない場合は
+  /// `AttackState.clip` をアニメーションクリップとして使用する。
+  static void Update(entt::registry& registry, const FrameData& frameData);
 };

--- a/Ash2/tests/TestAttackStateSystem.cpp
+++ b/Ash2/tests/TestAttackStateSystem.cpp
@@ -1,0 +1,95 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/AttackState.hpp"
+#include "Component/Hierarchy.hpp"
+#include "Component/NeutralState.hpp"
+#include "Component/Player.hpp"
+#include "Component/WorldPos.hpp"
+#include "Phase/FrameData.hpp"
+#include "System/AttackStateSystem.hpp"
+
+TEST_CASE("AttackStateSystem - timer decreases but stays in AttackState") {
+  // タイマーが残っている間は AttackState のまま、timer が減算される
+  entt::registry registry;
+
+  auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<WorldPos>(player);
+  registry.emplace<AttackState>(player,
+                                AttackState{.clip = U"attack", .timer = 1.0});
+
+  const FrameData frameData{.dt = 0.5};
+  AttackStateSystem::Update(registry, frameData);
+
+  REQUIRE(registry.all_of<AttackState>(player));
+  REQUIRE(registry.get<AttackState>(player).timer == Approx(0.5));
+  REQUIRE_FALSE(registry.all_of<NeutralState>(player));
+}
+
+TEST_CASE("AttackStateSystem - timer expiry transitions Attack to Neutral") {
+  // timer <= 0 になったら AttackState を外し NeutralState を付与する
+  entt::registry registry;
+
+  auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<WorldPos>(player);
+  registry.emplace<AttackState>(player,
+                                AttackState{.clip = U"attack", .timer = 0.1});
+
+  const FrameData frameData{.dt = 0.5};
+  AttackStateSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.all_of<AttackState>(player));
+  REQUIRE(registry.all_of<NeutralState>(player));
+}
+
+TEST_CASE(
+    "AttackStateSystem - destroys attack entity on Attack to Neutral "
+    "transition") {
+  // AttackState.entity が entt::null でない場合、終了時に
+  // DestroyWithChildren で破棄される
+  entt::registry registry;
+
+  auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<WorldPos>(player);
+
+  auto attackEntity = registry.create();
+  registry.emplace<WorldPos>(attackEntity);
+  Hierarchy::Attach(registry, player, attackEntity);
+
+  registry.emplace<AttackState>(
+      player,
+      AttackState{.clip = U"attack", .timer = 0.1, .entity = attackEntity});
+
+  const FrameData frameData{.dt = 0.5};
+  AttackStateSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.valid(attackEntity));
+  REQUIRE_FALSE(registry.all_of<AttackState>(player));
+  REQUIRE(registry.all_of<NeutralState>(player));
+}
+
+TEST_CASE(
+    "AttackStateSystem - ranged attack (entity == entt::null) transitions "
+    "safely") {
+  // 遠距離攻撃時（entity == entt::null）でも安全に遷移する
+  entt::registry registry;
+
+  auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<WorldPos>(player);
+  registry.emplace<AttackState>(player, AttackState{.clip = U"ranged_attack",
+                                                    .timer = 0.1,
+                                                    .entity = entt::null});
+
+  const FrameData frameData{.dt = 0.5};
+  AttackStateSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.all_of<AttackState>(player));
+  REQUIRE(registry.all_of<NeutralState>(player));
+}
+
+#endif

--- a/Ash2/tests/TestNeutralStateSystem.cpp
+++ b/Ash2/tests/TestNeutralStateSystem.cpp
@@ -1,0 +1,138 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/AnimationData.hpp"
+#include "Component/AttackState.hpp"
+#include "Component/NeutralState.hpp"
+#include "Component/Player.hpp"
+#include "Component/Projectile.hpp"
+#include "Component/SpriteAnimation.hpp"
+#include "Component/WorldPos.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "Phase/FrameData.hpp"
+#include "System/NeutralStateSystem.hpp"
+
+namespace {
+
+/// @brief テスト用の registry.ctx() セットアップ（PlayerConfig +
+/// AnimationDataRegistry）
+void SetupContext(entt::registry& registry) {
+  registry.ctx().emplace<PlayerConfig>(PlayerConfig{
+      .speed = 100.0,
+      .jumpSpeed = 300.0,
+      .gravity = 800.0,
+      .melee = {.capMidH = 40.0, .reach = 50.0, .radius = 20.0, .damage = 10},
+      .ranged = {.reach = 100.0,
+                 .radius = 5.0,
+                 .damage = 5,
+                 .bulletSpeed = 300.0,
+                 .spawnHeight = 40.0},
+  });
+
+  AnimationDataRegistry animReg;
+  AnimationData playerData{
+      .textureKey = U"player",
+      .size = {32, 32},
+      .drawOffset = {0, 0},
+  };
+  playerData.clips[U"attack"] =
+      AnimationClip{.row = 0, .count = 6, .speed = 12.0};
+  playerData.clips[U"ranged_attack"] =
+      AnimationClip{.row = 1, .count = 4, .speed = 8.0};
+  animReg[U"player"] = playerData;
+  registry.ctx().emplace<AnimationDataRegistry>(std::move(animReg));
+}
+
+/// @brief テスト用のプレイヤーエンティティを生成する（地上・NeutralState 付き）
+entt::entity MakePlayer(entt::registry& registry) {
+  const auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<WorldPos>(player, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
+  registry.emplace<SpriteAnimation>(
+      player, SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
+  registry.emplace<NeutralState>(player);
+  return player;
+}
+
+}  // namespace
+
+TEST_CASE(
+    "NeutralStateSystem - melee attack input transitions Neutral to Attack") {
+  // 近接攻撃入力で NeutralState から AttackState へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  FrameData frameData{};
+  frameData.input.attackDown = true;
+
+  NeutralStateSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.all_of<NeutralState>(player));
+  REQUIRE(registry.all_of<AttackState>(player));
+
+  const auto& attackState = registry.get<AttackState>(player);
+  REQUIRE(attackState.clip == U"attack");
+  REQUIRE(attackState.timer == Approx(6.0 / 12.0));
+  REQUIRE(attackState.entity != entt::entity{entt::null});
+  REQUIRE(registry.valid(attackState.entity));
+}
+
+TEST_CASE(
+    "NeutralStateSystem - ranged attack input transitions Neutral to "
+    "Attack") {
+  // 遠距離攻撃入力で NeutralState から AttackState へ遷移し、entity は
+  // entt::null のまま
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  FrameData frameData{};
+  frameData.input.rangedAttackDown = true;
+
+  NeutralStateSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.all_of<NeutralState>(player));
+  REQUIRE(registry.all_of<AttackState>(player));
+
+  const auto& attackState = registry.get<AttackState>(player);
+  REQUIRE(attackState.clip == U"ranged_attack");
+  REQUIRE(attackState.timer == Approx(4.0 / 8.0));
+  REQUIRE(attackState.entity == entt::entity{entt::null});
+
+  // 弾エンティティが生成されている
+  const auto bulletView = registry.view<Projectile>();
+  REQUIRE(bulletView.size() == 1);
+}
+
+TEST_CASE("NeutralStateSystem - no attack input keeps NeutralState") {
+  // 攻撃入力がない場合は NeutralState のまま
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const FrameData frameData{};
+  NeutralStateSystem::Update(registry, frameData);
+
+  REQUIRE(registry.all_of<NeutralState>(player));
+  REQUIRE_FALSE(registry.all_of<AttackState>(player));
+}
+
+TEST_CASE("NeutralStateSystem - airborne player ignores attack input") {
+  // 空中にいる場合は攻撃入力を無視する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;
+
+  FrameData frameData{};
+  frameData.input.attackDown = true;
+
+  NeutralStateSystem::Update(registry, frameData);
+
+  REQUIRE(registry.all_of<NeutralState>(player));
+  REQUIRE_FALSE(registry.all_of<AttackState>(player));
+}
+
+#endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,6 +119,8 @@ WorldPos { w, h, d }
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`ProjectileSystem` が移動・消滅を管理する対象を識別する |
+| [`NeutralState`](../Ash2/src/Component/NeutralState.hpp) | プレイヤーが通常状態（移動・ジャンプ可能）であることを示すタグ |
+| [`AttackState`](../Ash2/src/Component/AttackState.hpp) | プレイヤーが攻撃状態であることを示す（再生中クリップ・残り時間・攻撃判定の子エンティティ） |
 
 ---
 
@@ -158,7 +160,9 @@ WorldPos { w, h, d }
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算 |
-| [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase） | Player の移動・ジャンプ・重力・クリップ選択・向き更新 |
+| [`AttackStateSystem::Update`](../Ash2/src/System/AttackStateSystem.hpp) | フェーズ内（PlayerTestPhase、最初） | `AttackState` のタイマー減算、終了時に `NeutralState` へ遷移し攻撃判定エンティティを破棄 |
+| [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase） | Player の移動・ジャンプ・重力・クリップ選択・向き更新（`NeutralState` の有無で移動可否を判定） |
+| [`NeutralStateSystem::Update`](../Ash2/src/System/NeutralStateSystem.hpp) | フェーズ内（PlayerTestPhase、最後） | `NeutralState` 中の攻撃入力を検出し `AttackState` へ遷移、攻撃判定/弾エンティティを生成 |
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の移動、着弾（hitTargets 非空）/ 画面外での破棄 |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画 |
 


### PR DESCRIPTION
## 概要

`PlayerTestPhase` がメンバ変数（`m_attackClip` / `m_attackTimer` / `m_attackEntity`）として保持していた攻撃状態を、ECSコンポーネントとして切り出した。

Playerの「移動・ジャンプ可能かどうか」を、コンポーネントの付け替えで表現するステートマシンとして再設計した。

- **通常状態**: `Player` + `NeutralState`（空タグ）→ `PlayerMovementSystem` が移動・ジャンプを許可
- **攻撃状態**: `NeutralState` を外し `AttackState { clip, timer, entity }` を付与 → 移動・ジャンプが自然にロックされる

## 主な変更点

- `NeutralState` / `AttackState` コンポーネントの新設
- `NeutralStateSystem::Update`: 攻撃入力（近接・遠距離）をチェックし、Neutral→Attack遷移と攻撃エンティティ/弾の生成を行う
- `AttackStateSystem::Update`: タイマー管理とAttack→Neutral遷移、攻撃エンティティの破棄を行う
- `PlayerMovementSystem`: `attackClip` 引数を廃止し、`NeutralState`/`AttackState` の有無で移動可否・表示クリップを判定
- `PlayerTestPhase` から攻撃管理ロジックを削除
- `TestNeutralStateSystem` / `TestAttackStateSystem` を新設

## 設計判断の理由

- **2システムへの分割**: 単一の `AttackSystem` ではなく、状態ごとに `NeutralStateSystem`（開始処理）と `AttackStateSystem`（終了処理）に分割した。コンポーネントの付け替えで状態を表現する方針上、各システムが「自身が担当する状態の処理」のみを持つ形が自然なため
- **システム呼び出し順序（`AttackStateSystem` → `PlayerMovementSystem` → `NeutralStateSystem`）**: 旧実装の処理順序（タイマー更新・終了処理 → 移動 → 攻撃入力チェック・開始処理）を維持し、「タイマー誤差なし」「攻撃終了直後フレームでの連続攻撃が可能」という既存の挙動を変えないため
- **近距離・遠距離攻撃は `AttackState` / `NeutralStateSystem` を共通利用**: 現状はシンプルな差異（`entity` フィールドの有無のみ）のため統一を維持。将来、演出や仕様で大きく分岐する場合は分割を検討する

## スコープ外（フォローアップ）

- `PlayerMovementSystem` の物理処理（重力・位置更新・地面クランプ・ジャンプ）の分離 → #152
- 遠距離攻撃の発射位置（`spawn_height`）調整 → 既存値であり今回の変更による退行ではない。将来の定数調整時にまとめて対応

close #123