### PR TITLE
近距離攻撃コンボ3段目を追加

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -3,15 +3,19 @@ jump_speed = 400.0
 gravity = 980.0
 
 [melee]
-cap_mid_h         = 30.0
-reach             = 60.0
-radius            = 25.0
-damage            = 20
-windup_sec        = 0.05
-active_sec        = 0.10
-recovery_sec      = 0.20
-active2_sec       = 0.15
-slash_rise_height = 40.0
+cap_mid_h           = 30.0
+reach               = 60.0
+radius              = 25.0
+damage              = 20
+windup_sec          = 0.05
+active_sec          = 0.10
+recovery_sec        = 0.20
+active2_sec         = 0.15
+slash_rise_height   = 40.0
+windup3_sec         = 0.10
+active3_sec         = 0.20
+recovery3_sec       = 0.20
+radius3             = 32.0
 
 [ranged]
 reach        = 200.0

--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -5,4 +5,5 @@
 
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
 using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1,
-                            PlayerMotion::Melee2, PlayerMotion::Ranged>;
+                            PlayerMotion::Melee2, PlayerMotion::Melee3,
+                            PlayerMotion::Ranged>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -25,6 +25,16 @@ struct Melee2 {
   double elapsed = 0.0;
   /// 攻撃判定の子エンティティ
   entt::entity hitboxEntity = entt::null;
+  /// 後隙中の次段への遷移予約（windup/active中の入力で立つ）
+  bool comboQueued = false;
+};
+
+/// @brief 近距離攻撃3段目（締め技、キャンセル不可）
+struct Melee3 {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+  /// 攻撃判定の子エンティティ
+  entt::entity hitboxEntity = entt::null;
 };
 
 /// @brief 遠距離攻撃中

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -18,6 +18,10 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .recoverySec = m[U"recovery_sec"].get<double>(),
               .active2Sec = m[U"active2_sec"].get<double>(),
               .slashRiseHeight = m[U"slash_rise_height"].get<double>(),
+              .windup3Sec = m[U"windup3_sec"].get<double>(),
+              .active3Sec = m[U"active3_sec"].get<double>(),
+              .recovery3Sec = m[U"recovery3_sec"].get<double>(),
+              .radius3 = m[U"radius3"].get<double>(),
           },
       .ranged =
           {

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -21,6 +21,14 @@ struct MeleeConfig {
   double active2Sec;
   /// 2段目の斬り上げの振り幅（capMidH を中心とした上下の幅）
   double slashRiseHeight;
+  /// 3段目の構え時間（秒）
+  double windup3Sec;
+  /// 3段目の攻撃判定が有効な時間（秒）
+  double active3Sec;
+  /// 3段目の後隙時間（秒）
+  double recovery3Sec;
+  /// 3段目の攻撃カプセルの半径
+  double radius3;
 };
 
 /// @brief 遠距離攻撃の設定値

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -55,25 +55,27 @@ void RestartClip(SpriteAnimation& anim, const s3d::String& clip) {
   anim.elapsed = 0.0;
 }
 
-/// @brief 近接1段目の攻撃判定エンティティ（光の珠）を生成する
+/// @brief 近接攻撃判定エンティティ（光の珠）を生成する
 ///
 /// Component/Attack.hpp の Attack（ダメージ用）を付与する。
 /// 生成時点では構え中につき珠は体の近くに静止した位置に置く。
 /// Collider は珠エンティティ自身の原点からのオフセット 0 で固定し、
 /// 珠の現在位置は UpdateMeleeHitbox が更新する LocalOffset のみが担う。
+/// @param radius 攻撃カプセルの半径（兼 CircleDrawable の表示半径）
 entt::entity SpawnMeleeHitbox(entt::registry& registry, entt::entity owner,
-                              const WorldPos& pos, const PlayerConfig& cfg) {
+                              const WorldPos& pos, const PlayerConfig& cfg,
+                              double radius) {
   const auto hitbox = registry.create();
   registry.emplace<WorldPos>(hitbox, pos);
   registry.emplace<LocalOffset>(hitbox, LocalOffset{});
   Hierarchy::Attach(registry, owner, hitbox);
   registry.emplace<Collider>(hitbox, Collider{.segmentStart = Vec3::Zero(),
                                               .segmentEnd = Vec3::Zero(),
-                                              .radius = cfg.melee.radius});
+                                              .radius = radius});
   registry.emplace<Attack>(hitbox, Attack{.damage = cfg.melee.damage,
                                           .hitstopSec = KMeleeHitstopSec});
