### PR TITLE
スタミナシステムの実装

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -23,6 +23,7 @@ radius       = 15.0
 damage       = 15
 bullet_speed = 300.0
 spawn_height = 0.0
+stamina_cost = 30
 
 [dash]
 speed           = 600.0
@@ -31,3 +32,7 @@ dash_sec        = 0.15
 recovery_a_sec  = 0.15
 recovery_b_sec  = 0.15
 stamina_cost    = 20
+
+[stamina]
+recovery_delay = 2.0
+recovery_rate  = 0.5

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="src\System\DrawSystem.cpp" />
     <ClCompile Include="src\System\HitstopSystem.cpp" />
     <ClCompile Include="src\System\StaggerSystem.cpp" />
+    <ClCompile Include="src\System\StaminaSystem.cpp" />
     <ClCompile Include="src\Phase\PhaseStack.cpp" />
     <ClCompile Include="src\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -415,6 +416,7 @@
     <ClInclude Include="src\Component\Stagger.hpp" />
     <ClInclude Include="src\System\HitstopSystem.hpp" />
     <ClInclude Include="src\System\StaggerSystem.hpp" />
+    <ClInclude Include="src\System\StaminaSystem.hpp" />
     <ClInclude Include="src\Component\Invincible.hpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -213,6 +213,9 @@
     <ClCompile Include="System\StaggerSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\StaminaSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="GameSetup.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1092,6 +1095,9 @@
       <Filter>Header Files\System</Filter>
     </ClInclude>
     <ClInclude Include="System\StaggerSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
+    <ClInclude Include="System\StaminaSystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Ash2/src/Component/Stamina.hpp
+++ b/Ash2/src/Component/Stamina.hpp
@@ -4,4 +4,8 @@
 struct Stamina {
   int max;
   int current;
+  /// StaminaSystem が管理する回復端数の累積値
+  double accum = 0.0;
+  /// Neutral 状態が継続した経過時間（回復ディレイ計測用）
+  double recoveryTimer = 0.0;
 };

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -4,6 +4,7 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
   const auto& m = toml[U"melee"];
   const auto& r = toml[U"ranged"];
   const auto& d = toml[U"dash"];
+  const auto& s = toml[U"stamina"];
   return {
       .speed = toml[U"speed"].get<double>(),
       .jumpSpeed = toml[U"jump_speed"].get<double>(),
@@ -31,6 +32,7 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .damage = r[U"damage"].get<int>(),
               .bulletSpeed = r[U"bullet_speed"].get<double>(),
               .spawnHeight = r[U"spawn_height"].get<double>(),
+              .staminaCost = r[U"stamina_cost"].get<int>(),
           },
       .dash =
           {
@@ -40,6 +42,11 @@ PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
               .recoveryASec = d[U"recovery_a_sec"].get<double>(),
               .recoveryBSec = d[U"recovery_b_sec"].get<double>(),
               .staminaCost = d[U"stamina_cost"].get<int>(),
+          },
+      .stamina =
+          {
+              .recoveryDelay = s[U"recovery_delay"].get<double>(),
+              .recoveryRate = s[U"recovery_rate"].get<double>(),
           },
   };
 }

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -59,6 +59,16 @@ struct RangedConfig {
   double bulletSpeed;
   /// 弾の発射高さ（プレイヤーの WorldPos.h からのオフセット）
   double spawnHeight;
+  /// 1回の発生に必要なスタミナ消費量
+  int staminaCost;
+};
+
+/// @brief スタミナ回復の設定値
+struct StaminaConfig {
+  /// 行動後に回復が始まるまでの待機秒数
+  double recoveryDelay;
+  /// 毎秒、スタミナ不足分の何割を回復するか（0.5 = 不足分の半分/秒）
+  double recoveryRate;
 };
 
 /// @brief プレイヤーの設定値
