### PR TITLE
PlayerMovementSystemから位置更新・重力処理を分離

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -136,6 +136,8 @@
     <ClCompile Include="src\System\NeutralStateSystem.cpp" />
     <ClCompile Include="src\System\AttackStateSystem.cpp" />
     <ClCompile Include="src\System\ProjectileSystem.cpp" />
+    <ClCompile Include="src\System\MovementSystem.cpp" />
+    <ClCompile Include="src\System\GravitySystem.cpp" />
     <ClCompile Include="src\System\AttachmentSystem.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\Phase\PhaseStack.cpp" />
@@ -149,6 +151,7 @@
     <ClCompile Include="tests\TestHitSystem.cpp" />
     <ClCompile Include="tests\TestNeutralStateSystem.cpp" />
     <ClCompile Include="tests\TestProjectileSystem.cpp" />
+    <ClCompile Include="tests\TestMovementSystem.cpp" />
     <ClCompile Include="tests\TestNameLookup.cpp" />
     <ClCompile Include="tests\TestPhaseStack.cpp" />
     <ClCompile Include="tests\TestPlayerConfig.cpp" />
@@ -406,6 +409,9 @@
     <ClInclude Include="src\System\HitSystem.hpp" />
     <ClInclude Include="src\System\HudSystem.hpp" />
     <ClInclude Include="src\System\ProjectileSystem.hpp" />
+    <ClInclude Include="src\Component\Gravity.hpp" />
+    <ClInclude Include="src\System\MovementSystem.hpp" />
+    <ClInclude Include="src\System\GravitySystem.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -198,6 +198,12 @@
     <ClCompile Include="System\ProjectileSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\MovementSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
+    <ClCompile Include="System\GravitySystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="System\AttachmentSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
@@ -235,6 +241,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestProjectileSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\TestMovementSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestNeutralStateSystem.cpp">
@@ -1062,6 +1071,15 @@
       <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="System\ProjectileSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="Component\Gravity.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="System\MovementSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\GravitySystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Ash2/src/Component/Gravity.hpp
+++ b/Ash2/src/Component/Gravity.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+/// @brief 重力の影響を受けるエンティティに付与するコンポーネント
+struct Gravity {
+  /// 重力加速度（ピクセル/秒^2）
+  double accel = 0.0;
+};

--- a/Ash2/src/Component/Projectile.hpp
+++ b/Ash2/src/Component/Projectile.hpp
@@ -3,5 +3,6 @@
 /// @brief 飛翔体（弾）エンティティを示すタグコンポーネント
 ///
 /// `WorldPos` + `Velocity` + `Collider` + `Attack` と組み合わせて使用し、
-/// `ProjectileSystem` が移動・消滅を管理する対象を識別する。
+/// `MovementSystem` が移動を、`ProjectileSystem`
+/// が消滅を管理する対象を識別する。
 struct Projectile {};

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -2,6 +2,7 @@
 
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
+#include "Component/Gravity.hpp"
 #include "Component/Hierarchy.hpp"
 #include "Component/Hp.hpp"
 #include "Component/Name.hpp"
@@ -12,10 +13,13 @@
 #include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
+#include "Config/PlayerConfig.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
 #include "System/AttackStateSystem.hpp"
+#include "System/GravitySystem.hpp"
 #include "System/HitSystem.hpp"
+#include "System/MovementSystem.hpp"
 #include "System/NeutralStateSystem.hpp"
 #include "System/PlayerMovementSystem.hpp"
 #include "System/ProjectileSystem.hpp"
@@ -30,10 +34,13 @@ constexpr int KPlayerMaxHp = 100;
 constexpr int KPlayerMaxStamina = 100;
 
 void PlayerTestPhase::onAfterPush(entt::registry& registry) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+
   m_playerRoot = registry.create();
   registry.emplace<Player>(m_playerRoot);
   registry.emplace<WorldPos>(m_playerRoot);
   registry.emplace<Velocity>(m_playerRoot);
+  registry.emplace<Gravity>(m_playerRoot, Gravity{.accel = cfg.gravity});
   registry.emplace<Name>(m_playerRoot, Name{U"player"});
   registry.emplace<Drawable>(
       m_playerRoot, TextureDrawable{.anchor = DrawAnchor::BottomCenter});
@@ -71,10 +78,12 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
 
   AttackStateSystem::Update(registry, frameData);
   PlayerMovementSystem::Update(registry, frameData);
+  MovementSystem::Update(registry, dt);
+  GravitySystem::Update(registry, dt);
   NeutralStateSystem::Update(registry, frameData);
 
   HitSystem::Update(registry);
