### PR TITLE
モーション遷移のデバッグログを追加

### DIFF
--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -1,8 +1,35 @@
+#include <Siv3D.hpp>
+
 #include "System/MotionSystem.hpp"
 
 #include "Component/Hitstop.hpp"
+#include "Debug.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/PlayerMotionSystem.hpp"
+
+#ifdef _DEBUG
+namespace {
+s3d::String MotionName(const Motion& m) {
+  return std::visit(
+      [](const auto& s) -> s3d::String {
+        using T = std::decay_t<decltype(s)>;
+        if constexpr (std::is_same_v<T, PlayerMotion::Neutral>)
+          return U"Neutral";
+        else if constexpr (std::is_same_v<T, PlayerMotion::Melee1>)
+          return U"Melee1";
+        else if constexpr (std::is_same_v<T, PlayerMotion::Melee2>)
+          return U"Melee2";
+        else if constexpr (std::is_same_v<T, PlayerMotion::Melee3>)
+          return U"Melee3";
+        else if constexpr (std::is_same_v<T, PlayerMotion::Ranged>)
+          return U"Ranged";
+        else if constexpr (std::is_same_v<T, PlayerMotion::Dash>)
+          return U"Dash";
+      },
+      m);
+}
+}  // namespace
+#endif
 
 void MotionSystem::Update(entt::registry& registry,
                           const FrameData& frameData) {
@@ -13,6 +40,7 @@ void MotionSystem::Update(entt::registry& registry,
         [&](auto& state) { return Tick(state, registry, entity, frameData); },
         motion);
     if (next.has_value()) {
+      APP_LOG(U"[Motion] " + MotionName(motion) + U" → " + MotionName(*next));
       registry.replace<Motion>(entity, *next);
     }
   }


### PR DESCRIPTION
## 変更概要

`MotionSystem::Update` にモーション遷移のデバッグログを追加した。

- `MotionSystem.cpp` に `#ifdef _DEBUG` で囲んだ `MotionName()` ヘルパーを追加
- モーション遷移が発生したタイミングのみ `APP_LOG` で `[Motion] A → B` 形式のログを出力
- 遷移の from/to でキャンセルの有無を判断できる（例: `Melee1 → Dash` = 後隙をダッシュでキャンセル）
- リリースビルドには影響なし