### PR TITLE
名前空間の統一：s3d:: 省略・std 関数を s3d 側に統一

### DIFF
--- a/.claude/rules/cpp.md
+++ b/.claude/rules/cpp.md
@@ -12,6 +12,14 @@ paths:
 新しい `.cpp` / `.hpp` ファイルを追加するときは、**ビルド前に** `Ash2.vcxproj` と `Ash2.vcxproj.filters` の編集も必要。
 
 
+## 名前空間
+
+`stdafx.h` の `NO_S3D_USING` は**無効のまま**維持する（`using namespace s3d;` を全体に適用）。
+
+s3d の型・関数は `s3d::` を省略して書く（`Vec2`、`Circle`、`Max` など）。
+
+`std` と `s3d` の両方に同等の関数がある場合は **s3d 側を優先**する（例: `std::max` → `Max`）。
+
 ## コメント
 
 `.cpp` / `.hpp` 共通のルール。

--- a/Ash2/src/Component/Attack.hpp
+++ b/Ash2/src/Component/Attack.hpp
@@ -15,7 +15,7 @@ struct Attack {
   entt::entity root = entt::null;
 
   /// 攻撃の生存期間中にヒット済みのターゲット（重複ヒット防止用）
-  s3d::HashSet<entt::entity> hitTargets;
+  HashSet<entt::entity> hitTargets;
 
   /// ヒット成立時に攻撃側・被弾側へ付与するヒットストップ時間（秒）
   double hitstopSec = 0.0;

--- a/Ash2/src/Component/Collider.hpp
+++ b/Ash2/src/Component/Collider.hpp
@@ -7,8 +7,8 @@
 /// radius
 struct Collider {
   /// WorldPos からのオフセット
-  s3d::Vec3 segmentStart;
+  Vec3 segmentStart;
   /// WorldPos からのオフセット
-  s3d::Vec3 segmentEnd;
+  Vec3 segmentEnd;
   double radius;
 };

--- a/Ash2/src/Component/Name.hpp
+++ b/Ash2/src/Component/Name.hpp
@@ -5,9 +5,9 @@
 struct Name {
   // NameLookup は構築・破棄シグナルでのみ同期されるため、構築後に value を
   // 変更すると対応がずれる
-  const s3d::String value;
+  const String value;
 
-  explicit Name(s3d::String v) : value(std::move(v)) {}
+  explicit Name(String v) : value(std::move(v)) {}
 
   Name(const Name&) = default;
 };

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -52,7 +52,7 @@ struct Dash {
   /// 再ダッシュへの遷移予約（後隙B開始時に発生）
   bool dashQueued = false;
   /// ダッシュ移動中に記録した最終方向ベクトル（正規化済み）
-  s3d::Vec2 lastDashDir = {1.0, 0.0};
+  Vec2 lastDashDir = {1.0, 0.0};
 };
 
 /// @brief ダッシュ攻撃中（構え・攻撃・後隙の3区間を持つ）
@@ -62,7 +62,7 @@ struct DashAttack {
   /// 攻撃判定の子エンティティ
   entt::entity hitboxEntity = entt::null;
   /// ダッシュ時の移動方向（突進フェーズに使用、正規化済み）
-  s3d::Vec2 dashDir = {1.0, 0.0};
+  Vec2 dashDir = {1.0, 0.0};
 };
 
 /// @brief 着地硬直中（空中アクションの接地検出から遷移する）

--- a/Ash2/src/Component/SpriteAnimation.hpp
+++ b/Ash2/src/Component/SpriteAnimation.hpp
@@ -4,8 +4,8 @@
 /// @brief スプライトアニメーションコンポーネント（per-entity、軽量）
 struct SpriteAnimation {
   /// AnimationDataRegistry のキー（アニメーション設定ファイル名由来）
-  s3d::String dataKey;
-  s3d::String currentClip;
+  String dataKey;
+  String currentClip;
   /// 現クリップ内の位相（秒）。[0, count/speed) の範囲にラップされる
   double elapsed = 0.0;
   /// スプライトは左向きがデフォルト。true のとき AnimationSystem が反転描画する

--- a/Ash2/src/Component/Stagger.hpp
+++ b/Ash2/src/Component/Stagger.hpp
@@ -11,5 +11,5 @@ struct Stagger {
   /// 合計時間（秒）。縮み量の正規化に使う
   double duration = 0.0;
   /// 付与前の RectDrawable::size
-  s3d::SizeF originalSize;
+  SizeF originalSize;
 };

--- a/Ash2/src/Config/AnimationData.cpp
+++ b/Ash2/src/Config/AnimationData.cpp
@@ -1,6 +1,6 @@
 #include "Config/AnimationData.hpp"
 
-AnimationData AnimationData::FromToml(const s3d::TOMLValue& toml) {
+AnimationData AnimationData::FromToml(const TOMLValue& toml) {
   const auto& off = toml[U"draw_offset"];
   AnimationData data{
       .textureKey = toml[U"texture"].getString(),

--- a/Ash2/src/Config/AnimationData.hpp
+++ b/Ash2/src/Config/AnimationData.hpp
@@ -13,16 +13,16 @@ struct AnimationClip {
 /// @brief アニメーション共有データ（エンティティ種別ごとに1つ）
 struct AnimationData {
   /// TextureAsset キー（例: `assets/images/player.png`）
-  s3d::String textureKey;
-  s3d::Size size;
+  String textureKey;
+  Size size;
   /// TextureDrawable::anchor が示す位置からのずれ
-  s3d::Vec2 drawOffset;
+  Vec2 drawOffset;
   /// クリップ名 → AnimationClip の対応表
-  s3d::HashTable<s3d::String, AnimationClip> clips;
+  HashTable<String, AnimationClip> clips;
 
   /// @brief TOML からアニメーションデータを生成する
-  [[nodiscard]] static AnimationData FromToml(const s3d::TOMLValue& toml);
+  [[nodiscard]] static AnimationData FromToml(const TOMLValue& toml);
 };
 
 /// @brief アニメーションデータレジストリ（registry.ctx() に格納）
-using AnimationDataRegistry = s3d::HashTable<s3d::String, AnimationData>;
+using AnimationDataRegistry = HashTable<String, AnimationData>;

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -1,6 +1,6 @@
 #include "PlayerConfig.hpp"
 
-PlayerConfig PlayerConfig::FromToml(const s3d::TOMLValue& toml) {
+PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
   const auto& m = toml[U"melee"];
   const auto& r = toml[U"ranged"];
   const auto& d = toml[U"dash"];

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -111,5 +111,5 @@ struct PlayerConfig {
   LandingConfig landing;
 
   /// @brief TOML からプレイヤー設定を生成する
-  [[nodiscard]] static PlayerConfig FromToml(const s3d::TOMLValue& toml);
+  [[nodiscard]] static PlayerConfig FromToml(const TOMLValue& toml);
 };

--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -26,38 +26,38 @@ class PhaseMaker : public IPhaseMaker {
 };
 
 /// @brief TOML 値から PhaseMaker<T> を生成する関数の型
-using PhaseLoader = std::function<IPhaseMaker::Ptr(const s3d::TOMLValue&)>;
+using PhaseLoader = std::function<IPhaseMaker::Ptr(const TOMLValue&)>;
 
 /// @brief 型 T に対する PhaseLoader を生成するヘルパー
 /// @tparam T IPhase を継承するフェーズクラス（T::Param を持つこと）
 /// @param parse TOML 値から T::Param を生成するラムダ
 template <typename T, typename F>
 PhaseLoader MakeLoader(F&& parse) {
-  return [p = std::forward<F>(parse)](const s3d::TOMLValue& step) {
+  return [p = std::forward<F>(parse)](const TOMLValue& step) {
     return std::make_shared<const PhaseMaker<T>>(p(step));
   };
 }
 
 /// @brief フェーズ名 → PhaseLoader のマップ
-const s3d::HashTable<s3d::String, PhaseLoader> kPhaseLoaders{
-    {U"player_test", MakeLoader<PlayerTestPhase>([](const s3d::TOMLValue&) {
+const HashTable<String, PhaseLoader> kPhaseLoaders{
+    {U"player_test", MakeLoader<PlayerTestPhase>([](const TOMLValue&) {
        return PlayerTestPhase::Param{};
      })},
-    {U"test_menu", MakeLoader<TestMenuPhase>([](const s3d::TOMLValue&) {
+    {U"test_menu", MakeLoader<TestMenuPhase>([](const TOMLValue&) {
        return TestMenuPhase::Param{};
      })},
     {U"animation_viewer",
-     MakeLoader<AnimationViewerPhase>([](const s3d::TOMLValue& step) {
+     MakeLoader<AnimationViewerPhase>([](const TOMLValue& step) {
        return AnimationViewerPhase::Param{
-           .dataKey = step[U"param"].get<s3d::String>(),
+           .dataKey = step[U"param"].get<String>(),
        };
      })},
-    {U"scenario", MakeLoader<ScenarioPhase>([](const s3d::TOMLValue& step) {
+    {U"scenario", MakeLoader<ScenarioPhase>([](const TOMLValue& step) {
        return ScenarioPhase::Param{
-           .sectionName = step[U"param"].get<s3d::String>(),
+           .sectionName = step[U"param"].get<String>(),
        };
      })},
-    {U"wait", MakeLoader<WaitPhase>([](const s3d::TOMLValue& step) {
+    {U"wait", MakeLoader<WaitPhase>([](const TOMLValue& step) {
        return WaitPhase::Param{
            .duration = step[U"duration"].get<double>(),
        };
@@ -66,15 +66,15 @@ const s3d::HashTable<s3d::String, PhaseLoader> kPhaseLoaders{
 
 /// @brief TOML の 1 ステップ値を ScenarioStep に変換する
 /// @note "make" アクションは別 Issue で対応予定のためエラーとする
-ScenarioStep ParseStep(const s3d::TOMLValue& step) {
-  const auto action = step[U"action"].get<s3d::String>();
+ScenarioStep ParseStep(const TOMLValue& step) {
+  const auto action = step[U"action"].get<String>();
 
   if (action == U"push" || action == U"reset") {
-    const auto phaseName = step[U"phase"].get<s3d::String>();
+    const auto phaseName = step[U"phase"].get<String>();
     const auto it = kPhaseLoaders.find(phaseName);
     if (it == kPhaseLoaders.end()) {
-      throw s3d::Error{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
-                       phaseName + U"\""};
+      throw Error{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
+                  phaseName + U"\""};
     }
     auto maker = it->second(step);
     if (action == U"push") {
@@ -84,22 +84,21 @@ ScenarioStep ParseStep(const s3d::TOMLValue& step) {
   }
 
   if (action == U"make") {
-    throw s3d::Error{
+    throw Error{
         U"ScenarioData::FromToml: \"make\" アクションは未対応です（Issue #67 "
         U"スコープ外）"};
   }
 
-  throw s3d::Error{U"ScenarioData::FromToml: 不明なアクション \"" + action +
-                   U"\""};
+  throw Error{U"ScenarioData::FromToml: 不明なアクション \"" + action + U"\""};
 }
 
 }  // namespace
 
-ScenarioData ScenarioData::FromToml(const s3d::TOMLValue& toml) {
+ScenarioData ScenarioData::FromToml(const TOMLValue& toml) {
   ScenarioData data;
 
   for (const auto& member : toml.tableView()) {
-    s3d::Array<ScenarioStep> steps;
+    Array<ScenarioStep> steps;
     for (const auto& step : member.value.tableArrayView()) {
       steps.push_back(ParseStep(step));
     }

--- a/Ash2/src/Config/ScenarioData.hpp
+++ b/Ash2/src/Config/ScenarioData.hpp
@@ -32,8 +32,8 @@ using ScenarioStep = std::variant<StepPush, StepReset>;
 /// @brief シナリオデータ（ロード時に全セクションを変換済み）
 struct ScenarioData {
   /// セクション名 → ステップ一覧のテーブル
-  s3d::HashTable<s3d::String, s3d::Array<ScenarioStep>> sections;
+  HashTable<String, Array<ScenarioStep>> sections;
 
   /// @brief TOML からシナリオデータを生成する
-  [[nodiscard]] static ScenarioData FromToml(const s3d::TOMLValue& toml);
+  [[nodiscard]] static ScenarioData FromToml(const TOMLValue& toml);
 };

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -47,18 +47,18 @@ void AnimationViewerPhase::onAfterPush(entt::registry& registry) {
 
 IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
                                                   const FrameData& frameData) {
-  if (s3d::KeyEscape.down()) {
+  if (KeyEscape.down()) {
     return PhaseCommand::Pop();
   }
 
   if (!m_clips.empty()) {
     bool changed = false;
-    if (s3d::KeyLeft.down()) {
+    if (KeyLeft.down()) {
       m_clipIndex = (m_clipIndex - 1 + static_cast<int>(m_clips.size())) %
                     static_cast<int>(m_clips.size());
       changed = true;
     }
-    if (s3d::KeyRight.down()) {
+    if (KeyRight.down()) {
       m_clipIndex = (m_clipIndex + 1) % static_cast<int>(m_clips.size());
       changed = true;
     }
@@ -71,7 +71,7 @@ IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
       }
     }
 
-    if (s3d::KeyF.down() && m_entity != entt::null) {
+    if (KeyF.down() && m_entity != entt::null) {
       auto* anim = registry.try_get<SpriteAnimation>(m_entity);
       if (anim) {
         anim->facingRight = !anim->facingRight;
@@ -81,7 +81,7 @@ IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
 
   AnimationSystem::Update(registry, frameData.dt);
 
-  s3d::Scene::SetBackground(s3d::ColorF{KBgBrightness});
+  Scene::SetBackground(ColorF{KBgBrightness});
   m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(KTitleX, KTitleY);
   if (!m_clips.empty()) {
     m_font(U"Clip [{}/{}]: {}"_fmt(m_clipIndex + 1, m_clips.size(),
@@ -89,7 +89,7 @@ IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
         .draw(KTitleX, KClipInfoY);
   }
   m_font(U"← → : clip  F : flip  Esc : back")
-      .draw(KTitleX, KHintY, s3d::Palette::Gray);
+      .draw(KTitleX, KHintY, Palette::Gray);
 
   return PhaseCommand::None();
 }

--- a/Ash2/src/Phase/AnimationViewerPhase.hpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.hpp
@@ -10,7 +10,7 @@ class AnimationViewerPhase : public IPhase {
   /// @brief AnimationViewerPhase の生成パラメータ
   struct Param {
     /// AnimationDataRegistry のキー（エンティティ種別名）
-    s3d::String dataKey;
+    String dataKey;
   };
 
   explicit AnimationViewerPhase(const Param& param);
@@ -28,11 +28,11 @@ class AnimationViewerPhase : public IPhase {
   static constexpr int KFontSize = 20;
 
   /// AnimationDataRegistry のキー
-  s3d::String m_dataKey;
+  String m_dataKey;
   /// 表示対象エンティティ
   entt::entity m_entity = entt::null;
   /// クリップ名の配列（ソート済み）
-  s3d::Array<s3d::String> m_clips;
+  Array<String> m_clips;
   int m_clipIndex = 0;
-  s3d::Font m_font{KFontSize};
+  Font m_font{KFontSize};
 };

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -31,8 +31,8 @@
 #include "System/StaminaSystem.hpp"
 
 constexpr double KDummyPosW = 150.0;
-constexpr s3d::SizeF KDummySize = {60.0, 80.0};
-constexpr s3d::ColorF KDummyColor = {0.8, 0.2, 0.2};
+constexpr SizeF KDummySize = {60.0, 80.0};
+constexpr ColorF KDummyColor = {0.8, 0.2, 0.2};
 constexpr double KDummyCapRadius = 30.0;
 constexpr double KDummyCapHeight = 80.0;
 constexpr int KDummyMaxHp = 100;
@@ -102,7 +102,7 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
     reloadPlayer(registry);
   }
 
-  if (s3d::KeyEscape.down()) {
+  if (KeyEscape.down()) {
     return PhaseCommand::Pop();
   }
 
@@ -110,7 +110,7 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
 }
 
 void PlayerTestPhase::applyHitReactions(entt::registry& registry,
-                                        const s3d::Array<HitPair>& hits) {
+                                        const Array<HitPair>& hits) {
   for (const auto& hit : hits) {
     const auto& attack = registry.get<Attack>(hit.attacker);
     if (attack.hitstopSec <= 0.0) continue;
@@ -132,7 +132,7 @@ void PlayerTestPhase::applyHitReactions(entt::registry& registry,
       if (auto* rect = std::get_if<RectDrawable>(drawable); rect != nullptr) {
         // 既にひるみ中なら originalSize を引き継ぎ、縮小済みサイズを
         // originalSize として上書きしてしまうのを防ぐ
-        s3d::SizeF originalSize = rect->size;
+        SizeF originalSize = rect->size;
         if (const auto* existing = registry.try_get<Stagger>(hit.target);
             existing != nullptr) {
           originalSize = existing->originalSize;

--- a/Ash2/src/Phase/PlayerTestPhase.hpp
+++ b/Ash2/src/Phase/PlayerTestPhase.hpp
@@ -33,8 +33,7 @@ class PlayerTestPhase : public IPhase {
   ///
   /// 本格的なリアクション設計は #132/#134 のスコープであり、ここでは
   /// 近接1段目の操作感確認に必要な最小限の暫定実装を行う。
-  void applyHitReactions(entt::registry& registry,
-                         const s3d::Array<HitPair>& hits);
+  void applyHitReactions(entt::registry& registry, const Array<HitPair>& hits);
 
   entt::entity m_playerRoot = entt::null;
   entt::entity m_dummyTarget = entt::null;

--- a/Ash2/src/Phase/ScenarioPhase.hpp
+++ b/Ash2/src/Phase/ScenarioPhase.hpp
@@ -9,7 +9,7 @@ class ScenarioPhase : public IPhase {
   /// @brief ScenarioPhase の生成パラメータ
   struct Param {
     /// 処理するシナリオセクション名
-    s3d::String sectionName;
+    String sectionName;
   };
 
   explicit ScenarioPhase(const Param& param);
@@ -22,6 +22,6 @@ class ScenarioPhase : public IPhase {
                                     const FrameData& frameData) override;
 
  private:
-  s3d::String m_sectionName;
+  String m_sectionName;
   size_t m_currentStep = 0;
 };

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -35,25 +35,25 @@ void TestMenuPhase::onAfterPush(entt::registry& /*registry*/) {
 
 IPhase::PhaseCommand TestMenuPhase::update(entt::registry& registry,
                                            const FrameData& /*frameData*/) {
-  if (s3d::KeyUp.down()) {
+  if (KeyUp.down()) {
     m_selectedIndex = (m_selectedIndex - 1 + static_cast<int>(m_items.size())) %
                       static_cast<int>(m_items.size());
   }
-  if (s3d::KeyDown.down()) {
+  if (KeyDown.down()) {
     m_selectedIndex = (m_selectedIndex + 1) % static_cast<int>(m_items.size());
   }
 
-  if (s3d::KeyEnter.down() && !m_items.empty()) {
+  if (KeyEnter.down() && !m_items.empty()) {
     auto phase = m_items[m_selectedIndex].create(registry);
     return PhaseCommand::Push(std::move(phase));
   }
 
-  s3d::Scene::SetBackground(s3d::ColorF{KBgBrightness});
+  Scene::SetBackground(ColorF{KBgBrightness});
   m_font(U"Test Menu").draw(KTitleX, KTitleY);
 
   for (int i = 0; std::cmp_less(i, m_items.size()); ++i) {
-    const s3d::ColorF color =
-        (i == m_selectedIndex) ? s3d::Palette::Yellow : s3d::Palette::White;
+    const ColorF color =
+        (i == m_selectedIndex) ? Palette::Yellow : Palette::White;
     m_font(m_items[i].label).draw(KItemX, KItemBaseY + i * KItemSpacing, color);
   }
 

--- a/Ash2/src/Phase/TestMenuPhase.hpp
+++ b/Ash2/src/Phase/TestMenuPhase.hpp
@@ -24,14 +24,14 @@ class TestMenuPhase : public IPhase {
   /// メニュー項目（表示名 + 生成ラムダ）
   struct MenuItem {
     /// 表示名
-    s3d::String label;
+    String label;
     /// フェーズ生成ラムダ
     std::function<std::unique_ptr<IPhase>(entt::registry&)> create;
   };
 
   static constexpr int KFontSize = 24;
 
-  s3d::Array<MenuItem> m_items;
+  Array<MenuItem> m_items;
   int m_selectedIndex = 0;
-  s3d::Font m_font{KFontSize};
+  Font m_font{KFontSize};
 };

--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <Siv3D.hpp>
 
-#include <algorithm>
 #include <entt/entt.hpp>
 
 #include "Component/Attack.hpp"
@@ -22,13 +21,13 @@ class HitSystem {
   /// @brief 攻撃側コライダーと被弾側コライダーの重なりを検出し、Hp
   /// にダメージを適用する
   /// @return このフレームで新たに成立したヒットの一覧
-  [[nodiscard]] static s3d::Array<HitPair> Update(entt::registry& registry);
+  [[nodiscard]] static Array<HitPair> Update(entt::registry& registry);
 
  private:
   /// @brief 線分を表す内部構造体
   struct Segment {
-    s3d::Vec3 start;
-    s3d::Vec3 end;
+    Vec3 start;
+    Vec3 end;
   };
 
   /// @brief 2線分間の最近接距離の二乗を返す
@@ -39,9 +38,9 @@ inline double HitSystem::SegmentDistSq(Segment segA, Segment segB) {
   // 線分の長さの二乗がこの値以下のとき点とみなす
   constexpr double KDegenerateThreshold = 1e-10;
 
-  const s3d::Vec3 d1 = segA.end - segA.start;
-  const s3d::Vec3 d2 = segB.end - segB.start;
-  const s3d::Vec3 r = segA.start - segB.start;
+  const Vec3 d1 = segA.end - segA.start;
+  const Vec3 d2 = segB.end - segB.start;
+  const Vec3 r = segA.start - segB.start;
   const double a = d1.dot(d1);
   const double e = d2.dot(d2);
   const double f = d2.dot(r);
@@ -53,33 +52,33 @@ inline double HitSystem::SegmentDistSq(Segment segA, Segment segB) {
     return r.dot(r);
   }
   if (a <= KDegenerateThreshold) {
-    t = std::clamp(f / e, 0.0, 1.0);
+    t = Clamp(f / e, 0.0, 1.0);
   } else {
     const double c = d1.dot(r);
     if (e <= KDegenerateThreshold) {
-      s = std::clamp(-c / a, 0.0, 1.0);
+      s = Clamp(-c / a, 0.0, 1.0);
     } else {
       const double b = d1.dot(d2);
       const double denom = a * e - b * b;
-      s = (denom != 0.0) ? std::clamp((b * f - c * e) / denom, 0.0, 1.0) : 0.0;
+      s = (denom != 0.0) ? Clamp((b * f - c * e) / denom, 0.0, 1.0) : 0.0;
       t = (b * s + f) / e;
       if (t < 0.0) {
         t = 0.0;
-        s = std::clamp(-c / a, 0.0, 1.0);
+        s = Clamp(-c / a, 0.0, 1.0);
       } else if (t > 1.0) {
         t = 1.0;
-        s = std::clamp((b - c) / a, 0.0, 1.0);
+        s = Clamp((b - c) / a, 0.0, 1.0);
       }
     }
   }
 
-  const s3d::Vec3 closest1 = segA.start + d1 * s;
-  const s3d::Vec3 closest2 = segB.start + d2 * t;
+  const Vec3 closest1 = segA.start + d1 * s;
+  const Vec3 closest2 = segB.start + d2 * t;
   return (closest1 - closest2).dot(closest1 - closest2);
 }
 
-inline s3d::Array<HitPair> HitSystem::Update(entt::registry& registry) {
-  s3d::Array<HitPair> hits;
+inline Array<HitPair> HitSystem::Update(entt::registry& registry) {
+  Array<HitPair> hits;
 
   auto attackers = registry.view<WorldPos, Collider, Attack>();
   auto targets =
@@ -90,18 +89,18 @@ inline s3d::Array<HitPair> HitSystem::Update(entt::registry& registry) {
     const auto rootEntity = (atk.root != entt::null) ? atk.root : attacker;
     auto& rootAtk = registry.get<Attack>(rootEntity);
 
-    const s3d::Vec3 worldA{aPos.w, aPos.h, aPos.d};
-    const s3d::Vec3 ap1 = worldA + aCol.segmentStart;
-    const s3d::Vec3 ap2 = worldA + aCol.segmentEnd;
+    const Vec3 worldA{aPos.w, aPos.h, aPos.d};
+    const Vec3 ap1 = worldA + aCol.segmentStart;
+    const Vec3 ap2 = worldA + aCol.segmentEnd;
 
     for (auto&& [target, tPos, tCol, hp] : targets.each()) {
       if (attacker == target) continue;
       if (rootEntity == target) continue;
       if (rootAtk.hitTargets.contains(target)) continue;
 
-      const s3d::Vec3 worldT{tPos.w, tPos.h, tPos.d};
-      const s3d::Vec3 tp1 = worldT + tCol.segmentStart;
-      const s3d::Vec3 tp2 = worldT + tCol.segmentEnd;
+      const Vec3 worldT{tPos.w, tPos.h, tPos.d};
+      const Vec3 tp1 = worldT + tCol.segmentStart;
+      const Vec3 tp2 = worldT + tCol.segmentEnd;
 
       const double sumR = aCol.radius + tCol.radius;
       if (SegmentDistSq(Segment{.start = ap1, .end = ap2},
@@ -109,7 +108,7 @@ inline s3d::Array<HitPair> HitSystem::Update(entt::registry& registry) {
         continue;
 
       rootAtk.hitTargets.emplace(target);
-      hp.current = std::max(0, hp.current - rootAtk.damage);
+      hp.current = Max(0, hp.current - rootAtk.damage);
       hits.push_back(HitPair{.attacker = rootEntity, .target = target});
     }
   }

--- a/Ash2/src/System/HudSystem.hpp
+++ b/Ash2/src/System/HudSystem.hpp
@@ -18,26 +18,25 @@ class HudSystem {
     constexpr double KStaminaBarY = 40.0;
     constexpr double KBarWidth = 200.0;
     constexpr double KBarHeight = 18.0;
-    constexpr s3d::ColorF KBgColor{0.2, 0.2, 0.2, 0.7};
-    constexpr s3d::ColorF KHpColor{0.2, 0.8, 0.2};
-    constexpr s3d::ColorF KStaminaColor{0.9, 0.8, 0.1};
+    constexpr ColorF KBgColor{0.2, 0.2, 0.2, 0.7};
+    constexpr ColorF KHpColor{0.2, 0.8, 0.2};
+    constexpr ColorF KStaminaColor{0.9, 0.8, 0.1};
 
     auto view = registry.view<const Player, const Hp, const Stamina>();
     for (const auto& [entity, hp, stamina] : view.each()) {
-      s3d::RectF{KBarX, KHpBarY, KBarWidth, KBarHeight}.draw(KBgColor);
+      RectF{KBarX, KHpBarY, KBarWidth, KBarHeight}.draw(KBgColor);
       if (hp.max > 0) {
         const double hpRatio =
-            s3d::Clamp(static_cast<double>(hp.current) / hp.max, 0.0, 1.0);
-        s3d::RectF{KBarX, KHpBarY, KBarWidth * hpRatio, KBarHeight}.draw(
-            KHpColor);
+            Clamp(static_cast<double>(hp.current) / hp.max, 0.0, 1.0);
+        RectF{KBarX, KHpBarY, KBarWidth * hpRatio, KBarHeight}.draw(KHpColor);
       }
 
-      s3d::RectF{KBarX, KStaminaBarY, KBarWidth, KBarHeight}.draw(KBgColor);
+      RectF{KBarX, KStaminaBarY, KBarWidth, KBarHeight}.draw(KBgColor);
       if (stamina.max > 0) {
-        const double staminaRatio = s3d::Clamp(
-            static_cast<double>(stamina.current) / stamina.max, 0.0, 1.0);
-        s3d::RectF{KBarX, KStaminaBarY, KBarWidth * staminaRatio, KBarHeight}
-            .draw(KStaminaColor);
+        const double staminaRatio =
+            Clamp(static_cast<double>(stamina.current) / stamina.max, 0.0, 1.0);
+        RectF{KBarX, KStaminaBarY, KBarWidth * staminaRatio, KBarHeight}.draw(
+            KStaminaColor);
       }
 
       // Player タグを持つエンティティは 1

--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -9,9 +9,9 @@
 
 #ifdef _DEBUG
 namespace {
-s3d::String MotionName(const Motion& m) {
+String MotionName(const Motion& m) {
   return std::visit(
-      [](const auto& s) -> s3d::String {
+      [](const auto& s) -> String {
         using T = std::decay_t<decltype(s)>;
         if constexpr (std::is_same_v<T, PlayerMotion::Neutral>)
           return U"Neutral";

--- a/Ash2/src/System/NameLookup.hpp
+++ b/Ash2/src/System/NameLookup.hpp
@@ -7,7 +7,7 @@
 #include "Component/Name.hpp"
 
 /// @brief 名前からエンティティへの参照を管理するコンテキスト
-using NameLookup = s3d::HashTable<s3d::String, entt::entity>;
+using NameLookup = HashTable<String, entt::entity>;
 
 namespace NameLookupSystem {
 

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -2,8 +2,6 @@
 
 #include "System/PlayerMotionSystem.hpp"
 
-#include <algorithm>
-
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
@@ -23,14 +21,14 @@ namespace PlayerMotion {
 
 namespace {
 
-constexpr s3d::ColorF KBulletColor = {0.9, 0.9, 0.3};
-constexpr s3d::ColorF KMeleeOrbColor = {1.0, 0.9, 0.5};
+constexpr ColorF KBulletColor = {0.9, 0.9, 0.3};
+constexpr ColorF KMeleeOrbColor = {1.0, 0.9, 0.5};
 /// 暫定のヒットストップ時間（秒）。本格的な数値調整は #132/#134 で行う
 constexpr double KMeleeHitstopSec = 0.05;
 
 /// @brief 指定クリップの再生時間（秒）を返す
 /// @return クリップが見つからない場合は 0.0
-double GetClipDuration(const AnimationData& data, const s3d::String& clip) {
+double GetClipDuration(const AnimationData& data, const String& clip) {
   const auto it = data.clips.find(clip);
   if (it == data.clips.end()) return 0.0;
   return static_cast<double>(it->second.count) / it->second.speed;
@@ -44,7 +42,7 @@ void StopHorizontalMovement(entt::registry& registry, entt::entity entity) {
 }
 
 /// @brief クリップが変化していれば差し替え、再生位置をリセットする
-void SetClip(SpriteAnimation& anim, const s3d::String& clip) {
+void SetClip(SpriteAnimation& anim, const String& clip) {
   if (clip != anim.currentClip) {
     anim.currentClip = clip;
     anim.elapsed = 0.0;
@@ -52,7 +50,7 @@ void SetClip(SpriteAnimation& anim, const s3d::String& clip) {
 }
 
 /// @brief クリップ名が同じでも再生位置を先頭へ強制的に戻す
-void RestartClip(SpriteAnimation& anim, const s3d::String& clip) {
+void RestartClip(SpriteAnimation& anim, const String& clip) {
   anim.currentClip = clip;
   anim.elapsed = 0.0;
 }
@@ -83,19 +81,18 @@ entt::entity SpawnMeleeHitbox(entt::registry& registry, entt::entity owner,
 
 /// @brief 攻撃フレーム内の珠の前方オフセット（プレイヤー相対）を返す
 /// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
-s3d::Vec3 MeleeOrbOffset(double progress, bool facingRight,
-                         const MeleeConfig& cfg) {
+Vec3 MeleeOrbOffset(double progress, bool facingRight, const MeleeConfig& cfg) {
   const double sign = facingRight ? 1.0 : -1.0;
-  const double eased = s3d::EaseOutQuad(std::clamp(progress, 0.0, 1.0));
+  const double eased = EaseOutQuad(Clamp(progress, 0.0, 1.0));
   return Vec3{sign * cfg.reach * eased, cfg.capMidH, 0.0};
 }
 
 /// @brief 2段目の攻撃フレーム内の珠オフセット（斬り上げ軌道）を返す
 /// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
-s3d::Vec3 MeleeSlashOffset(double progress, bool facingRight,
-                           const MeleeConfig& cfg) {
+Vec3 MeleeSlashOffset(double progress, bool facingRight,
+                      const MeleeConfig& cfg) {
   const double sign = facingRight ? 1.0 : -1.0;
-  const double eased = s3d::EaseOutQuad(std::clamp(progress, 0.0, 1.0));
+  const double eased = EaseOutQuad(Clamp(progress, 0.0, 1.0));
   const double horizontal = sign * cfg.reach * eased;
   const double vertical = cfg.capMidH + (eased - 0.5) * cfg.slashRiseHeight;
   return Vec3{horizontal, vertical, 0.0};
@@ -126,8 +123,7 @@ void UpdateMeleeHitbox(entt::registry& registry, entt::entity owner,
                        double elapsed, double activeStart, double activeEnd,
                        bool facingRight, const PlayerConfig& cfg,
                        entt::entity& hitboxEntity, double radius,
-                       s3d::Vec3 (*offsetFn)(double, bool,
-                                             const MeleeConfig&)) {
+                       Vec3 (*offsetFn)(double, bool, const MeleeConfig&)) {
   const auto& melee = cfg.melee;
 
   // 攻撃フレーム中（未生成ならここで生成する）：珠を前方へ EaseOut
@@ -179,7 +175,7 @@ Ranged MakeRanged(entt::registry& registry, entt::entity entity,
                   const PlayerConfig& cfg, const AnimationData& playerData,
                   SpriteAnimation& anim) {
   auto& stamina = registry.get<Stamina>(entity);
-  stamina.current = std::max(0, stamina.current - cfg.ranged.staminaCost);
+  stamina.current = Max(0, stamina.current - cfg.ranged.staminaCost);
   SetClip(anim, U"ranged_attack");
   return Ranged{.timer = GetClipDuration(playerData, U"ranged_attack")};
 }
@@ -191,7 +187,7 @@ Ranged MakeRanged(entt::registry& registry, entt::entity entity,
 Dash MakeDash(entt::registry& registry, entt::entity entity,
               const PlayerConfig& cfg, SpriteAnimation& anim) {
   auto& stamina = registry.get<Stamina>(entity);
-  stamina.current = std::max(0, stamina.current - cfg.dash.staminaCost);
+  stamina.current = Max(0, stamina.current - cfg.dash.staminaCost);
   SetClip(anim, U"move");
   return Dash{};
 }
@@ -201,15 +197,15 @@ Dash MakeDash(entt::registry& registry, entt::entity entity,
 ///
 /// Vec3 の x が w 軸（横）、z が d 軸（奥行き）、y が高さ固定（capMidH）。
 /// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
-s3d::Vec3 DashAttackOrbOffset(double progress, const PlayerConfig& cfg) {
-  const double angle = s3d::Math::TwoPi * progress;
+Vec3 DashAttackOrbOffset(double progress, const PlayerConfig& cfg) {
+  const double angle = Math::TwoPi * progress;
   const double r = cfg.dashAttack.orbitRadius;
   return Vec3{r * std::cos(angle), cfg.melee.capMidH, r * std::sin(angle)};
 }
 
 /// @brief DashAttack へ移行する
 /// @param dashDir ダッシュ時の移動方向（正規化済み）
-DashAttack MakeDashAttack(SpriteAnimation& anim, s3d::Vec2 dashDir) {
+DashAttack MakeDashAttack(SpriteAnimation& anim, Vec2 dashDir) {
   // 専用クリップ未用意のため "melee_1" を暫定流用する
   SetClip(anim, U"melee_1");
   return DashAttack{

--- a/Ash2/src/System/ProjectileSystem.cpp
+++ b/Ash2/src/System/ProjectileSystem.cpp
@@ -8,7 +8,7 @@ void ProjectileSystem::Update(entt::registry& registry) {
   const Vec2 cameraOffset = Scene::Center();
   const RectF screenRect = Scene::Rect();
 
-  s3d::Array<entt::entity> toDestroy;
+  Array<entt::entity> toDestroy;
 
   auto view = registry.view<Projectile, WorldPos, Attack>();
   for (auto&& [entity, pos, atk] : view.each()) {

--- a/Ash2/src/System/StaggerSystem.cpp
+++ b/Ash2/src/System/StaggerSystem.cpp
@@ -2,8 +2,6 @@
 
 #include "System/StaggerSystem.hpp"
 
-#include <cmath>
-
 #include "Component/Drawable.hpp"
 #include "Component/Stagger.hpp"
 
@@ -29,13 +27,12 @@ void StaggerSystem::Update(entt::registry& registry, double dt) {
 
     // duration の中間で最も縮み、両端（開始・終了）で原寸に近づく
     const double progress = stagger.remaining / stagger.duration;
-    const double shrink =
-        (1.0 - std::abs(progress * 2.0 - 1.0)) * KMaxShrinkRatio;
+    const double shrink = (1.0 - Abs(progress * 2.0 - 1.0)) * KMaxShrinkRatio;
     rect->size.y = stagger.originalSize.y * (1.0 - shrink);
   }
 
   // remaining <= 0 になったエンティティから Stagger を除去する
-  s3d::Array<entt::entity> expired;
+  Array<entt::entity> expired;
   for (const auto entity : view) {
     if (view.get<Stagger>(entity).remaining <= 0.0) {
       expired.push_back(entity);


### PR DESCRIPTION
#192 で決定した名前空間方針をコードに適用する。

- s3d:: プレフィックスを全ファイルで省略（using namespace s3d; に委ねる）
- std::max → Max、std::clamp → Clamp、std::abs → Abs に統一
- 不要になった include algorithm / include cmath を削除

変更対象は src/ 配下の .cpp / .hpp 26 ファイル。
