### PR TITLE
ダッシュの実装

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -23,3 +23,11 @@ radius       = 15.0
 damage       = 15
 bullet_speed = 300.0
 spawn_height = 0.0
+
+[dash]
+speed           = 600.0
+windup_sec      = 0.00
+dash_sec        = 0.15
+recovery_a_sec  = 0.15
+recovery_b_sec  = 0.15
+stamina_cost    = 20

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -415,6 +415,7 @@
     <ClInclude Include="src\Component\Stagger.hpp" />
     <ClInclude Include="src\System\HitstopSystem.hpp" />
     <ClInclude Include="src\System\StaggerSystem.hpp" />
+    <ClInclude Include="src\Component\Invincible.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -1085,6 +1085,9 @@
     <ClInclude Include="Component\Stagger.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
+    <ClInclude Include="Component\Invincible.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
     <ClInclude Include="System\HitstopSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>

--- a/Ash2/src/Component/Invincible.hpp
+++ b/Ash2/src/Component/Invincible.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+/// @brief 無敵状態であることを示すタグコンポーネント
+///
+/// `HitSystem` の被弾対象ビューから除外される。
+struct Invincible {};

--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -6,4 +6,4 @@
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
 using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1,
                             PlayerMotion::Melee2, PlayerMotion::Melee3,
-                            PlayerMotion::Ranged>;
+                            PlayerMotion::Ranged, PlayerMotion::Dash>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -43,4 +43,12 @@ struct Ranged {
   double timer = 0.0;
 };
 
+/// @brief ダッシュ中（構え・ダッシュ・後隙A・後隙Bの4区間を持つ）
+struct Dash {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+  /// 後隙B中のダッシュ攻撃への遷移予約（#164 で遷移先を実装するまでは保持のみ）
+  bool dashAttackQueued = false;
+};
+
 }  // namespace PlayerMotion

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -3,6 +3,7 @@
 PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
   const auto& m = toml[U"melee"];
   const auto& r = toml[U"ranged"];
+  const auto& d = toml[U"dash"];
   return {
       .speed = toml[U"speed"].get<double>(),
       .jumpSpeed = toml[U"jump_speed"].get<double>(),
@@ -30,6 +31,15 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .damage = r[U"damage"].get<int>(),
               .bulletSpeed = r[U"bullet_speed"].get<double>(),
               .spawnHeight = r[U"spawn_height"].get<double>(),
+          },
+      .dash =
+          {
+              .speed = d[U"speed"].get<double>(),
+              .windupSec = d[U"windup_sec"].get<double>(),
+              .dashSec = d[U"dash_sec"].get<double>(),
+              .recoveryASec = d[U"recovery_a_sec"].get<double>(),
+              .recoveryBSec = d[U"recovery_b_sec"].get<double>(),
+              .staminaCost = d[U"stamina_cost"].get<int>(),
           },
   };
 }

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -31,6 +31,22 @@ struct MeleeConfig {
   double radius3;
 };
 
