### PR TITLE
空中攻撃の実装 #187

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -42,6 +42,14 @@ orbit_radius = 50.0
 radius       = 25.0
 damage       = 25
 
+[air_attack]
+windup_sec   = 0.05
+active_sec   = 0.25
+recovery_sec = 0.20
+orbit_radius = 50.0
+radius       = 25.0
+damage       = 25
+
 [stamina]
 recovery_delay = 2.0
 recovery_rate  = 0.5

--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -4,7 +4,7 @@
 #include "Component/PlayerMotion.hpp"
 
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
-using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1,
-                            PlayerMotion::Melee2, PlayerMotion::Melee3,
-                            PlayerMotion::Ranged, PlayerMotion::Dash,
-                            PlayerMotion::DashAttack, PlayerMotion::Landing>;
+using Motion = std::variant<
+    PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2,
+    PlayerMotion::Melee3, PlayerMotion::Ranged, PlayerMotion::Dash,
+    PlayerMotion::DashAttack, PlayerMotion::AirAttack, PlayerMotion::Landing>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -65,6 +65,15 @@ struct DashAttack {
   Vec2 dashDir = {1.0, 0.0};
 };
 
+/// @brief 空中攻撃中（構え・攻撃・後隙の3区間を持ち、接地で Landing
+/// へ遷移する）
+struct AirAttack {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+  /// 攻撃判定の子エンティティ
+  entt::entity hitboxEntity = entt::null;
+};
+
 /// @brief 着地硬直中（空中アクションの接地検出から遷移する）
 struct Landing {
   /// 残り硬直時間（秒）

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -5,6 +5,7 @@ PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
   const auto& r = toml[U"ranged"];
   const auto& d = toml[U"dash"];
   const auto& da = toml[U"dash_attack"];
+  const auto& aa = toml[U"air_attack"];
   const auto& s = toml[U"stamina"];
   const auto& l = toml[U"landing"];
   return {
@@ -54,6 +55,15 @@ PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
               .orbitRadius = da[U"orbit_radius"].get<double>(),
               .radius = da[U"radius"].get<double>(),
               .damage = da[U"damage"].get<int>(),
+          },
+      .airAttack =
+          {
+              .windupSec = aa[U"windup_sec"].get<double>(),
+              .activeSec = aa[U"active_sec"].get<double>(),
+              .recoverySec = aa[U"recovery_sec"].get<double>(),
+              .orbitRadius = aa[U"orbit_radius"].get<double>(),
+              .radius = aa[U"radius"].get<double>(),
+              .damage = aa[U"damage"].get<int>(),
           },
       .stamina =
           {

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -81,6 +81,22 @@ struct DashAttackConfig {
   int damage;
 };
 
+/// @brief 空中攻撃の設定値
+struct AirAttackConfig {
+  /// 構え時間（秒）
+  double windupSec;
+  /// 攻撃判定が有効な時間（秒）
+  double activeSec;
+  /// 後隙時間（秒）
+  double recoverySec;
+  /// ヒットボックスの軌道半径（w-h 平面上の円）
+  double orbitRadius;
+  /// 攻撃カプセルの半径
+  double radius;
+  /// 与えるダメージ量
+  int damage;
+};
+
 /// @brief スタミナ回復の設定値
 struct StaminaConfig {
   /// 行動後に回復が始まるまでの待機秒数
@@ -107,6 +123,7 @@ struct PlayerConfig {
   RangedConfig ranged;
   DashConfig dash;
   DashAttackConfig dashAttack;
+  AirAttackConfig airAttack;
   StaminaConfig stamina;
   LandingConfig landing;
 

--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -27,6 +27,8 @@ String MotionName(const Motion& m) {
           return U"Dash";
         else if constexpr (std::is_same_v<T, PlayerMotion::DashAttack>)
           return U"DashAttack";
+        else if constexpr (std::is_same_v<T, PlayerMotion::AirAttack>)
+          return U"AirAttack";
         else if constexpr (std::is_same_v<T, PlayerMotion::Landing>)
           return U"Landing";
       },

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -212,6 +212,29 @@ DashAttack MakeDashAttack(SpriteAnimation& anim, Vec2 dashDir) {
       .elapsed = 0.0, .hitboxEntity = entt::null, .dashDir = dashDir};
 }
 
+/// @brief
+/// 攻撃フレーム内の進行度から空中攻撃の珠オフセット（垂直軌道）を返す
+///
+/// Vec3 の x が w 軸（横）、y が高さ（capMidH を中心に周回）、z は 0
+/// 固定。DashAttack の w-d 平面軌道に対し、こちらは w-h 平面（垂直面）を
+/// 周回する。回転方向はプレイヤーの向きに応じて左右反転する。
+/// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
+/// @param facingRight プレイヤーの向き（false なら w 成分の符号を反転）
+Vec3 AirAttackOrbOffset(double progress, const PlayerConfig& cfg,
+                        bool facingRight) {
+  const double angle = Math::TwoPi * progress;
+  const double r = cfg.airAttack.orbitRadius;
+  const double w = facingRight ? r * std::cos(angle) : -r * std::cos(angle);
+  return Vec3{w, cfg.melee.capMidH - r * std::sin(angle), 0.0};
+}
+
+/// @brief AirAttack へ移行する
+AirAttack MakeAirAttack(SpriteAnimation& anim) {
+  // 専用クリップ未用意のため "melee_1" を暫定流用する
+  SetClip(anim, U"melee_1");
+  return AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null};
+}
+
 }  // namespace
 
 std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
@@ -258,6 +281,11 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
         registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
       return MakeDash(registry, entity, cfg, anim);
     }
