### PR TITLE
AnimationViewerPhase::Param の未使用フィールド initialClip を削除

### DIFF
--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -50,7 +50,6 @@ const s3d::HashTable<s3d::String, PhaseLoader> kPhaseLoaders{
      MakeLoader<AnimationViewerPhase>([](const s3d::TOMLValue& step) {
        return AnimationViewerPhase::Param{
            .dataKey = step[U"param"].get<s3d::String>(),
-           .initialClip = U"",
        };
      })},
     {U"scenario", MakeLoader<ScenarioPhase>([](const s3d::TOMLValue& step) {

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -17,9 +17,7 @@ constexpr int KHintY = 80;
 }  // namespace
 
 AnimationViewerPhase::AnimationViewerPhase(const Param& param)
-    : m_dataKey(param.dataKey) {
-  (void)param.initialClip;
-}
+    : m_dataKey(param.dataKey) {}
 
 void AnimationViewerPhase::onAfterPush(entt::registry& registry) {
   const auto& animRegistry = registry.ctx().get<AnimationDataRegistry>();

--- a/Ash2/src/Phase/AnimationViewerPhase.hpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.hpp
@@ -11,8 +11,6 @@ class AnimationViewerPhase : public IPhase {
   struct Param {
     /// AnimationDataRegistry のキー（エンティティ種別名）
     s3d::String dataKey;
-    /// 初期クリップ名（空文字の場合は最初のクリップを使用）
-    s3d::String initialClip;
   };
 
   explicit AnimationViewerPhase(const Param& param);

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -26,8 +26,7 @@ void TestMenuPhase::onAfterPush(entt::registry& /*registry*/) {
           .label = U"AnimationViewer (player)",
           .create = [](entt::registry&) -> std::unique_ptr<IPhase> {
             return std::make_unique<AnimationViewerPhase>(
-                AnimationViewerPhase::Param{.dataKey = U"player",
-                                            .initialClip = U""});
+                AnimationViewerPhase::Param{.dataKey = U"player"});
           },
       },
   };


### PR DESCRIPTION
## 概要
- `AnimationViewerPhase::Param::initialClip` は宣言のみで、コンストラクタ内で `(void)param.initialClip;` として捨てられている未使用フィールドだったため削除
- 呼び出し元（`TestMenuPhase.cpp`, `ScenarioData.cpp`）の `.initialClip = U""` 初期化指定も削除
- 純粋なデッドコード削除で、機能的な変更はなし

## 実装判断
- Issue本文に記載の3ファイルに加え、`ScenarioData.cpp` の `kPhaseLoaders`（animation_viewer ローダー）にも同種の初期化指定があり、ビルドエラーを避けるため合わせて削除した

close #129