-  registry.emplace<Drawable>(hitbox, CircleDrawable{.radius = cfg.melee.radius,
-                                                    .color = KMeleeOrbColor});
+  registry.emplace<Drawable>(
+      hitbox, CircleDrawable{.radius = radius, .color = KMeleeOrbColor});
   return hitbox;
 }
 
@@ -109,12 +111,19 @@ Melee2 MakeMelee2(SpriteAnimation& anim) {
   return Melee2{};
 }
 
+/// @brief Melee2 から Melee3 へ移行する（攻撃クリップを先頭から再生）
+Melee3 MakeMelee3(SpriteAnimation& anim) {
+  RestartClip(anim, U"melee_1");
+  return Melee3{};
+}
+
 /// @brief 攻撃判定の発生区間に応じてヒットボックスを生成・更新・破棄する
+/// @param radius 攻撃カプセルの半径（兼 CircleDrawable の表示半径）
 /// @param offsetFn 攻撃フレーム内の進行度から珠のオフセットを算出する関数
 void UpdateMeleeHitbox(entt::registry& registry, entt::entity owner,
                        double elapsed, double activeStart, double activeEnd,
                        bool facingRight, const PlayerConfig& cfg,
-                       entt::entity& hitboxEntity,
+                       entt::entity& hitboxEntity, double radius,
                        s3d::Vec3 (*offsetFn)(double, bool,
                                              const MeleeConfig&)) {
   const auto& melee = cfg.melee;
@@ -124,7 +133,7 @@ void UpdateMeleeHitbox(entt::registry& registry, entt::entity owner,
   if (elapsed >= activeStart && elapsed < activeEnd) {
     if (hitboxEntity == entt::null) {
       const auto& pos = registry.get<WorldPos>(owner);
-      hitboxEntity = SpawnMeleeHitbox(registry, owner, pos, cfg);
+      hitboxEntity = SpawnMeleeHitbox(registry, owner, pos, cfg, radius);
     }
 
     const double progress = (elapsed - activeStart) / (activeEnd - activeStart);
@@ -244,7 +253,8 @@ std::optional<Motion> Tick(Melee1& state, entt::registry& registry,
   state.elapsed += frameData.dt;
 
   UpdateMeleeHitbox(registry, entity, state.elapsed, activeStart, activeEnd,
-                    anim.facingRight, cfg, state.hitboxEntity, MeleeOrbOffset);
+                    anim.facingRight, cfg, state.hitboxEntity, melee.radius,
+                    MeleeOrbOffset);
 
   // windup・active中の攻撃入力は次段への遷移を予約するのみ
   if (state.elapsed < activeEnd && input.attackDown) {
@@ -269,7 +279,8 @@ std::optional<Motion> Tick(Melee2& state, entt::registry& registry,
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& melee = cfg.melee;
-  const auto& anim = registry.get<SpriteAnimation>(entity);
+  const auto& input = frameData.input;
+  auto& anim = registry.get<SpriteAnimation>(entity);
 
   const double activeStart = melee.windupSec;
   const double activeEnd = melee.windupSec + melee.active2Sec;
@@ -278,9 +289,45 @@ std::optional<Motion> Tick(Melee2& state, entt::registry& registry,
   state.elapsed += frameData.dt;
 
   UpdateMeleeHitbox(registry, entity, state.elapsed, activeStart, activeEnd,
-                    anim.facingRight, cfg, state.hitboxEntity,
+                    anim.facingRight, cfg, state.hitboxEntity, melee.radius,
                     MeleeSlashOffset);
 
+  // windup・active中の攻撃入力は次段への遷移を予約するのみ
+  if (state.elapsed < activeEnd && input.attackDown) {
+    state.comboQueued = true;
+  }
+
+  // 後隙に入った時点で予約済み、または後隙中の新規入力があれば即座に次段へ
+  if (state.elapsed >= activeEnd && (state.comboQueued || input.attackDown)) {
+    return MakeMelee3(anim);
+  }
+
+  if (state.elapsed >= recoveryEnd) {
+    return Neutral{};
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Motion> Tick(Melee3& state, entt::registry& registry,
+                           entt::entity entity, const FrameData& frameData) {
+  StopHorizontalMovement(registry, entity);
+
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& melee = cfg.melee;
+  const auto& anim = registry.get<SpriteAnimation>(entity);
+
+  const double activeStart = melee.windup3Sec;
+  const double activeEnd = melee.windup3Sec + melee.active3Sec;
+  const double recoveryEnd = activeEnd + melee.recovery3Sec;
+
+  state.elapsed += frameData.dt;
+
+  UpdateMeleeHitbox(registry, entity, state.elapsed, activeStart, activeEnd,
+                    anim.facingRight, cfg, state.hitboxEntity, melee.radius3,
+                    MeleeOrbOffset);
+
+  // 締め技のためコンボ継続なし、後隙満了で Neutral へ戻るのみ
   if (state.elapsed >= recoveryEnd) {
     return Neutral{};
   }

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -25,9 +25,18 @@ namespace PlayerMotion {
                                          entt::entity entity,
                                          const FrameData& frameData);
 
-/// @brief Melee2 状態の更新（横移動停止・タイマー減算・ヒットボックス管理）
+/// @brief Melee2 状態の更新（横移動停止・タイマー減算・ヒットボックス管理・
+/// コンボ予約判定）
 /// @return 遷移先がある場合はその Motion、なければ std::nullopt
 [[nodiscard]] std::optional<Motion> Tick(Melee2& state,
+                                         entt::registry& registry,
+                                         entt::entity entity,
+                                         const FrameData& frameData);
+
+/// @brief Melee3 状態の更新（横移動停止・タイマー減算・ヒットボックス管理、
+/// 締め技のためコンボ継続なし）
+/// @return 遷移先がある場合はその Motion、なければ std::nullopt
+[[nodiscard]] std::optional<Motion> Tick(Melee3& state,
                                          entt::registry& registry,
                                          entt::entity entity,
                                          const FrameData& frameData);

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -35,7 +35,11 @@ void SetupContext(entt::registry& registry) {
                 .activeSec = 0.10,
                 .recoverySec = 0.20,
                 .active2Sec = 0.15,
-                .slashRiseHeight = 40.0},
+                .slashRiseHeight = 40.0,
+                .windup3Sec = 0.10,
+                .active3Sec = 0.20,
+                .recovery3Sec = 0.20,
+                .radius3 = 25.0},
       .ranged = {.reach = 100.0,
                  .radius = 5.0,
                  .damage = 5,
@@ -500,8 +504,11 @@ TEST_CASE(
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
 }
 
-TEST_CASE("PlayerMotionSystem - Melee2 ignores attack input") {
-  // Melee2 中の攻撃入力は無視され、Melee2 のまま recoveryEnd 未満で留まる
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 attack input during windup only sets "
+    "comboQueued") {
+  // windup中（elapsed < activeStart）の攻撃入力では即時遷移せず、
+  // comboQueued が立つのみ
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -515,6 +522,188 @@ TEST_CASE("PlayerMotionSystem - Melee2 ignores attack input") {
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Melee2>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee2>(motion).comboQueued);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 transitions to Melee3 immediately when "
+    "comboQueued at activeEnd") {
+  // activeEnd 到達時に comboQueued が立っていれば即座に Melee3 へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // activeEnd は windupSec+active2Sec = 0.20
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee2{
+          .elapsed = 0.19, .hitboxEntity = entt::null, .comboQueued = true});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee3>(motion));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 transitions to Melee3 immediately on new "
+    "attack input during recovery") {
+  // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に Melee3 へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // activeEnd(0.20) を既に過ぎている状態（comboQueued は未予約）
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee2{.elapsed = 0.21, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee3>(motion));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee2 transitions to Neutral when recoveryEnd "
+    "exceeded without comboQueued") {
+  // comboQueued が立っていない状態で recoveryEnd を超えたら Neutral へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // recoveryEnd は windupSec+active2Sec+recoverySec = 0.40
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee2{.elapsed = 0.39, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
+TEST_CASE("PlayerMotionSystem - Melee3 elapsed increases but stays in Melee3") {
+  // recoveryEnd 未満の間は Melee3 のまま、elapsed が加算される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee3{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.1};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee3>(motion));
+  REQUIRE(std::get<PlayerMotion::Melee3>(motion).elapsed == Approx(0.1));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee3 spawns hitbox when entering active frame") {
+  // 構え時間（windup3Sec）を超えた瞬間にヒットボックス（光の珠）が生成される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee3{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  // windup3Sec(0.10) を跨ぐ dt
+  const FrameData frameData{.dt = 0.11};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& melee = std::get<PlayerMotion::Melee3>(motion);
+  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(melee.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
+
+  const auto& attack = registry.get<Attack>(melee.hitboxEntity);
+  REQUIRE(attack.hitstopSec > 0.0);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee3 destroys hitbox when entering recovery") {
+  // 攻撃判定終了（windup3Sec+active3Sec）を過ぎたらヒットボックスが破棄される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const auto hitbox = registry.create();
+  registry.emplace<LocalOffset>(hitbox);
+  registry.emplace<Collider>(hitbox);
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee3{.elapsed = 0.29, .hitboxEntity = hitbox});
+
+  // windup3Sec+active3Sec(0.30) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& melee = std::get<PlayerMotion::Melee3>(motion);
+  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  REQUIRE_FALSE(registry.valid(hitbox));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee3 transitions to Neutral when recoveryEnd "
+    "exceeded") {
+  // recoveryEnd を超えたら Neutral へ遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // recoveryEnd は windup3Sec+active3Sec+recovery3Sec = 0.50
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee3{.elapsed = 0.49, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
+TEST_CASE("PlayerMotionSystem - Melee3 ignores attack input (finisher)") {
+  // Melee3 は締め技のため攻撃入力を無視し、recoveryEnd 未満では Melee3 のまま
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee3{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee3>(motion));
+}
+
+TEST_CASE("PlayerMotionSystem - Melee3 stops horizontal movement") {
+  // Melee3 中は移動入力があっても横移動が止まる
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee3{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.1};
+  frameData.input.moveAxis = Vec2{1.0, 0.0};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& vel = registry.get<Velocity>(player);
+  REQUIRE(vel.w == Approx(0.0));
+  REQUIRE(vel.d == Approx(0.0));
 }
 
 #endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,7 +122,7 @@ WorldPos { w, h, d }
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
-| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1` のみ次段への遷移予約フラグ（`comboQueued`）を持つ |
+| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Melee3, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2`/`Melee3` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ |
 | [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
 | [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MotionSystem`/`MovementSystem`/`GravitySystem`/`AnimationSystem` の対象から除外される（暫定実装、本格化は #132/#134） |
 | [`Stagger`](../Ash2/src/Component/Stagger.hpp) | ひるみリアクション中であることを示すタイマー。`StaggerSystem` が `RectDrawable::size` を縮小させ、残り時間が尽きたら `originalSize` に戻す（暫定実装、本格化は #134） |


### PR DESCRIPTION
## 概要
- #170 の3段コンボ完成に向け、Melee3（締め技・コンボ継続なし）を追加
- Melee2::Tick に Melee1 と同様のコンボ予約ロジックを追加し、Melee2→Melee3 の遷移を実現
- close #170（マージで親issue #163 もクローズ）

## 技術選択の理由
3段目の見た目は当初「2つの光の刃」を試みたが、共通関数 SpawnMeleeHitbox
が判定エンティティ自身にも常に円描画を付与する構造のため、刃の扇形が
判定エンティティの円に完全に隠れてしまい、うまく表現できなかった。
今後演出を見直す際に何度も手直しになる見込みが高く、現時点で見た目の
作り込みに時間をかけるメリットが薄いと判断し、1・2段目と同じ単一の珠
表現に簡素化した。本格的な演出は別Issueで対応する想定。

## テスト
- 166→162アサーション（71テストケース）すべて通過
- /run でコンボ3段の操作感・見た目を確認済み