### PR TITLE
空中ダッシュの実装 (#188)

### DIFF
--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -4,7 +4,8 @@
 #include "Component/PlayerMotion.hpp"
 
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
-using Motion = std::variant<
-    PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2,
-    PlayerMotion::Melee3, PlayerMotion::Ranged, PlayerMotion::Dash,
-    PlayerMotion::DashAttack, PlayerMotion::AirAttack, PlayerMotion::Landing>;
+using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1,
+                            PlayerMotion::Melee2, PlayerMotion::Melee3,
+                            PlayerMotion::Ranged, PlayerMotion::Dash,
+                            PlayerMotion::DashAttack, PlayerMotion::AirAttack,
+                            PlayerMotion::AirDash, PlayerMotion::Landing>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -74,6 +74,13 @@ struct AirAttack {
   entt::entity hitboxEntity = entt::null;
 };
 
+/// @brief 空中ダッシュ中（構え・ダッシュ・後隙A・後隙Bの4区間を持ち、
+/// 接地で Landing へ遷移する）
+struct AirDash {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+};
+
 /// @brief 着地硬直中（空中アクションの接地検出から遷移する）
 struct Landing {
   /// 残り硬直時間（秒）

--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -29,6 +29,8 @@ String MotionName(const Motion& m) {
           return U"DashAttack";
         else if constexpr (std::is_same_v<T, PlayerMotion::AirAttack>)
           return U"AirAttack";
+        else if constexpr (std::is_same_v<T, PlayerMotion::AirDash>)
+          return U"AirDash";
         else if constexpr (std::is_same_v<T, PlayerMotion::Landing>)
           return U"Landing";
       },

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -235,6 +235,18 @@ AirAttack MakeAirAttack(SpriteAnimation& anim) {
   return AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null};
 }
 
+/// @brief AirDash へ移行する（スタミナ消費、クリップの設定）
+///
+/// 基本仕様は Dash と同じ（motion_design.md）ため MakeDash 同様に dash
+/// 設定を流用する。
+AirDash MakeAirDash(entt::registry& registry, entt::entity entity,
+                    const PlayerConfig& cfg, SpriteAnimation& anim) {
+  auto& stamina = registry.get<Stamina>(entity);
+  stamina.current = Max(0, stamina.current - cfg.dash.staminaCost);
+  SetClip(anim, U"move");
+  return AirDash{};
+}
+
 }  // namespace
 
 std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
@@ -286,6 +298,10 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
     vel.w = 0.0;
     vel.d = 0.0;
     return MakeAirAttack(anim);
+  } else if (input.dashDown &&
+             registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
+    // 空中ダッシュへの入場（AirDash::Tick が接地検出で Landing へ遷移させる）
+    return MakeAirDash(registry, entity, cfg, anim);
   }
 
   // ロコモーションクリップ（idle/move/jump）