-  ProjectileSystem::Update(registry, dt);
+  ProjectileSystem::Update(registry);
 
   AnimationSystem::Update(registry, dt);
 

--- a/Ash2/src/System/GravitySystem.cpp
+++ b/Ash2/src/System/GravitySystem.cpp
@@ -1,0 +1,19 @@
+#include "System/GravitySystem.hpp"
+
+#include "Component/Gravity.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+
+void GravitySystem::Update(entt::registry& registry, double dt) {
+  auto view = registry.view<WorldPos, Velocity, Gravity>();
+  for (auto&& [entity, pos, vel, gravity] : view.each()) {
+    // 次フレーム用の重力加速
+    vel.h -= gravity.accel * dt;
+
+    // 今フレームの位置に対する地面クランプ
+    if (pos.h < 0.0) {
+      pos.h = 0.0;
+      vel.h = 0.0;
+    }
+  }
+}

--- a/Ash2/src/System/GravitySystem.hpp
+++ b/Ash2/src/System/GravitySystem.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief 重力加速と地面クランプを行うシステム
+class GravitySystem {
+ public:
+  /// @brief WorldPos + Velocity + Gravity を持つエンティティに重力を適用する
+  ///
+  /// `vel.h -= gravity.accel * dt`
+  /// により次フレーム用の速度を更新したのち、`pos.h < 0`
+  /// の場合は今フレームの `pos.h` と `vel.h` を 0 にクランプする
+  /// （地面への沈み込み防止）。重力加速と地面クランプは時間軸の異なる
+  /// 処理（次フレーム用 / 今フレーム確定）であり、分割しないこと。
+  static void Update(entt::registry& registry, double dt);
+};

--- a/Ash2/src/System/MovementSystem.cpp
+++ b/Ash2/src/System/MovementSystem.cpp
@@ -1,0 +1,13 @@
+#include "System/MovementSystem.hpp"
+
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+
+void MovementSystem::Update(entt::registry& registry, double dt) {
+  auto view = registry.view<WorldPos, Velocity>();
+  for (auto&& [entity, pos, vel] : view.each()) {
+    pos.w += vel.w * dt;
+    pos.h += vel.h * dt;
+    pos.d += vel.d * dt;
+  }
+}

--- a/Ash2/src/System/MovementSystem.hpp
+++ b/Ash2/src/System/MovementSystem.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief Velocity に従って WorldPos を更新する汎用システム
+class MovementSystem {
+ public:
+  /// @brief WorldPos + Velocity を持つ全エンティティの位置を更新する
+  ///
+  /// `pos.w/h/d += vel.w/h/d * dt` を適用する。
+  static void Update(entt::registry& registry, double dt);
+};

--- a/Ash2/src/System/PlayerMovementSystem.cpp
+++ b/Ash2/src/System/PlayerMovementSystem.cpp
@@ -13,7 +13,6 @@ void PlayerMovementSystem::Update(entt::registry& registry,
                                   const FrameData& frameData) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& input = frameData.input;
