### PR TITLE
AnimationSystemをヒットストップ中の除外対象に追加

### DIFF
--- a/Ash2/src/Component/Hitstop.hpp
+++ b/Ash2/src/Component/Hitstop.hpp
@@ -5,8 +5,8 @@
 ///
 /// このコンポーネントを持つエンティティは、`HitstopSystem`
 /// が経過時間を減算し、0 以下になった時点で除去する。
-/// 付与中は `MotionSystem`/`MovementSystem`/`GravitySystem` の更新が
-/// スキップされる。
+/// 付与中は `MotionSystem`/`MovementSystem`/`GravitySystem`/`AnimationSystem`
+/// の更新がスキップされる。
 struct Hitstop {
   /// 残り時間（秒）
   double remaining = 0.0;

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -4,13 +4,14 @@
 #include <cmath>
 
 #include "Component/Drawable.hpp"
+#include "Component/Hitstop.hpp"
 #include "Component/SpriteAnimation.hpp"
 #include "Config/AnimationData.hpp"
 
 void AnimationSystem::Update(entt::registry& registry, double dt) {
   const auto& dataRegistry = registry.ctx().get<AnimationDataRegistry>();
 
-  auto view = registry.view<SpriteAnimation, Drawable>();
+  auto view = registry.view<SpriteAnimation, Drawable>(entt::exclude<Hitstop>);
   for (auto [entity, anim, drawable] : view.each()) {
     assert(dataRegistry.contains(anim.dataKey) &&
            "AnimationDataRegistry にキーが存在しない");

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,7 +124,7 @@ WorldPos { w, h, d }
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
 | [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1` のみ次段への遷移予約フラグ（`comboQueued`）を持つ |
 | [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
-| [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MotionSystem`/`MovementSystem`/`GravitySystem` の対象から除外される（暫定実装、本格化は #132/#134） |
+| [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MotionSystem`/`MovementSystem`/`GravitySystem`/`AnimationSystem` の対象から除外される（暫定実装、本格化は #132/#134） |
 | [`Stagger`](../Ash2/src/Component/Stagger.hpp) | ひるみリアクション中であることを示すタイマー。`StaggerSystem` が `RectDrawable::size` を縮小させ、残り時間が尽きたら `originalSize` に戻す（暫定実装、本格化は #134） |
 
 ---
@@ -161,7 +161,7 @@ WorldPos { w, h, d }
 |---|---|---|
 | [`AttachmentSystem::UpdateTransform`](../Ash2/src/System/AttachmentSystem.hpp) | 毎フレーム（フェーズ後）＋フェーズ内（PlayerTestPhase、GravitySystem の後・HitSystem の前） | Hierarchy ルートから子孫へ WorldPos 伝播。PlayerTestPhase では HitSystem が同フレーム内の最新座標（光の珠の LocalOffset 反映後）を見られるよう追加で呼び出す |
 | [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（最後） | WorldPos+Drawable を奥行き順にソートして描画 |
-| [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | SpriteAnimation の elapsed を進め Drawable を更新 |
+| [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | `Hitstop` を持たない SpriteAnimation の elapsed を進め Drawable を更新 |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
 | [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算。新たに成立したヒットの `HitPair`（attacker/target）配列を返す |


### PR DESCRIPTION
## 概要
`AnimationSystem::Update` の view に `Hitstop` コンポーネントを持つエンティティを除外する処理が無く、ヒットストップ中もスプライトのコマ送りが進んでしまっていた。`MotionSystem`/`MovementSystem`/`GravitySystem` と同様に `entt::exclude<Hitstop>` を追加し、ヒットストップ中はアニメーションも停止するように修正した。

## 変更内容
- `Ash2/src/System/AnimationSystem.cpp`: viewに `entt::exclude<Hitstop>` を追加
- `Ash2/src/Component/Hitstop.hpp`: Doxygenコメントを更新（`AnimationSystem` も除外対象である旨を追記）
- `docs/ARCHITECTURE.md`: 上記の仕様変更に合わせて記述を更新

## 確認
- CI（format・tidy・build・test）: OK
- コードレビュー: OK
- ビジュアルチェック: ゲームを起動し、ヒットストップ中のアニメーション挙動を確認済み

close #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)