### PR TITLE
Debugビルドのクラッシュハンドラから getchar() を削除

### DIFF
--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -65,10 +65,6 @@ void Main() {
     const String message = U"[例外] " + Unicode::Widen(e.what());
     TextWriter{U"crash.log", OpenMode::Append}.writeln(message);
     APP_LOG(message);
-    APP_LOG(U"Enterキーで終了...");
-#ifdef _DEBUG
-    static_cast<void>(std::getchar());
-#endif
     throw;
   }
 }


### PR DESCRIPTION
## 概要

Debugビルドで例外発生時に呼ばれていた `std::getchar()` を削除しました。

`Console.open()`（`AllocConsole()`）は別のコンソールウィンドウを開くため、クラッシュ後の `getchar()` はそのウィンドウへの入力を待ち続け、`/run` 経由のバックグラウンド実行ではプロセスが終了しなくなる問題がありました。クラッシュ情報は既に `crash.log` / `APP_LOG`（#92）で記録されるため、情報は失われません。

close #158

## 動作確認

`/run` スキルでゲームを起動・終了し、バックグラウンドタスクの完了通知（exit code 0）で正常終了が正しく検知できることを確認しました。