+  } else if (input.attackDown) {
+    // 空中攻撃への入場（AirAttack::Tick が接地検出で Landing へ遷移させる）
+    vel.w = 0.0;
+    vel.d = 0.0;
+    return MakeAirAttack(anim);
   }
 
   // ロコモーションクリップ（idle/move/jump）
@@ -522,6 +550,60 @@ std::optional<Motion> Tick(DashAttack& state, entt::registry& registry,
     anim.facingRight = false;
   }
 
+  if (state.elapsed >= recoveryEnd) {
+    return Neutral{};
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Motion> Tick(AirAttack& state, entt::registry& registry,
+                           entt::entity entity, const FrameData& frameData) {
+  StopHorizontalMovement(registry, entity);
+
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& aa = cfg.airAttack;
+  const auto& pos = registry.get<WorldPos>(entity);
+
+  const double activeStart = aa.windupSec;
+  const double activeEnd = aa.windupSec + aa.activeSec;
+  const double recoveryEnd = activeEnd + aa.recoverySec;
+
+  state.elapsed += frameData.dt;
+
+  // 接地検出は後隙中も含め毎フレーム優先して評価する（タイマー満了判定より先）
+  if (pos.isOnGround()) {
+    if (state.hitboxEntity != entt::null) {
+      Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
+      state.hitboxEntity = entt::null;
+    }
+    return Landing{.timer = cfg.landing.recoverySec};
+  }
+
+  // 攻撃判定区間：ヒットボックスの生成・軌道更新・後隙以降の破棄
+  if (state.elapsed >= activeStart && state.elapsed < activeEnd) {
+    if (state.hitboxEntity == entt::null) {
+      state.hitboxEntity =
+          SpawnMeleeHitbox(registry, entity, pos, cfg, aa.radius);
+      // Attack コンポーネントのダメージを空中攻撃用に上書きする
+      registry.get<Attack>(state.hitboxEntity).damage = aa.damage;
+    }
+
+    const double progress =
+        (state.elapsed - activeStart) / (activeEnd - activeStart);
+    const auto& anim = registry.get<SpriteAnimation>(entity);
+    const auto offset = AirAttackOrbOffset(progress, cfg, anim.facingRight);
+
+    auto& localOffset = registry.get<LocalOffset>(state.hitboxEntity);
+    localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
+  }
+
+  if (state.elapsed >= activeEnd && state.hitboxEntity != entt::null) {
+    Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
+    state.hitboxEntity = entt::null;
+  }
+
+  // 接地せずに終わった場合はタイマー満了で Neutral へ戻る
   if (state.elapsed >= recoveryEnd) {
     return Neutral{};
   }

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -63,6 +63,14 @@ namespace PlayerMotion {
                                          entt::entity entity,
                                          const FrameData& frameData);
 
+/// @brief AirAttack 状態の更新（垂直面の軌道上のヒットボックス管理・
+/// 接地で Landing へ遷移・後隙満了で Neutral へ戻る）
+/// @return 遷移先がある場合はその Motion、なければ std::nullopt
+[[nodiscard]] std::optional<Motion> Tick(AirAttack& state,
+                                         entt::registry& registry,
+                                         entt::entity entity,
+                                         const FrameData& frameData);
+
 /// @brief Landing 状態の更新（横移動停止・タイマー減算・満了で Neutral へ戻る）
 /// @return 遷移先がある場合はその Motion、なければ std::nullopt
 [[nodiscard]] std::optional<Motion> Tick(Landing& state,

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -53,6 +53,13 @@ void SetupContext(entt::registry& registry) {
                .recoveryASec = 0.15,
                .recoveryBSec = 0.15,
                .staminaCost = 20},
+      .airAttack = {.windupSec = 0.05,
+                    .activeSec = 0.25,
+                    .recoverySec = 0.20,
+                    .orbitRadius = 50.0,
+                    .radius = 20.0,
+                    .damage = 15},
+      .landing = {.recoverySec = 0.20},
   });
 
   AnimationDataRegistry animReg;
@@ -151,8 +158,10 @@ TEST_CASE("PlayerMotionSystem - no attack input keeps Neutral") {
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
 }
 
-TEST_CASE("PlayerMotionSystem - airborne player ignores attack input") {
-  // 空中にいる場合は攻撃入力を無視する
+TEST_CASE(
+    "PlayerMotionSystem - airborne player attack input transitions Neutral "
+    "to AirAttack") {
+  // 空中にいる場合は攻撃入力で AirAttack へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -161,6 +170,123 @@ TEST_CASE("PlayerMotionSystem - airborne player ignores attack input") {
   FrameData frameData{};
   frameData.input.attackDown = true;
 
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::AirAttack>(motion));
+
+  const auto& air = std::get<PlayerMotion::AirAttack>(motion);
+  REQUIRE(air.elapsed == Approx(0.0));
+  // 構え中（windupSec 未満）はヒットボックス未生成
+  REQUIRE(air.hitboxEntity == entt::entity{entt::null});
+
+  REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_1");
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirAttack spawns hitbox and moves along vertical "
+    "orbit during active frame") {
+  // 攻撃判定区間でヒットボックスが生成され、w-h 平面上の円軌道で移動する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 100.0;  // 空中（接地遷移を避ける）
+
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  // windupSec(0.05) を跨ぎ、activeSec(0.25) 中の進行度 0.25 地点まで進める
+  const FrameData frameData{.dt = 0.1125};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& air = std::get<PlayerMotion::AirAttack>(motion);
+  REQUIRE(air.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(air.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(air.hitboxEntity));
+
+  // 進行度0.25 → 円の頂点（w=0、h=capMidH(40.0)-orbitRadius(50.0)=-10.0）
+  const auto& localOffset = registry.get<LocalOffset>(air.hitboxEntity);
+  REQUIRE(localOffset.value.w == Approx(0.0).margin(0.001));
+  REQUIRE(localOffset.value.h == Approx(-10.0));
+  REQUIRE(localOffset.value.d == Approx(0.0));
+
+  const auto& attack = registry.get<Attack>(air.hitboxEntity);
+  REQUIRE(attack.damage == 15);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirAttack orbit mirrors horizontally when facing "
+    "left") {
+  // 左向きのとき w 成分の符号が反転する（progress 0.25 は cos=0 で符号の
+  // 影響を受けないため、progress 0.0 で検証する）
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 100.0;  // 空中（接地遷移を避ける）
+  registry.get<SpriteAnimation>(player).facingRight = false;
+
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null});
+
+  // windupSec(0.05) ちょうどまで進め、progress 0.0（w = -orbitRadius）にする
+  const FrameData frameData{.dt = 0.05};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& air = std::get<PlayerMotion::AirAttack>(motion);
+  REQUIRE(air.hitboxEntity != entt::entity{entt::null});
+
+  // 進行度0.0 → w = -orbitRadius(50.0)、h = capMidH(40.0)
+  const auto& localOffset = registry.get<LocalOffset>(air.hitboxEntity);
+  REQUIRE(localOffset.value.w == Approx(-50.0));
+  REQUIRE(localOffset.value.h == Approx(40.0));
+  REQUIRE(localOffset.value.d == Approx(0.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirAttack transitions to Landing when player "
+    "lands, destroying leftover hitbox") {
+  // 後隙中でも接地したら Landing へ強制遷移し、ヒットボックスは破棄される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 0.0;  // 接地
+
+  const auto hitbox = registry.create();
+  registry.emplace<LocalOffset>(hitbox);
+  registry.emplace<Collider>(hitbox);
+  registry.replace<Motion>(
+      player, PlayerMotion::AirAttack{.elapsed = 0.1, .hitboxEntity = hitbox});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Landing>(motion));
+  REQUIRE_FALSE(registry.valid(hitbox));
+
+  const auto& landing = std::get<PlayerMotion::Landing>(motion);
+  REQUIRE(landing.timer == Approx(0.20));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirAttack transitions to Neutral on recovery "
+    "timeout while still airborne") {
+  // 接地せずに後隙が満了した場合はタイマー満了で Neutral へ戻る
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 500.0;  // 十分な高さで着地しない
+
+  // recoveryEnd は windupSec+activeSec+recoverySec = 0.05+0.25+0.20 = 0.50
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::AirAttack{.elapsed = 0.49, .hitboxEntity = entt::null});
+
+  const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -55,12 +55,13 @@
 
 #### `Motion`
 
-エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, Landing>`）。
+エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, AirAttack, Landing>`）。
 
 - **Ranged**: 再生中クリップの残り時間を持つ
 - **Melee1 / Melee2 / Melee3**: コンボの段ごとに分けた型。モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ
 - **Dash**: 構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。ダッシュ中・後隙A・B中の攻撃入力（`attackDown`）でダッシュ攻撃を予約（`dashAttackQueued`）し、後隙B中に `DashAttack` へ遷移する。後隙B中のダッシュ入力（`dashDown`）は再ダッシュにキャンセルする。ダッシュ移動中の方向を `lastDashDir` に記録し `DashAttack::dashDir` へ引き渡す
 - **DashAttack**: 構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-d 平面の円軌道上で更新する
+- **AirAttack**: `Neutral` が空中（`!WorldPos::isOnGround()`）で攻撃入力を受けたときに入場する。構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-h 平面（垂直面）の円軌道上で更新する。後隙中も含め毎フレーム接地を検出し、接地した時点で（残っていればヒットボックスを破棄したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る。リアクション Lv2・スタミナ枯渇時の威力低下は `DashAttack` 同様に未実装（暫定のダメージ+ヒットストップのみ、本格対応は #134 のスコープ）
 - **Landing**: 着地硬直のタイマー状態。空中アクションの接地検出から遷移する
 
 ---


### PR DESCRIPTION
## 概要

Issue #187 の空中攻撃を実装する。空中の Neutral から攻撃入力で `PlayerMotion::AirAttack` に遷移し、光がプレイヤーの周りを垂直面（w-h 平面）で周回する。

## 変更内容

- `AirAttackConfig`（構え 0.05s / 攻撃 0.25s / 後隙 0.20s = 3F/15F/12F 相当）を追加し、`player.toml` の `[air_attack]` から読み込む
- `PlayerMotion::AirAttack` 状態と `Tick(AirAttack&)` を追加。ヒットボックスは攻撃区間中に垂直軌道で周回する
- 周回の回転方向はプレイヤーの向きに応じて反転する（ビジュアルチェック時のフィードバックによる仕様追加）
- 接地を毎フレーム検出し、後隙中も含め `Landing`（#186 着地硬直）へ強制遷移する。接地せず終わった場合はタイマー満了で Neutral へ戻る
- テスト追加: 入場・軌道（右向き・左向き）・接地→Landing 遷移・滞空タイムアウト→Neutral

## 実装判断

- 先行実装の `DashAttack` を雛形にした。差分は入場条件・軌道平面・接地遷移の3点のみ
- `Landing` へ遷移する際、生存中の `hitboxEntity` を `Hierarchy::DestroyWithChildren` で破棄してから遷移する（理由: ヒットボックスの破棄は各 Tick の activeEnd 判定でしか行われず、早期退出時に破棄しないと着地後も攻撃判定が残るため）
- 接地判定はタイマー満了判定より優先して評価する（後隙キャンセル不可だが接地遷移のみ許可という仕様のため）
- リアクション Lv2・スタミナ枯渇時の威力低下は未実装（`DashAttack` と同様の暫定ダメージ+ヒットストップのみ）。本格対応は #134 のスコープ（Issue コメントに記録済み）
- スタミナ消費なし（motion_design.md の表に記載がなく、`DashAttack` も消費しないため）

close #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)