### PR TITLE
近距離攻撃コンボ 2段目の追加

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -3,13 +3,15 @@ jump_speed = 400.0
 gravity = 980.0
 
 [melee]
-cap_mid_h    = 30.0
-reach        = 60.0
-radius       = 25.0
-damage       = 20
-windup_sec   = 0.05
-active_sec   = 0.10
-recovery_sec = 0.20
+cap_mid_h         = 30.0
+reach             = 60.0
+radius            = 25.0
+damage            = 20
+windup_sec        = 0.05
+active_sec        = 0.10
+recovery_sec      = 0.20
+active2_sec       = 0.15
+slash_rise_height = 40.0
 
 [ranged]
 reach        = 200.0

--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -4,5 +4,5 @@
 #include "Component/PlayerMotion.hpp"
 
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
-using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee,
-                            PlayerMotion::Ranged>;
+using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1,
+                            PlayerMotion::Melee2, PlayerMotion::Ranged>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -9,10 +9,18 @@ namespace PlayerMotion {
 /// @brief 通常状態（待機・移動・ジャンプ可能）
 struct Neutral {};
 
-/// @brief 近距離攻撃中
-struct Melee {
-  /// コンボ段数（1始まり）
-  int stage = 1;
+/// @brief 近距離攻撃1段目
+struct Melee1 {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+  /// 攻撃判定の子エンティティ
+  entt::entity hitboxEntity = entt::null;
+  /// 後隙中の次段への遷移予約（windup/active中の入力で立つ）
+  bool comboQueued = false;
+};
+
+/// @brief 近距離攻撃2段目
+struct Melee2 {
   /// モーション開始からの経過時間（秒）
   double elapsed = 0.0;
   /// 攻撃判定の子エンティティ

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -16,6 +16,8 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .windupSec = m[U"windup_sec"].get<double>(),
               .activeSec = m[U"active_sec"].get<double>(),
               .recoverySec = m[U"recovery_sec"].get<double>(),
+              .active2Sec = m[U"active2_sec"].get<double>(),
+              .slashRiseHeight = m[U"slash_rise_height"].get<double>(),
           },
       .ranged =
           {

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -17,6 +17,10 @@ struct MeleeConfig {
   double activeSec;
   /// 後隙時間（秒）
   double recoverySec;
+  /// 2段目の攻撃判定が有効な時間（秒）
+  double active2Sec;
+  /// 2段目の斬り上げの振り幅（capMidH を中心とした上下の幅）
+  double slashRiseHeight;
 };
 
 /// @brief 遠距離攻撃の設定値

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -151,8 +151,8 @@ void PlayerTestPhase::reloadPlayer(entt::registry& registry) {
 }
 
 void PlayerTestPhase::onBeforePop(entt::registry& registry) {
-  // 攻撃判定エンティティ（PlayerMotion::Melee.hitboxEntity）は m_playerRoot
-  // の子孫なので DestroyWithChildren で連動して破棄される
+  // 攻撃判定エンティティ（PlayerMotion::Melee1/Melee2.hitboxEntity）は
+  // m_playerRoot の子孫なので DestroyWithChildren で連動して破棄される
   if (m_playerRoot != entt::null) {
     Hierarchy::DestroyWithChildren(registry, m_playerRoot);
     m_playerRoot = entt::null;

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -49,12 +49,18 @@ void SetClip(SpriteAnimation& anim, const s3d::String& clip) {
   }
 }
 
+/// @brief クリップ名が同じでも再生位置を先頭へ強制的に戻す
+void RestartClip(SpriteAnimation& anim, const s3d::String& clip) {
+  anim.currentClip = clip;
+  anim.elapsed = 0.0;
+}
+
 /// @brief 近接1段目の攻撃判定エンティティ（光の珠）を生成する
 ///
 /// Component/Attack.hpp の Attack（ダメージ用）を付与する。
 /// 生成時点では構え中につき珠は体の近くに静止した位置に置く。
 /// Collider は珠エンティティ自身の原点からのオフセット 0 で固定し、
-/// 珠の現在位置は Melee::Tick が更新する LocalOffset のみが担う。
+/// 珠の現在位置は UpdateMeleeHitbox が更新する LocalOffset のみが担う。
 entt::entity SpawnMeleeHitbox(entt::registry& registry, entt::entity owner,
                               const WorldPos& pos, const PlayerConfig& cfg) {
   const auto hitbox = registry.create();
@@ -80,10 +86,59 @@ s3d::Vec3 MeleeOrbOffset(double progress, bool facingRight,
   return Vec3{sign * cfg.reach * eased, cfg.capMidH, 0.0};
 }
 
-/// @brief Melee へ移行する（攻撃クリップの設定、stage は呼び出し元が設定する）
-Melee MakeMelee(SpriteAnimation& anim, entt::entity hitboxEntity) {
+/// @brief 2段目の攻撃フレーム内の珠オフセット（斬り上げ軌道）を返す
+/// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
+s3d::Vec3 MeleeSlashOffset(double progress, bool facingRight,
+                           const MeleeConfig& cfg) {
+  const double sign = facingRight ? 1.0 : -1.0;
+  const double eased = s3d::EaseOutQuad(std::clamp(progress, 0.0, 1.0));
+  const double horizontal = sign * cfg.reach * eased;
+  const double vertical = cfg.capMidH + (eased - 0.5) * cfg.slashRiseHeight;
+  return Vec3{horizontal, vertical, 0.0};
+}
+
+/// @brief Melee1 へ移行する（攻撃クリップの設定）
+Melee1 MakeMelee(SpriteAnimation& anim, entt::entity hitboxEntity) {
   SetClip(anim, U"melee_1");
-  return Melee{.stage = 1, .elapsed = 0.0, .hitboxEntity = hitboxEntity};
+  return Melee1{.elapsed = 0.0, .hitboxEntity = hitboxEntity};
+}
+
+/// @brief Melee1 から Melee2 へ移行する（攻撃クリップを先頭から再生）
+Melee2 MakeMelee2(SpriteAnimation& anim) {
+  RestartClip(anim, U"melee_1");
+  return Melee2{};
+}
+
+/// @brief 攻撃判定の発生区間に応じてヒットボックスを生成・更新・破棄する
+/// @param offsetFn 攻撃フレーム内の進行度から珠のオフセットを算出する関数
+void UpdateMeleeHitbox(entt::registry& registry, entt::entity owner,
+                       double elapsed, double activeStart, double activeEnd,
+                       bool facingRight, const PlayerConfig& cfg,
+                       entt::entity& hitboxEntity,
+                       s3d::Vec3 (*offsetFn)(double, bool,
+                                             const MeleeConfig&)) {
+  const auto& melee = cfg.melee;
+
+  // 攻撃フレーム中（未生成ならここで生成する）：珠を前方へ EaseOut
+  // 補間で移動させる
+  if (elapsed >= activeStart && elapsed < activeEnd) {
+    if (hitboxEntity == entt::null) {
+      const auto& pos = registry.get<WorldPos>(owner);
+      hitboxEntity = SpawnMeleeHitbox(registry, owner, pos, cfg);
+    }
+
+    const double progress = (elapsed - activeStart) / (activeEnd - activeStart);
+    const auto offset = offsetFn(progress, facingRight, melee);
+
+    auto& localOffset = registry.get<LocalOffset>(hitboxEntity);
+    localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
+  }
+
+  // 後隙以降：ヒットボックスが残っていれば破棄する
+  if (elapsed >= activeEnd && hitboxEntity != entt::null) {
+    Hierarchy::DestroyWithChildren(registry, hitboxEntity);
+    hitboxEntity = entt::null;
+  }
 }
 
 /// @brief 遠距離攻撃の弾エンティティを生成する
@@ -145,7 +200,7 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
       // 直前で設定した横方向速度を打ち消す（持ち越すと1フレーム分滑る）
       vel.w = 0.0;
       vel.d = 0.0;
-      // ヒットボックス（光の珠）は攻撃フレーム開始時に Melee::Tick が生成する
+      // ヒットボックス（光の珠）は攻撃フレーム開始時に Melee1::Tick が生成する
       return MakeMelee(anim, entt::null);
     }
     if (input.rangedAttackDown) {
@@ -173,14 +228,14 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
   return std::nullopt;
 }
 
-std::optional<Motion> Tick(Melee& state, entt::registry& registry,
+std::optional<Motion> Tick(Melee1& state, entt::registry& registry,
                            entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& melee = cfg.melee;
-  const auto& pos = registry.get<WorldPos>(entity);
-  const auto& anim = registry.get<SpriteAnimation>(entity);
+  const auto& input = frameData.input;
+  auto& anim = registry.get<SpriteAnimation>(entity);
 
   const double activeStart = melee.windupSec;
   const double activeEnd = melee.windupSec + melee.activeSec;
@@ -188,25 +243,43 @@ std::optional<Motion> Tick(Melee& state, entt::registry& registry,
 
   state.elapsed += frameData.dt;
 
-  // 攻撃フレーム中（未生成ならここで生成する）：珠を前方へ EaseOut
-  // 補間で移動させる
-  if (state.elapsed >= activeStart && state.elapsed < activeEnd) {
-    if (state.hitboxEntity == entt::null) {
-      state.hitboxEntity = SpawnMeleeHitbox(registry, entity, pos, cfg);
-    }
+  UpdateMeleeHitbox(registry, entity, state.elapsed, activeStart, activeEnd,
+                    anim.facingRight, cfg, state.hitboxEntity, MeleeOrbOffset);
 
-    const double progress = (state.elapsed - activeStart) / melee.activeSec;
-    const auto offset = MeleeOrbOffset(progress, anim.facingRight, melee);
-
-    auto& localOffset = registry.get<LocalOffset>(state.hitboxEntity);
-    localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
+  // windup・active中の攻撃入力は次段への遷移を予約するのみ
+  if (state.elapsed < activeEnd && input.attackDown) {
+    state.comboQueued = true;
   }
 
-  // 後隙以降：ヒットボックスが残っていれば破棄する
-  if (state.elapsed >= activeEnd && state.hitboxEntity != entt::null) {
-    Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
-    state.hitboxEntity = entt::null;
+  // 後隙に入った時点で予約済み、または後隙中の新規入力があれば即座に次段へ
+  if (state.elapsed >= activeEnd && (state.comboQueued || input.attackDown)) {
+    return MakeMelee2(anim);
   }
+
+  if (state.elapsed >= recoveryEnd) {
+    return Neutral{};
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Motion> Tick(Melee2& state, entt::registry& registry,
+                           entt::entity entity, const FrameData& frameData) {
+  StopHorizontalMovement(registry, entity);
+
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& melee = cfg.melee;
+  const auto& anim = registry.get<SpriteAnimation>(entity);
+
+  const double activeStart = melee.windupSec;
+  const double activeEnd = melee.windupSec + melee.active2Sec;
+  const double recoveryEnd = activeEnd + melee.recoverySec;
+
+  state.elapsed += frameData.dt;
+
+  UpdateMeleeHitbox(registry, entity, state.elapsed, activeStart, activeEnd,
+                    anim.facingRight, cfg, state.hitboxEntity,
+                    MeleeSlashOffset);
 
   if (state.elapsed >= recoveryEnd) {
     return Neutral{};

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -17,9 +17,18 @@ namespace PlayerMotion {
                                          entt::entity entity,
                                          const FrameData& frameData);
 
-/// @brief Melee 状態の更新（横移動停止・タイマー減算・ヒットボックス破棄）
+/// @brief Melee1 状態の更新（横移動停止・タイマー減算・ヒットボックス管理・
+/// コンボ予約判定）
 /// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Melee& state, entt::registry& registry,
+[[nodiscard]] std::optional<Motion> Tick(Melee1& state,
+                                         entt::registry& registry,
+                                         entt::entity entity,
+                                         const FrameData& frameData);
+
+/// @brief Melee2 状態の更新（横移動停止・タイマー減算・ヒットボックス管理）
+/// @return 遷移先がある場合はその Motion、なければ std::nullopt
+[[nodiscard]] std::optional<Motion> Tick(Melee2& state,
+                                         entt::registry& registry,
                                          entt::entity entity,
                                          const FrameData& frameData);
 

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -33,7 +33,9 @@ void SetupContext(entt::registry& registry) {
                 .damage = 10,
                 .windupSec = 0.05,
                 .activeSec = 0.10,
-                .recoverySec = 0.20},
+                .recoverySec = 0.20,
+                .active2Sec = 0.15,
+                .slashRiseHeight = 40.0},
       .ranged = {.reach = 100.0,
                  .radius = 5.0,
                  .damage = 5,
@@ -73,8 +75,8 @@ entt::entity MakePlayer(entt::registry& registry) {
 }  // namespace
 
 TEST_CASE(
-    "PlayerMotionSystem - melee attack input transitions Neutral to Melee") {
-  // 近接攻撃入力で Neutral から Melee へ遷移する
+    "PlayerMotionSystem - melee attack input transitions Neutral to Melee1") {
+  // 近接攻撃入力で Neutral から Melee1 へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -85,13 +87,13 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee1>(motion));
 
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.stage == 1);
+  const auto& melee = std::get<PlayerMotion::Melee1>(motion);
   REQUIRE(melee.elapsed == Approx(0.0));
   // 構え中（windupSec 未満）はヒットボックス未生成
   REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  REQUIRE_FALSE(melee.comboQueued);
 
   REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_1");
 }
@@ -167,18 +169,18 @@ TEST_CASE("PlayerMotionSystem - jump input immediately switches to jump clip") {
   REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"jump");
 }
 
-TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee to Neutral") {
-  // elapsed が windupSec+activeSec+recoverySec を超えたら Melee から Neutral
+TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee1 to Neutral") {
+  // elapsed が windupSec+activeSec+recoverySec を超え、comboQueued
+  // が立っていない場合は Melee1 から Neutral
   // へ遷移し、ヒットボックスが残っていれば破棄する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
-  // ヒットボックスエンティティ（Melee.hitboxEntity 用のダミー）
+  // ヒットボックスエンティティ（Melee1.hitboxEntity 用のダミー）
   const auto hitbox = registry.create();
   registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{.stage = 1, .elapsed = 0.34, .hitboxEntity = hitbox});
+      player, PlayerMotion::Melee1{.elapsed = 0.34, .hitboxEntity = hitbox});
 
   const FrameData frameData{.dt = 0.5};
   MotionSystem::Update(registry, frameData);
@@ -203,41 +205,39 @@ TEST_CASE("PlayerMotionSystem - timer expiry transitions Ranged to Neutral") {
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
 }
 
-TEST_CASE("PlayerMotionSystem - Melee elapsed increases but stays in Melee") {
-  // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
+TEST_CASE("PlayerMotionSystem - Melee1 elapsed increases but stays in Melee1") {
+  // recoveryEnd 未満の間は Melee1 のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player, PlayerMotion::Melee1{.elapsed = 0.0, .hitboxEntity = entt::null});
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).elapsed == Approx(0.1));
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee1>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee1>(motion).elapsed == Approx(0.1));
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee spawns hitbox when entering active frame") {
+    "PlayerMotionSystem - Melee1 spawns hitbox when entering active frame") {
   // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player, PlayerMotion::Melee1{.elapsed = 0.0, .hitboxEntity = entt::null});
 
   // windupSec(0.05) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
+  const auto& melee = std::get<PlayerMotion::Melee1>(motion);
   REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
   REQUIRE(registry.valid(melee.hitboxEntity));
   REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
@@ -246,7 +246,8 @@ TEST_CASE(
   REQUIRE(attack.hitstopSec > 0.0);
 }
 
-TEST_CASE("PlayerMotionSystem - Melee destroys hitbox when entering recovery") {
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 destroys hitbox when entering recovery") {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが破棄される
   entt::registry registry;
   SetupContext(registry);
@@ -256,28 +257,26 @@ TEST_CASE("PlayerMotionSystem - Melee destroys hitbox when entering recovery") {
   registry.emplace<LocalOffset>(hitbox);
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{.stage = 1, .elapsed = 0.10, .hitboxEntity = hitbox});
+      player, PlayerMotion::Melee1{.elapsed = 0.10, .hitboxEntity = hitbox});
 
   // windupSec+activeSec(0.15) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
+  const auto& melee = std::get<PlayerMotion::Melee1>(motion);
   REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
   REQUIRE_FALSE(registry.valid(hitbox));
 }
 
-TEST_CASE("PlayerMotionSystem - Melee stops horizontal movement") {
-  // Melee 中は移動入力があっても横移動が止まる
+TEST_CASE("PlayerMotionSystem - Melee1 stops horizontal movement") {
+  // Melee1 中は移動入力があっても横移動が止まる
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player, PlayerMotion::Melee1{.elapsed = 0.0, .hitboxEntity = entt::null});
 
   FrameData frameData{.dt = 0.1};
   frameData.input.moveAxis = Vec2{1.0, 0.0};
@@ -286,6 +285,236 @@ TEST_CASE("PlayerMotionSystem - Melee stops horizontal movement") {
   const auto& vel = registry.get<Velocity>(player);
   REQUIRE(vel.w == Approx(0.0));
   REQUIRE(vel.d == Approx(0.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 attack input during windup only sets "
+    "comboQueued") {
+  // windup中（elapsed < activeStart）の攻撃入力では即時遷移せず、
+  // comboQueued が立つのみ
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee1{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee1>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee1>(motion).comboQueued);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 attack input during active only sets "
+    "comboQueued") {
+  // active中（activeStart <= elapsed < activeEnd）の攻撃入力でも
+  // 即時遷移せず、comboQueued が立つのみ
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // windupSec(0.05) を超え activeEnd(0.15) 未満
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee1{.elapsed = 0.10, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee1>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee1>(motion).comboQueued);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 transitions to Melee2 immediately when "
+    "comboQueued at activeEnd") {
+  // activeEnd 到達時に comboQueued が立っていれば即座に Melee2 へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // activeEnd は windupSec+activeSec = 0.15
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee1{
+          .elapsed = 0.14, .hitboxEntity = entt::null, .comboQueued = true});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee2>(motion));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 transitions to Melee2 immediately on new "
+    "attack input during recovery") {
+  // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に Melee2 へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // activeEnd(0.15) を既に過ぎている状態（comboQueued は未予約）
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee1{.elapsed = 0.16, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee2>(motion));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 transitions to Neutral when recoveryEnd "
+    "exceeded without comboQueued") {
+  // comboQueued が立っていない状態で recoveryEnd を超えたら Neutral へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // recoveryEnd は windupSec+activeSec+recoverySec = 0.35
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee1{.elapsed = 0.34, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
+TEST_CASE("PlayerMotionSystem - Melee1 comboQueued accumulates across frames") {
+  // comboQueued は一度立ったら立ったまま（OR的に蓄積）
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee1{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  // 1フレーム目：攻撃入力あり、comboQueued が立つ
+  FrameData frameData1{.dt = 0.01};
+  frameData1.input.attackDown = true;
+  MotionSystem::Update(registry, frameData1);
+
+  REQUIRE(
+      std::get<PlayerMotion::Melee1>(registry.get<Motion>(player)).comboQueued);
+
+  // 2フレーム目：攻撃入力なし、comboQueued は立ったまま
+  const FrameData frameData2{.dt = 0.01};
+  MotionSystem::Update(registry, frameData2);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee1>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee1>(motion).comboQueued);
+}
+
+TEST_CASE("PlayerMotionSystem - Melee2 elapsed increases but stays in Melee2") {
+  // recoveryEnd 未満の間は Melee2 のまま、elapsed が加算される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee2{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.1};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee2>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee2>(motion).elapsed == Approx(0.1));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 spawns hitbox when entering active frame") {
+  // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee2{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  // windupSec(0.05) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& melee = std::get<PlayerMotion::Melee2>(motion);
+  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(melee.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 destroys hitbox when entering recovery") {
+  // 攻撃判定終了（windupSec+active2Sec）を過ぎたらヒットボックスが破棄される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const auto hitbox = registry.create();
+  registry.emplace<LocalOffset>(hitbox);
+  registry.emplace<Collider>(hitbox);
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee2{.elapsed = 0.15, .hitboxEntity = hitbox});
+
+  // windupSec+active2Sec(0.20) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& melee = std::get<PlayerMotion::Melee2>(motion);
+  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  REQUIRE_FALSE(registry.valid(hitbox));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 transitions to Neutral when recoveryEnd "
+    "exceeded") {
+  // recoveryEnd を超えたら Neutral へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // recoveryEnd は windupSec+active2Sec+recoverySec = 0.40
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee2{.elapsed = 0.39, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
+TEST_CASE("PlayerMotionSystem - Melee2 ignores attack input") {
+  // Melee2 中の攻撃入力は無視され、Melee2 のまま recoveryEnd 未満で留まる
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee2{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee2>(motion));
 }
 
 #endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,7 +119,7 @@ WorldPos { w, h, d }
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
-| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee` は段数（`stage`）・モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ |
+| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1` のみ次段への遷移予約フラグ（`comboQueued`）を持つ |
 | [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
 | [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MotionSystem`/`MovementSystem`/`GravitySystem` の対象から除外される（暫定実装、本格化は #132/#134） |
 | [`Stagger`](../Ash2/src/Component/Stagger.hpp) | ひるみリアクション中であることを示すタイマー。`StaggerSystem` が `RectDrawable::size` を縮小させ、残り時間が尽きたら `originalSize` に戻す（暫定実装、本格化は #134） |
@@ -163,7 +163,7 @@ WorldPos { w, h, d }
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算。新たに成立したヒットの `HitPair`（attacker/target）配列を返す |
 | [`HitstopSystem::Update`](../Ash2/src/System/HitstopSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の前） | `Hitstop` を持つエンティティの残り時間を減算し、0 以下になったら除去する（暫定実装） |
-| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Hitstop` を持たない `Motion`（Neutral/Melee/Ranged）ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了）を行う |
+| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Hitstop` を持たない `Motion`（Neutral/Melee1/Melee2/Ranged）ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了）を行う |
 | [`MovementSystem::Update`](../Ash2/src/System/MovementSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity` エンティティ（Player・弾）の位置を `vel * dt` で更新 |
 | [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity`+`Gravity` エンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h` を 0 にする）を適用 |
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |


### PR DESCRIPTION
## 概要

#169 の実装。近距離攻撃コンボの2段目を追加し、コンボリセットのタイマー的な仕組みを導入した。

## 実装内容

- `PlayerMotion::Melee` を `Melee1`/`Melee2` という型に分割（`int stage` フィールドではなく）。既存の `Neutral`/`Melee`/`Ranged` という「状態＝別の型」の variant パターンに合わせ、3段目以降への遷移をコンパイル時に防ぎつつ、段ごとに異なるタイミング・軌道を型として自然に持たせられるようにした
- `Melee1` は windup・active 中の攻撃入力をフラグ（`comboQueued`）でバッファリングし、後隙（recovery）に入った時点で即座に `Melee2` へ遷移する。recovery 中の新規入力も即時遷移する
- `Melee2` は次段への遷移ロジックを持たず、後隙終了で `Neutral` に戻る（3段目は対象外）
- `docs/game_design/motion_design.md` に基づき、2段目は1段目と異なる攻撃秒数（0.15s）・当たり判定の軌道（斜め下から斜め上への斬り上げ）を持つ
- 画像（クリップ）は1段目と共通のため、同一クリップでも再生位置を強制的にリセットする `RestartClip` を新設し、2段目開始時にモーションが視覚的に再生されるようにした

## テスト

`TestPlayerMotionSystem.cpp` にコンボ遷移・境界値・`Melee2`単体動作のテストケースを追加。format・tidy・build・test すべて通過済み。