### PR TITLE
近距離攻撃コンボ1段目を実装

### DIFF
--- a/Ash2/App/assets/config/animation/player.toml
+++ b/Ash2/App/assets/config/animation/player.toml
@@ -18,10 +18,10 @@ row = 2
 count = 1
 speed = 6.0
 
-[attack]
+[melee_1]
 row = 3
 count = 2
-speed = 8.0
+speed = 5.714285714285714
 
 [ranged_attack]
 row = 4

--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -3,10 +3,13 @@ jump_speed = 400.0
 gravity = 980.0
 
 [melee]
-cap_mid_h = 30.0
-reach     = 60.0
-radius    = 25.0
-damage    = 20
+cap_mid_h    = 30.0
+reach        = 60.0
+radius       = 25.0
+damage       = 20
+windup_sec   = 0.05
+active_sec   = 0.10
+recovery_sec = 0.20
 
 [ranged]
 reach        = 200.0

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -139,6 +139,8 @@
     <ClCompile Include="src\System\GravitySystem.cpp" />
     <ClCompile Include="src\System\AttachmentSystem.cpp" />
     <ClCompile Include="src\System\DrawSystem.cpp" />
+    <ClCompile Include="src\System\HitstopSystem.cpp" />
+    <ClCompile Include="src\System\StaggerSystem.cpp" />
     <ClCompile Include="src\Phase\PhaseStack.cpp" />
     <ClCompile Include="src\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -409,6 +411,10 @@
     <ClInclude Include="src\Component\Gravity.hpp" />
     <ClInclude Include="src\System\MovementSystem.hpp" />
     <ClInclude Include="src\System\GravitySystem.hpp" />
+    <ClInclude Include="src\Component\Hitstop.hpp" />
+    <ClInclude Include="src\Component\Stagger.hpp" />
+    <ClInclude Include="src\System\HitstopSystem.hpp" />
+    <ClInclude Include="src\System\StaggerSystem.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -207,6 +207,12 @@
     <ClCompile Include="System\DrawSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\HitstopSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
+    <ClCompile Include="System\StaggerSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="GameSetup.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1071,6 +1077,18 @@
       <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="System\GravitySystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="Component\Hitstop.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="Component\Stagger.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="System\HitstopSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\StaggerSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Ash2/src/Component/Attack.hpp
+++ b/Ash2/src/Component/Attack.hpp
@@ -16,4 +16,7 @@ struct Attack {
 
   /// 攻撃の生存期間中にヒット済みのターゲット（重複ヒット防止用）
   s3d::HashSet<entt::entity> hitTargets;
+
+  /// ヒット成立時に攻撃側・被弾側へ付与するヒットストップ時間（秒）
+  double hitstopSec = 0.0;
 };

--- a/Ash2/src/Component/Hitstop.hpp
+++ b/Ash2/src/Component/Hitstop.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief ヒットストップ中であることを示すタイマーコンポーネント
+///
+/// このコンポーネントを持つエンティティは、`HitstopSystem`
+/// が経過時間を減算し、0 以下になった時点で除去する。
+/// 付与中は `MotionSystem`/`MovementSystem`/`GravitySystem` の更新が
+/// スキップされる。
+struct Hitstop {
+  /// 残り時間（秒）
+  double remaining = 0.0;
+};

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -11,8 +11,10 @@ struct Neutral {};
 
 /// @brief 近距離攻撃中
 struct Melee {
-  /// 攻撃モーション残り時間（秒）
-  double timer = 0.0;
+  /// コンボ段数（1始まり）
+  int stage = 1;
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
   /// 攻撃判定の子エンティティ
   entt::entity hitboxEntity = entt::null;
 };

--- a/Ash2/src/Component/Stagger.hpp
+++ b/Ash2/src/Component/Stagger.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief ひるみリアクション中であることを示すタイマーコンポーネント
+///
+/// `StaggerSystem` が経過時間を減算し、0 以下になった時点で
+/// `RectDrawable::size` を `originalSize` に戻したうえで除去する。
+struct Stagger {
+  /// 残り時間（秒）
+  double remaining = 0.0;
+  /// 合計時間（秒）。縮み量の正規化に使う
+  double duration = 0.0;
+  /// 付与前の RectDrawable::size
+  s3d::SizeF originalSize;
+};

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -13,6 +13,9 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .reach = m[U"reach"].get<double>(),
               .radius = m[U"radius"].get<double>(),
               .damage = m[U"damage"].get<int>(),