@@ -72,6 +82,7 @@ struct PlayerConfig {
   MeleeConfig melee;
   RangedConfig ranged;
   DashConfig dash;
+  StaminaConfig stamina;
 
   /// @brief TOML からプレイヤー設定を生成する
   [[nodiscard]] static PlayerConfig FromToml(const s3d::TOMLValue& toml);

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -28,6 +28,7 @@
 #include "System/MovementSystem.hpp"
 #include "System/ProjectileSystem.hpp"
 #include "System/StaggerSystem.hpp"
+#include "System/StaminaSystem.hpp"
 
 constexpr double KDummyPosW = 150.0;
 constexpr s3d::SizeF KDummySize = {60.0, 80.0};
@@ -85,6 +86,7 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
 
   HitstopSystem::Update(registry, dt);
   MotionSystem::Update(registry, frameData);
+  StaminaSystem::Update(registry, dt);
   MovementSystem::Update(registry, dt);
   GravitySystem::Update(registry, dt);
   AttachmentSystem::UpdateTransform(registry);

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -173,8 +173,13 @@ void SpawnProjectile(entt::registry& registry, const WorldPos& pos,
   registry.emplace<Projectile>(bullet);
 }
 
-/// @brief Ranged へ移行する（遠距離攻撃クリップの設定と timer の算出）
-Ranged MakeRanged(const AnimationData& playerData, SpriteAnimation& anim) {
+/// @brief Ranged へ移行する（スタミナ消費、遠距離攻撃クリップの設定と timer
+/// の算出）
+Ranged MakeRanged(entt::registry& registry, entt::entity entity,
+                  const PlayerConfig& cfg, const AnimationData& playerData,
+                  SpriteAnimation& anim) {
+  auto& stamina = registry.get<Stamina>(entity);
+  stamina.current = std::max(0, stamina.current - cfg.ranged.staminaCost);
   SetClip(anim, U"ranged_attack");
   return Ranged{.timer = GetClipDuration(playerData, U"ranged_attack")};
 }
@@ -226,11 +231,12 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
       // ヒットボックス（光の珠）は攻撃フレーム開始時に Melee1::Tick が生成する
       return MakeMelee(anim, entt::null);
     }
-    if (input.rangedAttackDown) {
+    if (input.rangedAttackDown &&
+        registry.get<Stamina>(entity).current >= cfg.ranged.staminaCost) {
       vel.w = 0.0;
       vel.d = 0.0;
       SpawnProjectile(registry, pos, anim.facingRight, cfg);
-      return MakeRanged(playerData, anim);
+      return MakeRanged(registry, entity, cfg, playerData, anim);
     }
     if (input.dashDown &&
         registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {

--- a/Ash2/src/System/StaminaSystem.cpp
+++ b/Ash2/src/System/StaminaSystem.cpp
@@ -1,0 +1,49 @@
+#include "System/StaminaSystem.hpp"
+
+#include "Component/Motion.hpp"
+#include "Component/Player.hpp"
+#include "Component/PlayerMotion.hpp"
+#include "Component/Stamina.hpp"
+#include "Config/PlayerConfig.hpp"
+
+namespace {
+// 99% 以上を満タンとみなして丸める閾値（浮動小数点誤差が残り続けるのを防ぐ）
+constexpr double KFullThreshold = 0.99;
+}  // namespace
+
+void StaminaSystem::Update(entt::registry& registry, double dt) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+
+  auto view = registry.view<Player, Stamina, Motion>();
+  for (auto&& [entity, stamina, motion] : view.each()) {
+    // Neutral 以外の状態はタイマーをリセットして回復しない
+    if (!std::holds_alternative<PlayerMotion::Neutral>(motion)) {
+      stamina.recoveryTimer = 0.0;
+      continue;
+    }
+
+    // Neutral
+    // が継続している間だけタイマーを進め、待機時間を満たすまで回復しない
+    stamina.recoveryTimer += dt;
+    if (stamina.recoveryTimer < cfg.stamina.recoveryDelay) continue;
+
+    if (stamina.current >= stamina.max) continue;
+
+    // 残量が少ないほど回復が速い（満タン付近でゼロに近づく）
+    const double gain =
+        (stamina.max - stamina.current) * cfg.stamina.recoveryRate * dt;
+
+    // 端数を accum に積み立てて毎フレームの切り捨て誤差を防ぐ
+    stamina.accum += gain;
+    const int intGain = static_cast<int>(stamina.accum);
+    if (intGain > 0) {
+      stamina.accum -= static_cast<double>(intGain);
+      stamina.current += intGain;
+    }
+
+    // 満タンに近い残量を丸めて微小な誤差が残り続けるのを防ぐ
+    if (stamina.current >= static_cast<int>(stamina.max * KFullThreshold)) {
+      stamina.current = stamina.max;
+    }
+  }
+}

--- a/Ash2/src/System/StaminaSystem.hpp
+++ b/Ash2/src/System/StaminaSystem.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief スタミナ回復の処理を行うシステム
+class StaminaSystem {
+ public:
+  /// @brief Neutral 状態のみ、recoveryDelay 秒待機後にスタミナを回復する
+  static void Update(entt::registry& registry, double dt);
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,7 +120,7 @@ WorldPos { w, h, d }
 | [`Collider`](../Ash2/src/Component/Collider.hpp) | カプセル形状の当たり判定（形状のみ、役割はコンポーネントの組み合わせで表現） |
 | [`Attack`](../Ash2/src/Component/Attack.hpp) | 攻撃中タグ兼攻撃力（`Collider` と組み合わせて攻撃判定が有効になる）。`root` で複数コライダー構成のルートを指定し、`hitTargets` で攻撃生存期間中の重複ヒットを防ぐ。`hitstopSec` はヒット成立時に攻撃側・被弾側へ付与するヒットストップ時間 |
 | [`Hp`](../Ash2/src/Component/Hp.hpp) | HP（`Collider` と組み合わせて被弾判定の対象になる） |
-| [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド） |
+| [`Stamina`](../Ash2/src/Component/Stamina.hpp) | スタミナ（max / current の int フィールド、StaminaSystem が管理する回復端数累積 accum と回復ディレイ計測用 recoveryTimer を持つ） |
 | [`Projectile`](../Ash2/src/Component/Projectile.hpp) | 飛翔体（弾）タグ（データなし）。`WorldPos`+`Velocity`+`Collider`+`Attack` と組み合わせ、`MovementSystem` が移動を、`ProjectileSystem` が消滅を管理する対象を識別する |
 | [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2, PlayerMotion::Melee3, PlayerMotion::Ranged, PlayerMotion::Dash>`）。`Ranged` は再生中クリップの残り時間。`Melee1`/`Melee2`/`Melee3` はコンボの段ごとに分けた型で、モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ。`Dash` は構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理し、後隙Bでのダッシュ攻撃キャンセル予約フラグ（`dashAttackQueued`）を持つが、遷移先の実装は #164 で行う |
 | [`Gravity`](../Ash2/src/Component/Gravity.hpp) | 重力の影響を受けるエンティティに付与する重力加速度 |
@@ -172,6 +172,7 @@ WorldPos { w, h, d }
 | [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity`+`Gravity` エンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h` を 0 にする）を適用 |
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（弾が存在する間、毎フレーム） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |
 | [`StaggerSystem::Update`](../Ash2/src/System/StaggerSystem.hpp) | フェーズ内（PlayerTestPhase、HitSystem の後） | `Stagger` を持つエンティティの残り時間を減算し `RectDrawable::size` を縮小、0 以下で `originalSize` に戻して除去する（暫定実装） |
+| [`StaminaSystem::Update`](../Ash2/src/System/StaminaSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の後） | `Player + Stamina + Motion` を持つエンティティのスタミナを回復する。Neutral 状態のみ `recoveryDelay` 秒の待機後に `(max - current) / 2 * dt` で回復し、端数は `accum` に積み立てて誤差を防ぐ |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画 |
 
 ---


### PR DESCRIPTION
## 変更概要

Issue #131 の対応。スタミナの消費と回復ロジックを実装した。

- 遠距離攻撃（`MakeRanged`）でスタミナを消費するよう実装。スタミナ不足時は発動しない
- `StaminaSystem` を新規追加。Neutral 状態のみ、最後の行動から 2 秒待機後に回復を開始する
- 回復式は `(max - current) / 2 × dt`（ピンチほど速く、満タン付近でゼロに漸近）
- 消費量・回復ディレイは `player.toml` で調整可能

## 実装上の判断

- 近距離攻撃はスタミナを消費しない（設計仕様に基づく）
- `Stamina` コンポーネントに `accum`（回復端数累積）と `recoveryTimer`（回復ディレイ計測）を追加した。どちらも `StaminaSystem` が内部管理する状態であり、外部から操作するものではない
- 満タン付近の微小誤差は `KFullThreshold = 0.99` で丸めて解消する