+/// @brief ダッシュの設定値
+struct DashConfig {
+  /// ダッシュ移動速度（ピクセル/秒）
+  double speed;
+  /// 構え時間（秒）
+  double windupSec;
+  /// ダッシュ時間（秒）
+  double dashSec;
+  /// 後隙A（キャンセル不可）の時間（秒）
+  double recoveryASec;
+  /// 後隙B（キャンセル可）の時間（秒）
+  double recoveryBSec;
+  /// 1回の発生に必要なスタミナ消費量
+  int staminaCost;
+};
+
 /// @brief 遠距離攻撃の設定値
 struct RangedConfig {
   /// 攻撃リーチ（w 軸方向の距離）
@@ -55,6 +71,7 @@ struct PlayerConfig {
   double gravity;
   MeleeConfig melee;
   RangedConfig ranged;
+  DashConfig dash;
 
   /// @brief TOML からプレイヤー設定を生成する
   [[nodiscard]] static PlayerConfig FromToml(const s3d::TOMLValue& toml);

--- a/Ash2/src/Input/InputState.hpp
+++ b/Ash2/src/Input/InputState.hpp
@@ -12,4 +12,5 @@ struct InputState {
   bool reloadConfig = false;
   bool attackDown = false;
   bool rangedAttackDown = false;
+  bool dashDown = false;
 };

--- a/Ash2/src/Input/KeyboardInputAction.hpp
+++ b/Ash2/src/Input/KeyboardInputAction.hpp
@@ -13,6 +13,7 @@ struct KeyboardInputAction {
   InputGroup reloadConfig;
   InputGroup attack;
   InputGroup rangedAttack;
+  InputGroup dash;
 
   /// @brief デフォルトのキー割り当てを返す
   [[nodiscard]] static KeyboardInputAction Default();
@@ -31,6 +32,7 @@ inline KeyboardInputAction KeyboardInputAction::Default() {
       .reloadConfig = KeyF5,
       .attack = MouseL,
       .rangedAttack = MouseR,
+      .dash = KeyShift,
   };
 }
 
@@ -48,5 +50,6 @@ inline InputState KeyboardInputAction::toInputState() const {
       .reloadConfig = reloadConfig.down(),
       .attackDown = attack.down(),
       .rangedAttackDown = rangedAttack.down(),
+      .dashDown = dash.down(),
   };
 }

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -39,6 +39,7 @@ inline InputState XInputAction::ToInputState() {
       .jumpDown = pad.buttonA.down(),
       .reloadConfig = false,
       .attackDown = pad.buttonB.down(),
-      .rangedAttackDown = pad.buttonY.down(),
+      .rangedAttackDown = pad.buttonX.down(),
+      .dashDown = pad.buttonY.down(),
   };
 }

--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -7,6 +7,7 @@
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
 #include "Component/Hp.hpp"
+#include "Component/Invincible.hpp"
 #include "Component/WorldPos.hpp"
 
 /// @brief 攻撃側・被弾側のエンティティの組
@@ -81,7 +82,8 @@ inline s3d::Array<HitPair> HitSystem::Update(entt::registry& registry) {
   s3d::Array<HitPair> hits;
 
   auto attackers = registry.view<WorldPos, Collider, Attack>();
-  auto targets = registry.view<WorldPos, Collider, Hp>();
+  auto targets =
+      registry.view<WorldPos, Collider, Hp>(entt::exclude<Invincible>);
 
   for (auto&& [attacker, aPos, aCol, atk] : attackers.each()) {
     // root が設定されている場合はルートの Attack を参照してヒット管理する

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -8,9 +8,11 @@
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Hierarchy.hpp"
+#include "Component/Invincible.hpp"
 #include "Component/LocalOffset.hpp"
 #include "Component/Projectile.hpp"
 #include "Component/SpriteAnimation.hpp"
+#include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/AnimationData.hpp"
@@ -177,6 +179,18 @@ Ranged MakeRanged(const AnimationData& playerData, SpriteAnimation& anim) {
   return Ranged{.timer = GetClipDuration(playerData, U"ranged_attack")};
 }
 
+/// @brief Dash へ移行する（スタミナ消費、クリップの設定）
+///
+/// 専用のダッシュ用クリップは未用意のため、移動主体の動きという特性が近い
+/// "move" クリップを暫定的に流用する。
+Dash MakeDash(entt::registry& registry, entt::entity entity,
+              const PlayerConfig& cfg, SpriteAnimation& anim) {
+  auto& stamina = registry.get<Stamina>(entity);
+  stamina.current = std::max(0, stamina.current - cfg.dash.staminaCost);
+  SetClip(anim, U"move");
+  return Dash{};
+}
+
 }  // namespace
 
 std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
@@ -217,6 +231,10 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
       vel.d = 0.0;
       SpawnProjectile(registry, pos, anim.facingRight, cfg);
       return MakeRanged(playerData, anim);
+    }
+    if (input.dashDown &&
+        registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
+      return MakeDash(registry, entity, cfg, anim);
     }
   }
 
@@ -266,6 +284,12 @@ std::optional<Motion> Tick(Melee1& state, entt::registry& registry,
     return MakeMelee2(anim);
   }
 