+              .windupSec = m[U"windup_sec"].get<double>(),
+              .activeSec = m[U"active_sec"].get<double>(),
+              .recoverySec = m[U"recovery_sec"].get<double>(),
           },
       .ranged =
           {

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -11,6 +11,12 @@ struct MeleeConfig {
   double radius;
   /// 与えるダメージ量
   int damage;
+  /// 構え時間（秒）
+  double windupSec;
+  /// 攻撃判定が有効な時間（秒）
+  double activeSec;
+  /// 後隙時間（秒）
+  double recoverySec;
 };
 
 /// @brief 遠距離攻撃の設定値

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -1,9 +1,11 @@
 #include "Phase/PlayerTestPhase.hpp"
 
+#include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Gravity.hpp"
 #include "Component/Hierarchy.hpp"
+#include "Component/Hitstop.hpp"
 #include "Component/Hp.hpp"
 #include "Component/Motion.hpp"
 #include "Component/Name.hpp"
@@ -11,17 +13,21 @@
 #include "Component/PlayerMotion.hpp"
 #include "Component/Projectile.hpp"
 #include "Component/SpriteAnimation.hpp"
+#include "Component/Stagger.hpp"
 #include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/PlayerConfig.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
+#include "System/AttachmentSystem.hpp"
 #include "System/GravitySystem.hpp"
 #include "System/HitSystem.hpp"
+#include "System/HitstopSystem.hpp"
 #include "System/MotionSystem.hpp"
 #include "System/MovementSystem.hpp"
 #include "System/ProjectileSystem.hpp"
+#include "System/StaggerSystem.hpp"
 
 constexpr double KDummyPosW = 150.0;
 constexpr s3d::SizeF KDummySize = {60.0, 80.0};
@@ -31,6 +37,8 @@ constexpr double KDummyCapHeight = 80.0;
 constexpr int KDummyMaxHp = 100;
 constexpr int KPlayerMaxHp = 100;
 constexpr int KPlayerMaxStamina = 100;
+/// 暫定のひるみ時間（秒）。本格的な数値調整は #132/#134 で行う
+constexpr double KStaggerSec = 0.15;
 
 void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -75,13 +83,17 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
                                              const FrameData& frameData) {
   const double dt = frameData.dt;
 
+  HitstopSystem::Update(registry, dt);
   MotionSystem::Update(registry, frameData);
   MovementSystem::Update(registry, dt);
   GravitySystem::Update(registry, dt);
+  AttachmentSystem::UpdateTransform(registry);
 
-  HitSystem::Update(registry);
+  const auto hits = HitSystem::Update(registry);
+  applyHitReactions(registry, hits);
   ProjectileSystem::Update(registry);
 
+  StaggerSystem::Update(registry, dt);
   AnimationSystem::Update(registry, dt);
 
   if (frameData.input.reloadConfig) {
@@ -93,6 +105,44 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
   }
 
   return PhaseCommand::None();
+}
+
+void PlayerTestPhase::applyHitReactions(entt::registry& registry,
+                                        const s3d::Array<HitPair>& hits) {
+  for (const auto& hit : hits) {
+    const auto& attack = registry.get<Attack>(hit.attacker);
+    if (attack.hitstopSec <= 0.0) continue;
+
+    // ヒットボックスの親（プレイヤー本体）にヒットストップを付与する
+    auto attackerOwner = hit.attacker;
+    if (const auto* hierarchy = registry.try_get<Hierarchy>(hit.attacker);
+        hierarchy != nullptr && hierarchy->parent() != entt::null) {
+      attackerOwner = hierarchy->parent();
+    }
+    registry.emplace_or_replace<Hitstop>(
+        attackerOwner, Hitstop{.remaining = attack.hitstopSec});
+    registry.emplace_or_replace<Hitstop>(
+        hit.target, Hitstop{.remaining = attack.hitstopSec});
+
+    // ひるみリアクション（最小実装：本格的な状態機械は #134 のスコープ）
+    if (auto* drawable = registry.try_get<Drawable>(hit.target);
+        drawable != nullptr) {
+      if (auto* rect = std::get_if<RectDrawable>(drawable); rect != nullptr) {
+        // 既にひるみ中なら originalSize を引き継ぎ、縮小済みサイズを
+        // originalSize として上書きしてしまうのを防ぐ
+        s3d::SizeF originalSize = rect->size;
+        if (const auto* existing = registry.try_get<Stagger>(hit.target);
+            existing != nullptr) {
+          originalSize = existing->originalSize;
+          rect->size = originalSize;
+        }
+        registry.emplace_or_replace<Stagger>(
+            hit.target, Stagger{.remaining = KStaggerSec,
+                                .duration = KStaggerSec,
+                                .originalSize = originalSize});
+      }
+    }
+  }
 }
 
 void PlayerTestPhase::reloadPlayer(entt::registry& registry) {

--- a/Ash2/src/Phase/PlayerTestPhase.hpp
+++ b/Ash2/src/Phase/PlayerTestPhase.hpp
@@ -1,6 +1,10 @@
 #pragma once
+#include <Siv3D.hpp>
+
+#include <entt/entt.hpp>
 
 #include "IPhase.hpp"
+#include "System/HitSystem.hpp"
 
 /// @brief プレイヤー操作テストフェーズ
 class PlayerTestPhase : public IPhase {
@@ -24,6 +28,13 @@ class PlayerTestPhase : public IPhase {
  private:
   /// @brief プレイヤーを破棄して最新の設定で再生成する
   void reloadPlayer(entt::registry& registry);
+
+  /// @brief ヒット成立した攻撃側・被弾側へヒットストップ・ひるみを付与する
+  ///
+  /// 本格的なリアクション設計は #132/#134 のスコープであり、ここでは
+  /// 近接1段目の操作感確認に必要な最小限の暫定実装を行う。
+  void applyHitReactions(entt::registry& registry,
+                         const s3d::Array<HitPair>& hits);
 
   entt::entity m_playerRoot = entt::null;
   entt::entity m_dummyTarget = entt::null;

--- a/Ash2/src/System/GravitySystem.cpp
+++ b/Ash2/src/System/GravitySystem.cpp
@@ -1,11 +1,13 @@
 #include "System/GravitySystem.hpp"
 
 #include "Component/Gravity.hpp"
+#include "Component/Hitstop.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 
 void GravitySystem::Update(entt::registry& registry, double dt) {
-  auto view = registry.view<WorldPos, Velocity, Gravity>();
+  auto view =
+      registry.view<WorldPos, Velocity, Gravity>(entt::exclude<Hitstop>);
   for (auto&& [entity, pos, vel, gravity] : view.each()) {
     // 次フレーム用の重力加速
     vel.h -= gravity.accel * dt;

--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -9,12 +9,19 @@
 #include "Component/Hp.hpp"
 #include "Component/WorldPos.hpp"
 
+/// @brief 攻撃側・被弾側のエンティティの組
+struct HitPair {
+  entt::entity attacker;
+  entt::entity target;
+};
+
 /// @brief ヒット判定システム
 class HitSystem {
  public:
   /// @brief 攻撃側コライダーと被弾側コライダーの重なりを検出し、Hp
   /// にダメージを適用する
-  static void Update(entt::registry& registry);
+  /// @return このフレームで新たに成立したヒットの一覧
+  [[nodiscard]] static s3d::Array<HitPair> Update(entt::registry& registry);
 
  private:
   /// @brief 線分を表す内部構造体
@@ -70,7 +77,9 @@ inline double HitSystem::SegmentDistSq(Segment segA, Segment segB) {
   return (closest1 - closest2).dot(closest1 - closest2);
 }
 
-inline void HitSystem::Update(entt::registry& registry) {
+inline s3d::Array<HitPair> HitSystem::Update(entt::registry& registry) {
+  s3d::Array<HitPair> hits;
+
   auto attackers = registry.view<WorldPos, Collider, Attack>();
   auto targets = registry.view<WorldPos, Collider, Hp>();
 
@@ -99,6 +108,9 @@ inline void HitSystem::Update(entt::registry& registry) {
 
       rootAtk.hitTargets.emplace(target);
       hp.current = std::max(0, hp.current - rootAtk.damage);
+      hits.push_back(HitPair{.attacker = rootEntity, .target = target});
     }
   }
+
+  return hits;
 }

--- a/Ash2/src/System/HitstopSystem.cpp
+++ b/Ash2/src/System/HitstopSystem.cpp
@@ -1,0 +1,16 @@
+#include "System/HitstopSystem.hpp"
+
+#include "Component/Hitstop.hpp"
+
+void HitstopSystem::Update(entt::registry& registry, double dt) {
+  auto view = registry.view<Hitstop>();
+  for (auto&& [entity, hitstop] : view.each()) {
+    hitstop.remaining -= dt;
+  }
+
+  for (const auto entity : view) {
+    if (view.get<Hitstop>(entity).remaining <= 0.0) {
+      registry.remove<Hitstop>(entity);
+    }
+  }
+}

--- a/Ash2/src/System/HitstopSystem.hpp
+++ b/Ash2/src/System/HitstopSystem.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief ヒットストップの経過処理を行うシステム
+class HitstopSystem {
+ public:
+  /// @brief Hitstop を持つエンティティの残り時間を減算し、0
+  /// 以下になったら除去する
+  static void Update(entt::registry& registry, double dt);
+};

--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -1,11 +1,12 @@
 #include "System/MotionSystem.hpp"
 
+#include "Component/Hitstop.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/PlayerMotionSystem.hpp"
 
 void MotionSystem::Update(entt::registry& registry,
                           const FrameData& frameData) {
-  auto view = registry.view<Motion>();
+  auto view = registry.view<Motion>(entt::exclude<Hitstop>);
   for (const auto entity : view) {
     auto& motion = view.get<Motion>(entity);
     auto next = std::visit(

--- a/Ash2/src/System/MovementSystem.cpp
+++ b/Ash2/src/System/MovementSystem.cpp
@@ -1,10 +1,11 @@
 #include "System/MovementSystem.hpp"
 
+#include "Component/Hitstop.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 
 void MovementSystem::Update(entt::registry& registry, double dt) {
-  auto view = registry.view<WorldPos, Velocity>();
+  auto view = registry.view<WorldPos, Velocity>(entt::exclude<Hitstop>);
   for (auto&& [entity, pos, vel] : view.each()) {
     pos.w += vel.w * dt;
     pos.h += vel.h * dt;

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -2,6 +2,8 @@
 
 #include "System/PlayerMotionSystem.hpp"
 
+#include <algorithm>
+
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
@@ -20,6 +22,9 @@ namespace PlayerMotion {
 namespace {
 
 constexpr s3d::ColorF KBulletColor = {0.9, 0.9, 0.3};
+constexpr s3d::ColorF KMeleeOrbColor = {1.0, 0.9, 0.5};
+/// 暫定のヒットストップ時間（秒）。本格的な数値調整は #132/#134 で行う
+constexpr double KMeleeHitstopSec = 0.05;
 
 /// @brief 指定クリップの再生時間（秒）を返す
 /// @return クリップが見つからない場合は 0.0
@@ -44,33 +49,41 @@ void SetClip(SpriteAnimation& anim, const s3d::String& clip) {
   }
 }
 
-/// @brief 近距離攻撃のヒットボックスエンティティを生成する
+/// @brief 近接1段目の攻撃判定エンティティ（光の珠）を生成する
 ///
 /// Component/Attack.hpp の Attack（ダメージ用）を付与する。
-/// PlayerMotion::Melee の "attack" とは別概念。
+/// 生成時点では構え中につき珠は体の近くに静止した位置に置く。
+/// Collider は珠エンティティ自身の原点からのオフセット 0 で固定し、
+/// 珠の現在位置は Melee::Tick が更新する LocalOffset のみが担う。
 entt::entity SpawnMeleeHitbox(entt::registry& registry, entt::entity owner,
-                              const WorldPos& pos, bool facingRight,
-                              const PlayerConfig& cfg) {
-  const double sign = facingRight ? 1.0 : -1.0;
+                              const WorldPos& pos, const PlayerConfig& cfg) {
   const auto hitbox = registry.create();
   registry.emplace<WorldPos>(hitbox, pos);
   registry.emplace<LocalOffset>(hitbox, LocalOffset{});
   Hierarchy::Attach(registry, owner, hitbox);
-  registry.emplace<Collider>(
-      hitbox, Collider{.segmentStart = Vec3{0.0, cfg.melee.capMidH, 0.0},
-                       .segmentEnd =
-                           Vec3{sign * cfg.melee.reach, cfg.melee.capMidH, 0.0},
-                       .radius = cfg.melee.radius});
-  registry.emplace<Attack>(hitbox, Attack{.damage = cfg.melee.damage});
+  registry.emplace<Collider>(hitbox, Collider{.segmentStart = Vec3::Zero(),
+                                              .segmentEnd = Vec3::Zero(),
+                                              .radius = cfg.melee.radius});
+  registry.emplace<Attack>(hitbox, Attack{.damage = cfg.melee.damage,
+                                          .hitstopSec = KMeleeHitstopSec});
+  registry.emplace<Drawable>(hitbox, CircleDrawable{.radius = cfg.melee.radius,
+                                                    .color = KMeleeOrbColor});
   return hitbox;
 }
 
-/// @brief Melee へ移行する（攻撃クリップの設定と timer の算出）
-Melee MakeMelee(const AnimationData& playerData, SpriteAnimation& anim,
-                entt::entity hitboxEntity) {
-  SetClip(anim, U"attack");
-  return Melee{.timer = GetClipDuration(playerData, U"attack"),
-               .hitboxEntity = hitboxEntity};
+/// @brief 攻撃フレーム内の珠の前方オフセット（プレイヤー相対）を返す
+/// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
+s3d::Vec3 MeleeOrbOffset(double progress, bool facingRight,
+                         const MeleeConfig& cfg) {
+  const double sign = facingRight ? 1.0 : -1.0;
+  const double eased = s3d::EaseOutQuad(std::clamp(progress, 0.0, 1.0));
+  return Vec3{sign * cfg.reach * eased, cfg.capMidH, 0.0};
+}
+
+/// @brief Melee へ移行する（攻撃クリップの設定、stage は呼び出し元が設定する）
+Melee MakeMelee(SpriteAnimation& anim, entt::entity hitboxEntity) {
+  SetClip(anim, U"melee_1");
+  return Melee{.stage = 1, .elapsed = 0.0, .hitboxEntity = hitboxEntity};
 }
 
 /// @brief 遠距離攻撃の弾エンティティを生成する
@@ -132,9 +145,8 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
       // 直前で設定した横方向速度を打ち消す（持ち越すと1フレーム分滑る）
       vel.w = 0.0;
       vel.d = 0.0;
-      const auto hitbox =
-          SpawnMeleeHitbox(registry, entity, pos, anim.facingRight, cfg);
-      return MakeMelee(playerData, anim, hitbox);
+      // ヒットボックス（光の珠）は攻撃フレーム開始時に Melee::Tick が生成する
+      return MakeMelee(anim, entt::null);
     }
     if (input.rangedAttackDown) {
       vel.w = 0.0;
@@ -165,11 +177,38 @@ std::optional<Motion> Tick(Melee& state, entt::registry& registry,
                            entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
-  state.timer -= frameData.dt;
-  if (state.timer <= 0.0) {
-    if (state.hitboxEntity != entt::null) {
-      Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& melee = cfg.melee;
+  const auto& pos = registry.get<WorldPos>(entity);
+  const auto& anim = registry.get<SpriteAnimation>(entity);
+
+  const double activeStart = melee.windupSec;
+  const double activeEnd = melee.windupSec + melee.activeSec;
+  const double recoveryEnd = activeEnd + melee.recoverySec;
+
+  state.elapsed += frameData.dt;
+
+  // 攻撃フレーム中（未生成ならここで生成する）：珠を前方へ EaseOut
+  // 補間で移動させる
+  if (state.elapsed >= activeStart && state.elapsed < activeEnd) {
+    if (state.hitboxEntity == entt::null) {
+      state.hitboxEntity = SpawnMeleeHitbox(registry, entity, pos, cfg);
     }
+
+    const double progress = (state.elapsed - activeStart) / melee.activeSec;
+    const auto offset = MeleeOrbOffset(progress, anim.facingRight, melee);
+
+    auto& localOffset = registry.get<LocalOffset>(state.hitboxEntity);
+    localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
+  }
+
+  // 後隙以降：ヒットボックスが残っていれば破棄する
+  if (state.elapsed >= activeEnd && state.hitboxEntity != entt::null) {
+    Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
+    state.hitboxEntity = entt::null;
+  }
+
+  if (state.elapsed >= recoveryEnd) {
     return Neutral{};
   }
 

--- a/Ash2/src/System/StaggerSystem.cpp
+++ b/Ash2/src/System/StaggerSystem.cpp
@@ -1,0 +1,47 @@
+#include <Siv3D.hpp>
+
+#include "System/StaggerSystem.hpp"
+
+#include <cmath>
+
+#include "Component/Drawable.hpp"
+#include "Component/Stagger.hpp"
+
+namespace {
+
+/// @brief ひるみ表現の最大縮小率（縦方向）
+constexpr double KMaxShrinkRatio = 0.2;
+
+}  // namespace
+
+void StaggerSystem::Update(entt::registry& registry, double dt) {
+  auto view = registry.view<Stagger, Drawable>();
+  for (auto&& [entity, stagger, drawable] : view.each()) {
+    stagger.remaining -= dt;
+
+    auto* rect = std::get_if<RectDrawable>(&drawable);
+    if (rect == nullptr) continue;
+
+    if (stagger.remaining <= 0.0) {
+      rect->size = stagger.originalSize;
+      continue;
+    }
+
+    // duration の中間で最も縮み、両端（開始・終了）で原寸に近づく
+    const double progress = stagger.remaining / stagger.duration;
+    const double shrink =
+        (1.0 - std::abs(progress * 2.0 - 1.0)) * KMaxShrinkRatio;
+    rect->size.y = stagger.originalSize.y * (1.0 - shrink);
+  }
+
+  // remaining <= 0 になったエンティティから Stagger を除去する
+  s3d::Array<entt::entity> expired;
+  for (const auto entity : view) {
+    if (view.get<Stagger>(entity).remaining <= 0.0) {
+      expired.push_back(entity);
+    }
+  }
+  for (const auto entity : expired) {
+    registry.remove<Stagger>(entity);
+  }
+}

--- a/Ash2/src/System/StaggerSystem.hpp
+++ b/Ash2/src/System/StaggerSystem.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief ひるみリアクションの経過処理を行うシステム
+class StaggerSystem {
+ public:
+  /// @brief Stagger を持つエンティティの残り時間を減算し、RectDrawable::size
+  /// を縮み具合に応じて更新する。0 以下になったら originalSize に戻して除去する
+  static void Update(entt::registry& registry, double dt);
+};

--- a/Ash2/tests/TestHitSystem.cpp
+++ b/Ash2/tests/TestHitSystem.cpp
@@ -28,18 +28,23 @@ TEST_CASE("HitSystem - no repeated damage from multi-frame attack") {
                                               .radius = 10.0});
   registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
 
-  // 1フレーム目：ヒットしてダメージが入る
-  HitSystem::Update(registry);
+  // 1フレーム目：ヒットしてダメージが入り、HitPair が1件返る
+  auto hits = HitSystem::Update(registry);
   REQUIRE(registry.get<Hp>(target).current == 95);
+  REQUIRE(hits.size() == 1);
+  REQUIRE(hits[0].attacker == attacker);
+  REQUIRE(hits[0].target == target);
 
   // 2フレーム目：同じ攻撃が持続しているが hitTargets
-  // に登録済みなのでダメージなし
-  HitSystem::Update(registry);
+  // に登録済みなのでダメージなし、HitPair も返らない
+  hits = HitSystem::Update(registry);
   REQUIRE(registry.get<Hp>(target).current == 95);
+  REQUIRE(hits.isEmpty());
 
   // 3フレーム目：同上
-  HitSystem::Update(registry);
+  hits = HitSystem::Update(registry);
   REQUIRE(registry.get<Hp>(target).current == 95);
+  REQUIRE(hits.isEmpty());
 }
 
 TEST_CASE("HitSystem - multi-collider attack hits target only once") {
@@ -76,8 +81,9 @@ TEST_CASE("HitSystem - multi-collider attack hits target only once") {
   registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
 
   // 1回の Update で child1 と child2 が両方ヒットしても、ダメージは1回分のみ
-  HitSystem::Update(registry);
+  const auto hits = HitSystem::Update(registry);
   REQUIRE(registry.get<Hp>(target).current == 90);
+  REQUIRE(hits.size() == 1);
 }
 
 #endif

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -2,6 +2,9 @@
 #include <ThirdParty/Catch2/catch.hpp>
 #include <entt/entt.hpp>
 
+#include "Component/Attack.hpp"
+#include "Component/Collider.hpp"
+#include "Component/LocalOffset.hpp"
 #include "Component/Motion.hpp"
 #include "Component/Player.hpp"
 #include "Component/PlayerMotion.hpp"
@@ -24,7 +27,13 @@ void SetupContext(entt::registry& registry) {
       .speed = 100.0,
       .jumpSpeed = 300.0,
       .gravity = 800.0,
-      .melee = {.capMidH = 40.0, .reach = 50.0, .radius = 20.0, .damage = 10},
+      .melee = {.capMidH = 40.0,
+                .reach = 50.0,
+                .radius = 20.0,
+                .damage = 10,
+                .windupSec = 0.05,
+                .activeSec = 0.10,
+                .recoverySec = 0.20},
       .ranged = {.reach = 100.0,
                  .radius = 5.0,
                  .damage = 5,
@@ -41,7 +50,7 @@ void SetupContext(entt::registry& registry) {
   playerData.clips[U"idle"] = AnimationClip{.row = 0, .count = 4, .speed = 4.0};
   playerData.clips[U"move"] = AnimationClip{.row = 1, .count = 4, .speed = 8.0};
   playerData.clips[U"jump"] = AnimationClip{.row = 2, .count = 1, .speed = 1.0};
-  playerData.clips[U"attack"] =
+  playerData.clips[U"melee_1"] =
       AnimationClip{.row = 3, .count = 6, .speed = 12.0};
   playerData.clips[U"ranged_attack"] =
       AnimationClip{.row = 4, .count = 4, .speed = 8.0};
@@ -79,11 +88,12 @@ TEST_CASE(
   REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
 
   const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.timer == Approx(6.0 / 12.0));
-  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
-  REQUIRE(registry.valid(melee.hitboxEntity));
+  REQUIRE(melee.stage == 1);
+  REQUIRE(melee.elapsed == Approx(0.0));
+  // 構え中（windupSec 未満）はヒットボックス未生成
+  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
 
-  REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"attack");
+  REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_1");
 }
 
 TEST_CASE(
@@ -157,8 +167,9 @@ TEST_CASE("PlayerMotionSystem - jump input immediately switches to jump clip") {
   REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"jump");
 }
 
-TEST_CASE("PlayerMotionSystem - timer expiry transitions Melee to Neutral") {
-  // timer <= 0 になったら Melee から Neutral へ遷移し、ヒットボックスを破棄する
+TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee to Neutral") {
+  // elapsed が windupSec+activeSec+recoverySec を超えたら Melee から Neutral
+  // へ遷移し、ヒットボックスが残っていれば破棄する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -166,7 +177,8 @@ TEST_CASE("PlayerMotionSystem - timer expiry transitions Melee to Neutral") {
   // ヒットボックスエンティティ（Melee.hitboxEntity 用のダミー）
   const auto hitbox = registry.create();
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{.timer = 0.1, .hitboxEntity = hitbox});
+      player,
+      PlayerMotion::Melee{.stage = 1, .elapsed = 0.34, .hitboxEntity = hitbox});
 
   const FrameData frameData{.dt = 0.5};
   MotionSystem::Update(registry, frameData);
@@ -191,21 +203,70 @@ TEST_CASE("PlayerMotionSystem - timer expiry transitions Ranged to Neutral") {
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
 }
 
-TEST_CASE("PlayerMotionSystem - Melee timer decreases but stays in Melee") {
-  // タイマーが残っている間は Melee のまま、timer が減算される
+TEST_CASE("PlayerMotionSystem - Melee elapsed increases but stays in Melee") {
+  // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{.timer = 1.0, .hitboxEntity = entt::null});
+      player, PlayerMotion::Melee{
+                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
 
-  const FrameData frameData{.dt = 0.5};
+  const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).timer == Approx(0.5));
+  REQUIRE(std::get<PlayerMotion::Melee>(motion).elapsed == Approx(0.1));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee spawns hitbox when entering active frame") {
+  // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee{
+                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+
+  // windupSec(0.05) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& melee = std::get<PlayerMotion::Melee>(motion);
+  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(melee.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
+
+  const auto& attack = registry.get<Attack>(melee.hitboxEntity);
+  REQUIRE(attack.hitstopSec > 0.0);
+}
+
+TEST_CASE("PlayerMotionSystem - Melee destroys hitbox when entering recovery") {
+  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが破棄される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const auto hitbox = registry.create();
+  registry.emplace<LocalOffset>(hitbox);
+  registry.emplace<Collider>(hitbox);
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee{.stage = 1, .elapsed = 0.10, .hitboxEntity = hitbox});
+
+  // windupSec+activeSec(0.15) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& melee = std::get<PlayerMotion::Melee>(motion);
+  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  REQUIRE_FALSE(registry.valid(hitbox));
 }
 
 TEST_CASE("PlayerMotionSystem - Melee stops horizontal movement") {
@@ -215,7 +276,8 @@ TEST_CASE("PlayerMotionSystem - Melee stops horizontal movement") {
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{.timer = 1.0, .hitboxEntity = entt::null});
+      player, PlayerMotion::Melee{
+                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
 
   FrameData frameData{.dt = 0.1};
   frameData.input.moveAxis = Vec2{1.0, 0.0};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,12 +115,14 @@ WorldPos { w, h, d }
 | [`Name`](../Ash2/src/Component/Name.hpp) | エンティティ名（不変、NameLookup と対応） |
 | [`Player`](../Ash2/src/Component/Player.hpp) | プレイヤータグ（データなし） |
 | [`Collider`](../Ash2/src/Component/Collider.hpp) | カプセル形状の当たり判定（形状のみ、役割はコンポーネントの組み合わせで表現） |
-| [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる）。`root` で複数コライダー構成のルートを指定し、`hitTargets` で攻撃生存期間中の重複ヒットを防ぐ |
+| [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる）。`root` で複数コライダー構成のルートを指定し、`hitTargets` で攻撃生存期間中の重複ヒットを防ぐ。`hitstopSec` はヒット成立時に攻撃側・被弾側へ付与するヒットストップ時間 |
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
-| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee, PlayerMotion::Ranged>`）。`Melee`/`Ranged` は再生中クリップの残り時間、`Melee` は攻撃判定の子エンティティを持つ |
+| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee` は段数（`stage`）・モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ |
 | [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
+| [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MotionSystem`/`MovementSystem`/`GravitySystem` の対象から除外される（暫定実装、本格化は #132/#134） |
+| [`Stagger`](../Ash2/src/Component/Stagger.hpp) | ひるみリアクション中であることを示すタイマー。`StaggerSystem` が `RectDrawable::size` を縮小させ、残り時間が尽きたら `originalSize` に戻す（暫定実装、本格化は #134） |
 
 ---
 
@@ -141,7 +143,7 @@ WorldPos { w, h, d }
 |---|---|
 | [`ScenarioPhase`](../Ash2/src/Phase/ScenarioPhase.hpp) | TOML シナリオを 1 ステップずつ実行（push/reset） |
 | [`TestMenuPhase`](../Ash2/src/Phase/TestMenuPhase.hpp) | テストフェーズ一覧メニュー（↑↓選択、Enter で Push） |
-| [`PlayerTestPhase`](../Ash2/src/Phase/PlayerTestPhase.hpp) | プレイヤー操作・物理・アニメーションのビジュアルテスト |
+| [`PlayerTestPhase`](../Ash2/src/Phase/PlayerTestPhase.hpp) | プレイヤー操作・物理・アニメーションのビジュアルテスト。`HitSystem::Update` が返す `HitPair` を見て攻撃側・被弾側へ `Hitstop`/`Stagger` を付与する（暫定実装） |
 | [`AnimationViewerPhase`](../Ash2/src/Phase/AnimationViewerPhase.hpp) | アニメーションクリップ単体確認（←→切替、F反転） |
 | [`WaitPhase`](../Ash2/src/Phase/WaitPhase.hpp) | 指定秒数待機して Pop |
 
@@ -154,16 +156,18 @@ WorldPos { w, h, d }
 
 | システム | タイミング | 処理 |
 |---|---|---|
-| [`AttachmentSystem::UpdateTransform`](../Ash2/src/System/AttachmentSystem.hpp) | 毎フレーム（フェーズ後） | Hierarchy ルートから子孫へ WorldPos 伝播 |
+| [`AttachmentSystem::UpdateTransform`](../Ash2/src/System/AttachmentSystem.hpp) | 毎フレーム（フェーズ後）＋フェーズ内（PlayerTestPhase、GravitySystem の後・HitSystem の前） | Hierarchy ルートから子孫へ WorldPos 伝播。PlayerTestPhase では HitSystem が同フレーム内の最新座標（光の珠の LocalOffset 反映後）を見られるよう追加で呼び出す |
 | [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（最後） | WorldPos+Drawable を奥行き順にソートして描画 |
 | [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | SpriteAnimation の elapsed を進め Drawable を更新 |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
-| [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算 |
-| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、最初） | `Motion`（Neutral/Melee/Ranged）ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了）を行う |
-| [`MovementSystem::Update`](../Ash2/src/System/MovementSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の後） | `WorldPos`+`Velocity` を持つ全エンティティ（Player・弾）の位置を `vel * dt` で更新 |
-| [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `WorldPos`+`Velocity`+`Gravity` を持つエンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h` を 0 にする）を適用 |
+| [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算。新たに成立したヒットの `HitPair`（attacker/target）配列を返す |
+| [`HitstopSystem::Update`](../Ash2/src/System/HitstopSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の前） | `Hitstop` を持つエンティティの残り時間を減算し、0 以下になったら除去する（暫定実装） |
+| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Hitstop` を持たない `Motion`（Neutral/Melee/Ranged）ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了）を行う |
+| [`MovementSystem::Update`](../Ash2/src/System/MovementSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity` エンティティ（Player・弾）の位置を `vel * dt` で更新 |
+| [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity`+`Gravity` エンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h` を 0 にする）を適用 |
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |
+| [`StaggerSystem::Update`](../Ash2/src/System/StaggerSystem.hpp) | フェーズ内（PlayerTestPhase、HitSystem の後） | `Stagger` を持つエンティティの残り時間を減算し `RectDrawable::size` を縮小、0 以下で `originalSize` に戻して除去する（暫定実装） |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画 |
 
 ---


### PR DESCRIPTION
## 概要

close #168

- `Melee` を「残り時間を減算するtimer」方式から「経過時間を加算するelapsed」+`stage`方式に変更し、構え（0.05秒）・攻撃（0.10秒）・後隙（0.20秒）をしきい値で区切る
- 攻撃フレーム中だけ、判定用エンティティ（光の珠）が`EaseOutQuad`補間で体の位置から`reach`まで前方に移動し、後隙開始時に破棄する
- ヒットストップ（`Hitstop`）・ひるみリアクション（`Stagger`）を最小実装として新設。#132・#134の本格実装の先取りであり、暫定実装と位置付けている
- `HitSystem::Update`の戻り値を`void`から新たに成立したヒットの配列（`HitPair`）に変更し、ヒット成立をプレイヤー側のヒットストップ・ひるみ付与処理に伝える経路を新設

## 実装中の判断

- ヒットボックスの位置オフセットを`LocalOffset`と`Collider`の両方に重複適用してしまっていたバグ、および`HitSystem`が1フレーム遅延した座標を見てしまう問題をレビューで発見し修正済み（`PlayerTestPhase::update`内で`HitSystem::Update`の前に`AttachmentSystem::UpdateTransform`を追加呼び出し）
- `AttachmentSystem::UpdateTransform`の全走査コストが気になったため、将来の最適化案として #172 を別途作成（今回のスコープ外）

## Test plan

- [x] `tools/run-tests.sh` 全件パス
- [x] `/run`でゲームを起動し、近接攻撃→ヒットストップ→ひるみ→Neutral復帰の流れを確認