@@ -605,6 +621,61 @@ std::optional<Motion> Tick(AirAttack& state, entt::registry& registry,
 
   // 接地せずに終わった場合はタイマー満了で Neutral へ戻る
   if (state.elapsed >= recoveryEnd) {
+    return Neutral{};
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Motion> Tick(AirDash& state, entt::registry& registry,
+                           entt::entity entity, const FrameData& frameData) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& dash = cfg.dash;
+  const auto& input = frameData.input;
+  const auto& pos = registry.get<WorldPos>(entity);
+  auto& vel = registry.get<Velocity>(entity);
+  auto& anim = registry.get<SpriteAnimation>(entity);
+
+  const double dashStart = dash.windupSec;
+  const double dashEnd = dash.windupSec + dash.dashSec;
+  const double recoveryBEnd = dashEnd + dash.recoveryASec + dash.recoveryBSec;
+
+  state.elapsed += frameData.dt;
+
+  // 接地検出は後隙中も含め毎フレーム優先して評価する（タイマー満了判定より先）
+  if (pos.isOnGround()) {
+    registry.remove<Invincible>(entity);
+    return Landing{.timer = cfg.landing.recoverySec};
+  }
+
+  // 構え・ダッシュ中（後隙入り前）は無敵、後隙入りで除去する
+  if (state.elapsed < dashEnd) {
+    registry.emplace_or_replace<Invincible>(entity);
+  } else {
+    registry.remove<Invincible>(entity);
+  }
+
+  // ダッシュ移動中：フリー方向、無方向なら facingRight から前方
+  // 垂直速度は移動区間中 0 に固定する（重力の影響を受けない、暫定仕様）
+  if (state.elapsed >= dashStart && state.elapsed < dashEnd) {
+    vel.h = 0.0;
+    if (!input.moveAxis.isZero()) {
+      const Vec2 dir = input.moveAxis.normalized();
+      vel.w = dir.x * dash.speed;
+      vel.d = dir.y * dash.speed;
+    } else {
+      const double sign = anim.facingRight ? 1.0 : -1.0;
+      vel.w = sign * dash.speed;
+      vel.d = 0.0;
+    }
+  } else {
+    vel.w = 0.0;
+    vel.d = 0.0;
+  }
+
+  // 接地せずに終わった場合はタイマー満了で Neutral へ戻る
+  // （AirDash は再ダッシュ・ダッシュ攻撃キャンセルを持たない）
+  if (state.elapsed >= recoveryBEnd) {
     return Neutral{};
   }
 

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -71,6 +71,14 @@ namespace PlayerMotion {
                                          entt::entity entity,
                                          const FrameData& frameData);
 
+/// @brief AirDash 状態の更新（ダッシュ移動・無敵の付与/除去・
+/// 接地で Landing へ強制遷移）
+/// @return 遷移先がある場合はその Motion、なければ std::nullopt
+[[nodiscard]] std::optional<Motion> Tick(AirDash& state,
+                                         entt::registry& registry,
+                                         entt::entity entity,
+                                         const FrameData& frameData);
+
 /// @brief Landing 状態の更新（横移動停止・タイマー減算・満了で Neutral へ戻る）
 /// @return 遷移先がある場合はその Motion、なければ std::nullopt
 [[nodiscard]] std::optional<Motion> Tick(Landing& state,

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -1095,4 +1095,147 @@ TEST_CASE(
   REQUIRE_FALSE(registry.valid(hitbox));
 }
 
+TEST_CASE(
+    "PlayerMotionSystem - airborne player dash input transitions Neutral to "
+    "AirDash") {
+  // 空中でのダッシュ入力で Neutral から AirDash へ遷移し、ST が1回分消費される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;
+
+  FrameData frameData{};
+  frameData.input.dashDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::AirDash>(motion));
+  REQUIRE(std::get<PlayerMotion::AirDash>(motion).elapsed == Approx(0.0));
+
+  // dash.staminaCost(20) 分が消費される
+  REQUIRE(registry.get<Stamina>(player).current == 80);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - airborne dash input is ignored when stamina is "
+    "insufficient") {
+  // ST不足の場合は空中ダッシュ入力を無視し Neutral のまま、ST も減らない
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;
+  registry.get<Stamina>(player).current = 10;
+
+  FrameData frameData{};
+  frameData.input.dashDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+  REQUIRE(registry.get<Stamina>(player).current == 10);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash grants Invincible during windup and dash") {
+  // 構え・ダッシュ中（elapsed < dashEnd）は Invincible が付与される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
+
+  // dash.windupSec(0.0) + dash.dashSec(0.15) = 0.15 未満
+  registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.0});
+
+  const FrameData frameData{.dt = 0.1};
+  MotionSystem::Update(registry, frameData);
+
+  REQUIRE(registry.all_of<Invincible>(player));
+  REQUIRE(std::holds_alternative<PlayerMotion::AirDash>(
+      registry.get<Motion>(player)));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash removes Invincible when entering "
+    "recovery") {
+  // dashEnd(0.15) を超えた時点で Invincible が除去される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
+
+  registry.emplace<Invincible>(player);
+  registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.14});
+
+  const FrameData frameData{.dt = 0.02};
+  MotionSystem::Update(registry, frameData);
+
+  REQUIRE_FALSE(registry.all_of<Invincible>(player));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash fixes vertical velocity to zero during "
+    "dash movement") {
+  // ダッシュ移動区間中は垂直速度が 0 に固定される（暫定仕様）
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;    // 空中（接地遷移を避ける）
+  registry.get<Velocity>(player).h = -200.0;  // 落下中を模した垂直速度
+  registry.get<SpriteAnimation>(player).facingRight = true;
+
+  registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.0});
+
+  const FrameData frameData{.dt = 0.05};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& vel = registry.get<Velocity>(player);
+  REQUIRE(vel.h == Approx(0.0));
+  // dash.speed(500.0)
+  REQUIRE(vel.w == Approx(500.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash transitions to Landing when player lands") {
+  // 移動・後隙中いずれでも接地したら Landing へ強制遷移する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 0.0;  // 接地
+  registry.emplace<Invincible>(player);
+
+  registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.1});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Landing>(motion));
+  // 接地遷移時に Invincible が残らないよう除去される
+  REQUIRE_FALSE(registry.all_of<Invincible>(player));
+
+  const auto& landing = std::get<PlayerMotion::Landing>(motion);
+  REQUIRE(landing.timer == Approx(0.20));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash transitions to Neutral on recovery "
+    "timeout while still airborne") {
+  // 接地せずに後隙が満了した場合はタイマー満了で Neutral へ戻る
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 500.0;  // 十分な高さで着地しない
+
+  // recoveryBEnd は windupSec+dashSec+recoveryASec+recoveryBSec = 0.45
+  registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.44});
+
+  const FrameData frameData{.dt = 0.02};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
 #endif

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -55,13 +55,14 @@
 
 #### `Motion`
 
-エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, AirAttack, Landing>`）。
+エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, AirAttack, AirDash, Landing>`）。
 
 - **Ranged**: 再生中クリップの残り時間を持つ
 - **Melee1 / Melee2 / Melee3**: コンボの段ごとに分けた型。モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ
 - **Dash**: 構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。ダッシュ中・後隙A・B中の攻撃入力（`attackDown`）でダッシュ攻撃を予約（`dashAttackQueued`）し、後隙B中に `DashAttack` へ遷移する。後隙B中のダッシュ入力（`dashDown`）は再ダッシュにキャンセルする。ダッシュ移動中の方向を `lastDashDir` に記録し `DashAttack::dashDir` へ引き渡す
 - **DashAttack**: 構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-d 平面の円軌道上で更新する
 - **AirAttack**: `Neutral` が空中（`!WorldPos::isOnGround()`）で攻撃入力を受けたときに入場する。構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-h 平面（垂直面）の円軌道上で更新する。後隙中も含め毎フレーム接地を検出し、接地した時点で（残っていればヒットボックスを破棄したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る。リアクション Lv2・スタミナ枯渇時の威力低下は `DashAttack` 同様に未実装（暫定のダメージ+ヒットストップのみ、本格対応は #134 のスコープ）
+- **AirDash**: `Neutral` が空中（`!WorldPos::isOnGround()`）でダッシュ入力を受けたときに入場する。基本仕様は `Dash` と同じで `DashConfig` を流用し、構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。地上 `Dash` と異なり再ダッシュ・ダッシュ攻撃へのキャンセルは持たず（空中ダッシュ攻撃は #189 のスコープ）、ダッシュ移動区間中は垂直速度を 0 に固定して重力の影響を受けない（暫定仕様）。構え・ダッシュ中は `Invincible` を付与し後隙入りで除去する。後隙中も含め毎フレーム接地を検出し、接地した時点で（`Invincible` を除去したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る
 - **Landing**: 着地硬直のタイマー状態。空中アクションの接地検出から遷移する
 
 ---


### PR DESCRIPTION
## 概要

空中での高速移動アクション（空中ダッシュ）を実装する。close #188

## 変更内容

- 新しい Motion 状態 `AirDash` を追加（既存の `Dash` を踏襲、設定値は `DashConfig` を流用）
- 入場条件: 空中での `dashDown` 入力（スタミナ `staminaCost` 以上を要求・消費）
- キャンセル先: 接地時の `Landing` への強制遷移のみ（接地検出はタイマー満了より先に評価し、遷移前に `Invincible` を除去）
- 地上ダッシュにあった再ダッシュ・ダッシュ攻撃キャンセルは持たない
- テスト追加（入場・スタミナ不足時の拒否・無敵の付与/除去・垂直速度固定・接地遷移・後隙満了）
- `docs/REFERENCE.md` を更新

## 実装判断

- **垂直速度の扱い**: motion_design.md に空中ダッシュの垂直挙動の規定がないため、暫定でダッシュ移動区間中は垂直速度を 0 に固定（水平ダッシュ）とした。詳細は Issue #188 のコメントを参照
- **空中ダッシュ攻撃**: #189 のスコープのため本 PR では実装しない。攻撃予約フィールド等も未使用となるため追加せず、`AirDash` は `elapsed` のみの最小構成とした

🤖 Generated with [Claude Code](https://claude.com/claude-code)