+  // 後隙中のダッシュ入力でダッシュへキャンセル（ST不足時は無視）
+  if (state.elapsed >= activeEnd && input.dashDown &&
+      registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
+    return MakeDash(registry, entity, cfg, anim);
+  }
+
   if (state.elapsed >= recoveryEnd) {
     return Neutral{};
   }
@@ -300,6 +324,12 @@ std::optional<Motion> Tick(Melee2& state, entt::registry& registry,
   // 後隙に入った時点で予約済み、または後隙中の新規入力があれば即座に次段へ
   if (state.elapsed >= activeEnd && (state.comboQueued || input.attackDown)) {
     return MakeMelee3(anim);
+  }
+
+  // 後隙中のダッシュ入力でダッシュへキャンセル（ST不足時は無視）
+  if (state.elapsed >= activeEnd && input.dashDown &&
+      registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
+    return MakeDash(registry, entity, cfg, anim);
   }
 
   if (state.elapsed >= recoveryEnd) {
@@ -341,6 +371,56 @@ std::optional<Motion> Tick(Ranged& state, entt::registry& registry,
 
   state.timer -= frameData.dt;
   if (state.timer <= 0.0) {
+    return Neutral{};
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Motion> Tick(Dash& state, entt::registry& registry,
+                           entt::entity entity, const FrameData& frameData) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& dash = cfg.dash;
+  const auto& input = frameData.input;
+  auto& vel = registry.get<Velocity>(entity);
+  auto& anim = registry.get<SpriteAnimation>(entity);
+
+  const double dashStart = dash.windupSec;
+  const double dashEnd = dash.windupSec + dash.dashSec;
+  const double recoveryAEnd = dashEnd + dash.recoveryASec;
+  const double recoveryBEnd = recoveryAEnd + dash.recoveryBSec;
+
+  state.elapsed += frameData.dt;
+
+  // 構え・ダッシュ中（後隙入り前）は無敵、後隙入りで除去する
+  if (state.elapsed < dashEnd) {
+    registry.emplace_or_replace<Invincible>(entity);
+  } else {
+    registry.remove<Invincible>(entity);
+  }
+
+  // ダッシュ移動中：フリー方向、無方向なら facingRight から前方
+  if (state.elapsed >= dashStart && state.elapsed < dashEnd) {
+    if (!input.moveAxis.isZero()) {
+      const Vec2 dir = input.moveAxis.normalized();
+      vel.w = dir.x * dash.speed;
+      vel.d = dir.y * dash.speed;
+    } else {
+      vel.w = (anim.facingRight ? 1.0 : -1.0) * dash.speed;
+      vel.d = 0.0;
+    }
+  } else {
+    vel.w = 0.0;
+    vel.d = 0.0;
+  }
+
+  // 後隙B中のダッシュ入力はダッシュ攻撃への遷移を予約するのみ
+  // （遷移先の実装は #164）
+  if (state.elapsed >= recoveryAEnd && input.dashDown) {
+    state.dashAttackQueued = true;
+  }
+
+  if (state.elapsed >= recoveryBEnd) {
     return Neutral{};
   }
 

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -48,4 +48,11 @@ namespace PlayerMotion {
                                          entt::entity entity,
                                          const FrameData& frameData);
 
+/// @brief Dash 状態の更新（移動・タイマー減算・無敵の付与/除去・
+/// 後隙Bでのダッシュ攻撃キャンセル予約）
+/// @return 遷移先がある場合はその Motion、なければ std::nullopt
+[[nodiscard]] std::optional<Motion> Tick(Dash& state, entt::registry& registry,
+                                         entt::entity entity,
+                                         const FrameData& frameData);
+
 }  // namespace PlayerMotion

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -4,12 +4,14 @@
 
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
+#include "Component/Invincible.hpp"
 #include "Component/LocalOffset.hpp"
 #include "Component/Motion.hpp"
 #include "Component/Player.hpp"
 #include "Component/PlayerMotion.hpp"
 #include "Component/Projectile.hpp"
 #include "Component/SpriteAnimation.hpp"
+#include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
 #include "Config/AnimationData.hpp"
@@ -45,6 +47,12 @@ void SetupContext(entt::registry& registry) {
                  .damage = 5,
                  .bulletSpeed = 300.0,
                  .spawnHeight = 40.0},
+      .dash = {.speed = 500.0,
+               .windupSec = 0.0,
+               .dashSec = 0.15,
+               .recoveryASec = 0.15,
+               .recoveryBSec = 0.15,
+               .staminaCost = 20},
   });
 
   AnimationDataRegistry animReg;
@@ -73,6 +81,7 @@ entt::entity MakePlayer(entt::registry& registry) {
   registry.emplace<SpriteAnimation>(
       player, SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
   registry.emplace<Motion>(player, PlayerMotion::Neutral{});
+  registry.emplace<Stamina>(player, Stamina{.max = 100, .current = 100});
   return player;
 }
 
@@ -704,6 +713,219 @@ TEST_CASE("PlayerMotionSystem - Melee3 stops horizontal movement") {
   const auto& vel = registry.get<Velocity>(player);
   REQUIRE(vel.w == Approx(0.0));
   REQUIRE(vel.d == Approx(0.0));
+}
+
+TEST_CASE("PlayerMotionSystem - dash input transitions Neutral to Dash") {
+  // ダッシュ入力で Neutral から Dash へ遷移し、ST が1回分消費される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  FrameData frameData{};
+  frameData.input.dashDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
+  REQUIRE(std::get<PlayerMotion::Dash>(motion).elapsed == Approx(0.0));
+
+  // dash.staminaCost(20) 分が消費される
+  REQUIRE(registry.get<Stamina>(player).current == 80);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - dash input is ignored when stamina is "
+    "insufficient") {
+  // ST不足の場合はダッシュ入力を無視し Neutral のまま、ST も減らない
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<Stamina>(player).current = 10;
+
+  FrameData frameData{};
+  frameData.input.dashDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+  REQUIRE(registry.get<Stamina>(player).current == 10);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Dash grants Invincible during windup and dash") {
+  // 構え・ダッシュ中（elapsed < dashEnd）は Invincible が付与される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // dash.windupSec(0.0) + dash.dashSec(0.15) = 0.15 未満
+  registry.replace<Motion>(player, PlayerMotion::Dash{.elapsed = 0.0});
+
+  const FrameData frameData{.dt = 0.1};
+  MotionSystem::Update(registry, frameData);
+
+  REQUIRE(registry.all_of<Invincible>(player));
+  REQUIRE(
+      std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player)));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Dash removes Invincible when entering recovery") {
+  // dashEnd(0.15) を超えた時点で Invincible が除去される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.emplace<Invincible>(player);
+  registry.replace<Motion>(player, PlayerMotion::Dash{.elapsed = 0.14});
+
+  const FrameData frameData{.dt = 0.02};
+  MotionSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.all_of<Invincible>(player));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Dash moves in facing direction when no move "
+    "input") {
+  // ダッシュ中に移動入力がない場合は facingRight 方向へ移動する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<SpriteAnimation>(player).facingRight = true;
+
+  registry.replace<Motion>(player, PlayerMotion::Dash{.elapsed = 0.0});
+
+  const FrameData frameData{.dt = 0.05};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& vel = registry.get<Velocity>(player);
+  // dash.speed(500.0)
+  REQUIRE(vel.w == Approx(500.0));
+  REQUIRE(vel.d == Approx(0.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Dash moves in free direction when input given") {
+  // ダッシュ中にフリー方向の移動入力があればその方向へ移動する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(player, PlayerMotion::Dash{.elapsed = 0.0});
+
+  FrameData frameData{.dt = 0.05};
+  frameData.input.moveAxis = Vec2{0.0, 1.0};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& vel = registry.get<Velocity>(player);
+  REQUIRE(vel.w == Approx(0.0));
+  REQUIRE(vel.d == Approx(500.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Dash queues dash attack on dash input during "
+    "recovery B") {
+  // 後隙B中（recoveryAEnd 以降）のダッシュ入力で dashAttackQueued が立つ
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // dashEnd(0.15) + recoveryASec(0.15) = 0.30 が recoveryAEnd
+  registry.replace<Motion>(player, PlayerMotion::Dash{.elapsed = 0.29});
+
+  FrameData frameData{.dt = 0.02};
+  frameData.input.dashDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
+  REQUIRE(std::get<PlayerMotion::Dash>(motion).dashAttackQueued);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Dash transitions to Neutral at recovery B end "
+    "even when dashAttackQueued") {
+  // recoveryBEnd を超えたら dashAttackQueued の有無に関わらず Neutral へ戻る
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // recoveryBEnd は windupSec+dashSec+recoveryASec+recoveryBSec = 0.45
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.44, .dashAttackQueued = true});
+
+  const FrameData frameData{.dt = 0.02};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
+TEST_CASE("PlayerMotionSystem - Melee1 recovery dash input cancels into Dash") {
+  // Melee1 の後隙中にダッシュ入力があるとダッシュへキャンセルする
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // activeEnd(0.15) を既に過ぎている状態
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee1{.elapsed = 0.16, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.dashDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
+  REQUIRE(registry.get<Stamina>(player).current == 80);
+}
+
+TEST_CASE("PlayerMotionSystem - Melee2 recovery dash input cancels into Dash") {
+  // Melee2 の後隙中にダッシュ入力があるとダッシュへキャンセルする
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  // activeEnd(0.20) を既に過ぎている状態
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee2{.elapsed = 0.21, .hitboxEntity = entt::null});
+
+  FrameData frameData{.dt = 0.01};
+  frameData.input.dashDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
+  REQUIRE(registry.get<Stamina>(player).current == 80);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - Melee1 recovery dash input is ignored without "
+    "leftover hitbox") {
+  // Melee1 後隙からダッシュへキャンセルする際、ヒットボックスは既に破棄済み
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const auto hitbox = registry.create();
+  registry.emplace<LocalOffset>(hitbox);
+  registry.emplace<Collider>(hitbox);
+  // activeEnd(0.15) を跨ぐ dt でヒットボックスが破棄される
+  registry.replace<Motion>(
+      player, PlayerMotion::Melee1{.elapsed = 0.14, .hitboxEntity = hitbox});
+
+  FrameData frameData{.dt = 0.02};
+  frameData.input.dashDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
+  REQUIRE_FALSE(registry.valid(hitbox));
 }
 
 #endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,7 +97,7 @@ WorldPos { w, h, d }
 |---|---|
 | [`InputState`](../Ash2/src/Input/InputState.hpp) | フレームの論理入力（`Key`/`TOMLValue` 等のテストしづらい型は持ち込まないが、`Vec2` 等の単純な数学型は許容） |
 | [`KeyboardInputAction`](../Ash2/src/Input/KeyboardInputAction.hpp) | キーボード/マウス → InputState 変換 |
-| [`XInputAction`](../Ash2/src/Input/XInputAction.hpp) | XInput コントローラー → InputState 変換（左スティック+十字ボタンで移動、A/B/Y でジャンプ/近距離/遠距離） |
+| [`XInputAction`](../Ash2/src/Input/XInputAction.hpp) | XInput コントローラー → InputState 変換（左スティック+十字ボタンで移動、A/B/X/Y でジャンプ/近距離/遠距離/ダッシュ） |
 
 [`InputDeviceSelector`](../Ash2/src/Input/InputDeviceSelector.hpp) が毎フレームデバイス入力を検出し、最後にアクティブだったデバイスに切り替える（ボタン入力に加え、左スティックがデッドゾーンを超えて傾いた場合もゲームパッドへの切り替え条件とする）。切断時はキーボードへ自動フォールバック。
 
@@ -122,10 +122,11 @@ WorldPos { w, h, d }
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
 | [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
-| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Melee3, PlayerMotion::Ranged>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2`/`Melee3` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ |
+| [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Melee3, PlayerMotion::Ranged, PlayerMotion::Dash>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2`/`Melee3` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ。`Dash` は構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理し、後隙Bでのダッシュ攻撃キャンセル予約フラグ（`dashAttackQueued`）を持つが、遷移先の実装は #164 で行う |
 | [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
 | [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MotionSystem`/`MovementSystem`/`GravitySystem`/`AnimationSystem` の対象から除外される（暫定実装、本格化は #132/#134） |
 | [`Stagger`](../Ash2/src/Component/Stagger.hpp) | ひるみリアクション中であることを示すタイマー。`StaggerSystem` が `RectDrawable::size` を縮小させ、残り時間が尽きたら `originalSize` に戻す（暫定実装、本格化は #134） |
+| [`Invincible`](../Ash2/src/Component/Invincible.hpp) | 無敵状態であることを示すタグ。`HitSystem` の被弾対象ビューから除外される。`PlayerMotion::Dash` が構え・ダッシュ中は毎フレーム付与し、後隙入りで除去する |
 
 ---
 
@@ -164,9 +165,9 @@ WorldPos { w, h, d }
 | [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | `Hitstop` を持たない SpriteAnimation の elapsed を進め Drawable を更新 |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
-| [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp` の間でカプセル重なり検出 → Hp 減算。新たに成立したヒットの `HitPair`（attacker/target）配列を返す |
+| [`HitSystem::Update`](../Ash2/src/System/HitSystem.hpp) | フェーズ内（攻撃入力時） | `Collider+Attack` と `Collider+Hp`（`Invincible` を除く）の間でカプセル重なり検出 → Hp 減算。新たに成立したヒットの `HitPair`（attacker/target）配列を返す |
 | [`HitstopSystem::Update`](../Ash2/src/System/HitstopSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の前） | `Hitstop` を持つエンティティの残り時間を減算し、0 以下になったら除去する（暫定実装） |
-| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Hitstop` を持たない `Motion`（Neutral/Melee1/Melee2/Ranged）ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了）を行う。各状態の `Tick()` 実体は [`PlayerMotionSystem.cpp`](../Ash2/src/System/PlayerMotionSystem.cpp) にある |
+| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Hitstop` を持たない `Motion`（Neutral/Melee1/Melee2/Melee3/Ranged/Dash）ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了、無敵の付与/除去）を行う。各状態の `Tick()` 実体は [`PlayerMotionSystem.cpp`](../Ash2/src/System/PlayerMotionSystem.cpp) にある |
 | [`MovementSystem::Update`](../Ash2/src/System/MovementSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity` エンティティ（Player・弾）の位置を `vel * dt` で更新 |
 | [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity`+`Gravity` エンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h` を 0 にする）を適用 |
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |


### PR DESCRIPTION
## 概要

battle_design.md の整理により「回避」から名称・仕様を統合したダッシュアクションを実装する（close #136）。

- `PlayerMotion::Dash` を追加し、構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` で管理
- 無敵コンポーネント `Invincible` を新規追加し、構え・ダッシュ中のみ付与。`HitSystem` の被弾対象から除外する
- 移動はフリー方向、無方向で押すと前方（`facingRight` から決定）
- ST消費は入場時（Neutral→Dash）に1回。不足時は入力を無視する
- 入力に `dashDown` を追加（キーボード: Shift、XInput: Yボタン）
- XInputの遠距離攻撃をYボタンからXボタンに変更（Yボタンをダッシュに割り当てるため）
- 近接1段・2段の後隙からダッシュへのキャンセル遷移に対応
- 後隙Bでのダッシュ攻撃へのキャンセル予約フラグを用意（遷移先は実装しない）

## スコープ外

- ダッシュ攻撃（締め技）は #164 で対応
- 空中ダッシュは #165 で対応
- 変身モード中のダッシュ方向変化は demo版の変身システム実装時に対応
- ダッシュ専用の画像・アニメーションは別Issueの想定。今回は暫定的に既存の `move` クリップを流用
- スタミナの消費・回復ロジック本体（近接・遠距離攻撃分・回復）は #131 のスコープ。本PRではダッシュ専用の消費判定のみを実装

## テスト

`TestPlayerMotionSystem.cpp` にDash関連テストを11件追加（Neutralからの入場、ST不足時の拒否、無敵の付与・解除タイミング、移動方向、後隙Bでのキャンセル予約、Melee1/Melee2からのキャンセル遷移など）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)