-  const double dt = frameData.dt;
 
   auto view = registry.view<Player, WorldPos, Velocity, SpriteAnimation>();
   for (auto&& [entity, pos, vel, anim] : view.each()) {
@@ -25,17 +24,6 @@ void PlayerMovementSystem::Update(entt::registry& registry,
     } else {
       vel.w = input.moveAxis.x * cfg.speed;
       vel.d = input.moveAxis.y * cfg.speed;
-    }
-
-    pos.w += vel.w * dt;
-    pos.d += vel.d * dt;
-
-    vel.h -= cfg.gravity * dt;
-    pos.h += vel.h * dt;
-
-    if (pos.h < 0.0) {
-      pos.h = 0.0;
-      vel.h = 0.0;
     }
 
     const bool onGround = pos.isOnGround();

--- a/Ash2/src/System/PlayerMovementSystem.hpp
+++ b/Ash2/src/System/PlayerMovementSystem.hpp
@@ -5,14 +5,16 @@
 
 struct FrameData;
 
-/// @brief プレイヤーの移動・ジャンプ・重力・アニメーションクリップ選択システム
+/// @brief プレイヤーの水平移動・ジャンプ・アニメーションクリップ選択システム
 class PlayerMovementSystem {
  public:
   /// @brief Player コンポーネントを持つエンティティの移動処理を更新する
   ///
-  /// 水平速度の決定・位置への速度適用・ジャンプ・重力・地面クランプ・
+  /// 水平速度の決定・ジャンプ判定（`vel.h` への代入）・
   /// アニメーションクリップ選択・向き更新を行う。`NeutralState`
   /// を持つエンティティのみ移動・ジャンプを許可し、持たない場合は
   /// `AttackState.clip` をアニメーションクリップとして使用する。
+  /// 位置更新・重力・地面クランプは `MovementSystem`/`GravitySystem`
+  /// が行うため、このシステムより後に呼び出すこと。
   static void Update(entt::registry& registry, const FrameData& frameData);
 };

--- a/Ash2/src/System/ProjectileSystem.cpp
+++ b/Ash2/src/System/ProjectileSystem.cpp
@@ -2,21 +2,16 @@
 
 #include "Component/Attack.hpp"
 #include "Component/Projectile.hpp"
-#include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 
-void ProjectileSystem::Update(entt::registry& registry, double dt) {
+void ProjectileSystem::Update(entt::registry& registry) {
   const Vec2 cameraOffset = Scene::Center();
   const RectF screenRect = Scene::Rect();
 
   s3d::Array<entt::entity> toDestroy;
 
-  auto view = registry.view<Projectile, WorldPos, Velocity, Attack>();
-  for (auto&& [entity, pos, vel, atk] : view.each()) {
-    pos.w += vel.w * dt;
-    pos.h += vel.h * dt;
-    pos.d += vel.d * dt;
-
+  auto view = registry.view<Projectile, WorldPos, Attack>();
+  for (auto&& [entity, pos, atk] : view.each()) {
     // 着弾: HitSystem がヒットを記録した
     if (!atk.hitTargets.empty()) {
       toDestroy.push_back(entity);

--- a/Ash2/src/System/ProjectileSystem.hpp
+++ b/Ash2/src/System/ProjectileSystem.hpp
@@ -5,18 +5,17 @@
 
 struct FrameData;
 
-/// @brief 飛翔体（弾）の移動・消滅を管理するシステム
+/// @brief 飛翔体（弾）の消滅を管理するシステム
 class ProjectileSystem {
  public:
-  /// @brief Projectile
-  /// を持つエンティティを移動させ、消滅条件を満たしたものを破棄する
+  /// @brief Projectile を持つエンティティのうち消滅条件を満たしたものを破棄する
   ///
-  /// `Velocity` に従って `WorldPos` を更新したのち、以下のいずれかを満たす
-  /// エンティティを `registry.destroy()` する。
+  /// 以下のいずれかを満たすエンティティを `registry.destroy()` する。
   /// - 着弾: `Attack.hitTargets` が空でなくなった（`HitSystem`
   /// がヒットを記録した）
   /// - 画面外: `WorldPos` を画面座標に変換した結果が `Scene::Rect()` の範囲外
   ///
-  /// 着弾判定が正しく行われるよう、`HitSystem::Update` の後に呼び出すこと。
-  static void Update(entt::registry& registry, double dt);
+  /// 位置更新は `MovementSystem` が担うため、`MovementSystem::Update`
+  /// および `HitSystem::Update` の後に呼び出すこと。
+  static void Update(entt::registry& registry);
 };

--- a/Ash2/tests/TestMovementSystem.cpp
+++ b/Ash2/tests/TestMovementSystem.cpp
@@ -1,0 +1,26 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+#include "System/MovementSystem.hpp"
+
+TEST_CASE("MovementSystem - moves entity by velocity each frame") {
+  // Velocity に従って WorldPos が更新される
+  entt::registry registry;
+
+  const auto entity = registry.create();
+  registry.emplace<WorldPos>(entity, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Velocity>(entity, Velocity{.w = 100.0, .h = 0.0, .d = 0.0});
+
+  MovementSystem::Update(registry, 0.5);
+
+  REQUIRE(registry.get<WorldPos>(entity).w == Approx(50.0));
+
+  MovementSystem::Update(registry, 0.5);
+
+  REQUIRE(registry.get<WorldPos>(entity).w == Approx(100.0));
+}
+
+#endif

--- a/Ash2/tests/TestProjectileSystem.cpp
+++ b/Ash2/tests/TestProjectileSystem.cpp
@@ -31,25 +31,6 @@ entt::entity MakeBullet(entt::registry& registry, const WorldPos& pos,
 
 }  // namespace
 
-TEST_CASE("ProjectileSystem - moves bullet by velocity each frame") {
-  // Velocity に従って WorldPos が更新される
-  entt::registry registry;
-
-  const auto bullet =
-      MakeBullet(registry, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0},
-                 Velocity{.w = 100.0, .h = 0.0, .d = 0.0});
-
-  ProjectileSystem::Update(registry, 0.5);
-
-  REQUIRE(registry.valid(bullet));
-  REQUIRE(registry.get<WorldPos>(bullet).w == Approx(50.0));
-
-  ProjectileSystem::Update(registry, 0.5);
-
-  REQUIRE(registry.valid(bullet));
-  REQUIRE(registry.get<WorldPos>(bullet).w == Approx(100.0));
-}
-
 TEST_CASE(
     "ProjectileSystem - destroys bullet on impact (hitTargets non-empty)") {
   // Attack.hitTargets が空でなくなった（HitSystem
@@ -64,7 +45,7 @@ TEST_CASE(
   const auto dummyTarget = registry.create();
   registry.get<Attack>(bullet).hitTargets.emplace(dummyTarget);
 
-  ProjectileSystem::Update(registry, 1.0 / 60.0);
+  ProjectileSystem::Update(registry);
 
   REQUIRE_FALSE(registry.valid(bullet));
 }
@@ -80,7 +61,7 @@ TEST_CASE("ProjectileSystem - destroys bullet when off-screen") {
       MakeBullet(registry, WorldPos{.w = KFarAway, .h = 0.0, .d = 0.0},
                  Velocity{.w = 0.0, .h = 0.0, .d = 0.0});
 
-  ProjectileSystem::Update(registry, 1.0 / 60.0);
+  ProjectileSystem::Update(registry);
 
   REQUIRE_FALSE(registry.valid(bullet));
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,9 +118,10 @@ WorldPos { w, h, d }
 | [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる）。`root` で複数コライダー構成のルートを指定し、`hitTargets` で攻撃生存期間中の重複ヒットを防ぐ |
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
-| [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`ProjectileSystem` が移動・消滅を管理する対象を識別する |
+| [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
 | [`NeutralState`](../Ash2/src/Component/NeutralState.hpp) | プレイヤーが通常状態（移動・ジャンプ可能）であることを示すタグ |
 | [`AttackState`](../Ash2/src/Component/AttackState.hpp) | プレイヤーが攻撃状態であることを示す（再生中クリップ・残り時間・攻撃判定の子エンティティ） |
+| [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
 
 ---
 
@@ -161,9 +162,11 @@ WorldPos { w, h, d }
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算 |
 | [`AttackStateSystem::Update`](../Ash2/src/System/AttackStateSystem.hpp) | フェーズ内（PlayerTestPhase、最初） | `AttackState` のタイマー減算、終了時に `NeutralState` へ遷移し攻撃判定エンティティを破棄 |
-| [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase） | Player の移動・ジャンプ・重力・クリップ選択・向き更新（`NeutralState` の有無で移動可否を判定） |
+| [`PlayerMovementSystem::Update`](../Ash2/src/System/PlayerMovementSystem.hpp) | フェーズ内（PlayerTestPhase） | Player の水平移動量決定・ジャンプ判定・クリップ選択・向き更新（`NeutralState` の有無で移動可否を判定） |
+| [`MovementSystem::Update`](../Ash2/src/System/MovementSystem.hpp) | フェーズ内（PlayerTestPhase、PlayerMovementSystem の後） | `WorldPos`+`Velocity` を持つ全エンティティ（Player・弾）の位置を `vel * dt` で更新 |
+| [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `WorldPos`+`Velocity`+`Gravity` を持つエンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h` を 0 にする）を適用 |
 | [`NeutralStateSystem::Update`](../Ash2/src/System/NeutralStateSystem.hpp) | フェーズ内（PlayerTestPhase、最後） | `NeutralState` 中の攻撃入力を検出し `AttackState` へ遷移、攻撃判定/弾エンティティを生成 |
-| [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の移動、着弾（hitTargets 非空）/ 画面外での破棄 |
+| [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画 |
 
 ---


### PR DESCRIPTION
## 概要

`PlayerMovementSystem` に混在していた物理処理（位置更新・重力・地面クランプ）を、コンポーネント構成に基づいた汎用システムに分離した。

- 新設 `MovementSystem`: `WorldPos` + `Velocity` を持つ全エンティティ（Player・弾）の位置更新を行う
- 新設 `Gravity` コンポーネント / `GravitySystem`: 重力加速と地面クランプを行う
- `PlayerMovementSystem`: 水平移動量の決定・ジャンプ判定・アニメーションクリップ選択・向き更新のみに専念
- `ProjectileSystem`: 位置更新を削除し、着弾・画面外判定のみに専念

## 技術選択について

`ProjectileSystem::Update` は位置更新の削除により `dt` パラメータが不要になったため、シグネチャを `Update(entt::registry&)` に変更した（`/W4` での未使用パラメータ警告を回避）。呼び出し元（`PlayerTestPhase.cpp`、`TestProjectileSystem.cpp`）も合わせて更新した。

## 関連

close #152