### PR TITLE
InputDeviceSelectorがスティック入力単体でもゲームパッドに切り替わるよう修正

### DIFF
--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -24,11 +24,13 @@ inline InputState InputDeviceSelector::update() {
     m_activeDevice = Device::Keyboard;
   }
   // 最後に入力があったデバイスへ切り替える
+  const Vec2 stickAxis = XInputAction::LeftThumbDeadZone(
+      Vec2{XInput(0).leftThumbX, XInput(0).leftThumbY});
   if (XInput(0).isConnected() &&
       (XInput(0).buttonUp.down() || XInput(0).buttonDown.down() ||
        XInput(0).buttonLeft.down() || XInput(0).buttonRight.down() ||
        XInput(0).buttonA.down() || XInput(0).buttonB.down() ||
-       XInput(0).buttonY.down())) {
+       XInput(0).buttonY.down() || !stickAxis.isZero())) {
     m_activeDevice = Device::Gamepad;
   } else if (!Keyboard::GetAllInputs().isEmpty() ||
              !Mouse::GetAllInputs().isEmpty()) {

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -7,6 +7,11 @@
 /// @note メンバ変数を持たない。ToInputState()
 /// は毎フレームコントローラー状態を直接参照する
 struct XInputAction {
+  /// 左スティックに適用するデッドゾーン（`InputDeviceSelector`
+  /// もスティック傾き判定に同じ定数を参照する）
+  static constexpr DeadZone LeftThumbDeadZone{
+      .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular};
+
   /// @brief 現在のコントローラー入力状態を InputState に変換して返す
   [[nodiscard]] static InputState ToInputState();
 };
@@ -16,8 +21,6 @@ inline InputState XInputAction::ToInputState() {
 
   // `XInput(0)` は const 参照のため `setLeftThumbDeadZone()` を直接呼べず、
   // ここで明示的にデッドゾーンを適用する
-  constexpr DeadZone LeftThumbDeadZone{
-      .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular};
   const Vec2 stickAxis =
       LeftThumbDeadZone(Vec2{pad.leftThumbX, pad.leftThumbY});
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,9 +99,9 @@ WorldPos { w, h, d }
 | [`KeyboardInputAction`](../Ash2/src/Input/KeyboardInputAction.hpp) | キーボード/マウス → InputState 変換 |
 | [`XInputAction`](../Ash2/src/Input/XInputAction.hpp) | XInput コントローラー → InputState 変換（左スティック+十字ボタンで移動、A/B/Y でジャンプ/近距離/遠距離） |
 
-`Main.cpp` が毎フレームデバイス入力を検出し、最後にアクティブだったデバイスに切り替える。切断時はキーボードへ自動フォールバック。
+[`InputDeviceSelector`](../Ash2/src/Input/InputDeviceSelector.hpp) が毎フレームデバイス入力を検出し、最後にアクティブだったデバイスに切り替える（ボタン入力に加え、左スティックがデッドゾーンを超えて傾いた場合もゲームパッドへの切り替え条件とする）。切断時はキーボードへ自動フォールバック。
 
-**移動入力の正規化方針：** `InputState::moveAxis`（`Vec2`、x=横方向/y=奥行き方向）は「常に長さ 1.0 以下に正規化済み」という不変条件を持つ。この保証の責任は `toInputState()` を実装する各入力レイヤー側にあり、`PlayerMotion::Tick(Neutral&, ...)` は無条件にこの値を信頼してそのまま速度計算に使う（System 側で正規化やクランプを行わない）。`XInputAction` は左スティックにデッドゾーン処理（`DeadZone`）を適用し、十字ボタンの軸ベクトルと加算したうえで `limitLength(1.0)` により正規化する。
+**移動入力の正規化方針：** `InputState::moveAxis`（`Vec2`、x=横方向/y=奥行き方向）は「常に長さ 1.0 以下に正規化済み」という不変条件を持つ。この保証の責任は `toInputState()` を実装する各入力レイヤー側にあり、`PlayerMotion::Tick(Neutral&, ...)` は無条件にこの値を信頼してそのまま速度計算に使う（System 側で正規化やクランプを行わない）。`XInputAction` は左スティックのデッドゾーン定数（`LeftThumbDeadZone`、`InputDeviceSelector` も参照する公開 `static constexpr` メンバ）を適用し、十字ボタンの軸ベクトルと加算したうえで `limitLength(1.0)` により正規化する。
 
 ---
 


### PR DESCRIPTION
## 概要

`InputDeviceSelector::update()` のゲームパッド検出条件が十字ボタン・A/B/Yボタンのみで、左スティックの傾きを見ていなかったため、スティックのみで移動し始めたプレイヤーの操作が反映されない不整合があった。

## 変更内容

- `XInputAction`: 左スティックのデッドゾーン定数をローカル変数から `static constexpr` な公開メンバ `LeftThumbDeadZone` に切り出し、`InputDeviceSelector` と共有できるようにした
- `InputDeviceSelector::update()`: ゲームパッド検出条件に、`LeftThumbDeadZone` 適用後の左スティック傾きが非ゼロであることを追加
- `docs/ARCHITECTURE.md`: 上記の責務変更を反映

close #176