### PR TITLE
std:: の使用箇所を s3d の同等品に統一

### DIFF
--- a/.claude/rules/cpp.md
+++ b/.claude/rules/cpp.md
@@ -18,7 +18,7 @@ paths:
 
 s3d の型・関数は `s3d::` を省略して書く（`Vec2`、`Circle`、`Max` など）。
 
-`std` と `s3d` の両方に同等の関数がある場合は **s3d 側を優先**する（例: `std::max` → `Max`）。
+`std` と `s3d` の両方に同等の型・関数がある場合は **s3d 側を優先**する（例: `std::max` → `Max`、`std::optional` → `Optional`）。
 
 ## コメント
 

--- a/Ash2/src/Component/Drawable.hpp
+++ b/Ash2/src/Component/Drawable.hpp
@@ -10,7 +10,7 @@ struct BorderStyle {
 };
 
 /// @brief WorldPos を描画形状内のどの点に合わせるか
-enum class DrawAnchor : std::uint8_t {
+enum class DrawAnchor : uint8 {
   /// 形状の中心
   Center,
   /// 形状の下端中央

--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -11,7 +11,7 @@ struct InputDeviceSelector {
   [[nodiscard]] InputState update();
 
  private:
-  enum class Device : std::uint8_t { Keyboard, Gamepad };
+  enum class Device : uint8 { Keyboard, Gamepad };
 
   /// キーボード/マウス入力アクション
   KeyboardInputAction m_keyboardAction = KeyboardInputAction::Default();

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -1,7 +1,6 @@
 #include "System/AnimationSystem.hpp"
 
 #include <cassert>
-#include <cmath>
 
 #include "Component/Drawable.hpp"
 #include "Component/Hitstop.hpp"
@@ -25,7 +24,7 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
     assert(clip.count > 0 && "clip.count は正の値でなければならない");
     assert(clip.speed > 0.0 && "clip.speed は正の値でなければならない");
     const double cycleDuration = clip.count / clip.speed;
-    anim.elapsed = std::fmod(anim.elapsed, cycleDuration);
+    anim.elapsed = Math::Fmod(anim.elapsed, cycleDuration);
     const int col = static_cast<int>(anim.elapsed * clip.speed) % clip.count;
     auto region = TextureAsset{data.textureKey}(
         col * data.size.x, clip.row * data.size.y, data.size.x, data.size.y);

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -200,7 +200,7 @@ Dash MakeDash(entt::registry& registry, entt::entity entity,
 Vec3 DashAttackOrbOffset(double progress, const PlayerConfig& cfg) {
   const double angle = Math::TwoPi * progress;
   const double r = cfg.dashAttack.orbitRadius;
-  return Vec3{r * std::cos(angle), cfg.melee.capMidH, r * std::sin(angle)};
+  return Vec3{r * Math::Cos(angle), cfg.melee.capMidH, r * Math::Sin(angle)};
 }
 
 /// @brief DashAttack へ移行する
@@ -224,8 +224,8 @@ Vec3 AirAttackOrbOffset(double progress, const PlayerConfig& cfg,
                         bool facingRight) {
   const double angle = Math::TwoPi * progress;
   const double r = cfg.airAttack.orbitRadius;
-  const double w = facingRight ? r * std::cos(angle) : -r * std::cos(angle);
-  return Vec3{w, cfg.melee.capMidH - r * std::sin(angle), 0.0};
+  const double w = facingRight ? r * Math::Cos(angle) : -r * Math::Cos(angle);
+  return Vec3{w, cfg.melee.capMidH - r * Math::Sin(angle), 0.0};
 }
 
 /// @brief AirAttack へ移行する
@@ -249,8 +249,8 @@ AirDash MakeAirDash(entt::registry& registry, entt::entity entity,
 
 }  // namespace
 
-std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   const auto& input = frameData.input;
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& playerData =
@@ -318,11 +318,11 @@ std::optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
     SetClip(anim, U"idle");
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(Melee1& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Melee1& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -360,11 +360,11 @@ std::optional<Motion> Tick(Melee1& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(Melee2& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Melee2& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -402,11 +402,11 @@ std::optional<Motion> Tick(Melee2& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(Melee3& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Melee3& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -428,11 +428,11 @@ std::optional<Motion> Tick(Melee3& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(Ranged& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Ranged& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   state.timer -= frameData.dt;
@@ -440,11 +440,11 @@ std::optional<Motion> Tick(Ranged& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(Dash& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Dash& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& dash = cfg.dash;
   const auto& input = frameData.input;
@@ -510,11 +510,11 @@ std::optional<Motion> Tick(Dash& state, entt::registry& registry,
     return MakeDash(registry, entity, cfg, anim);
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(DashAttack& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -570,11 +570,11 @@ std::optional<Motion> Tick(DashAttack& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(AirAttack& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -624,11 +624,11 @@ std::optional<Motion> Tick(AirAttack& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(AirDash& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(AirDash& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& dash = cfg.dash;
   const auto& input = frameData.input;
@@ -679,11 +679,11 @@ std::optional<Motion> Tick(AirDash& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
-std::optional<Motion> Tick(Landing& state, entt::registry& registry,
-                           entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(Landing& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
   StopHorizontalMovement(registry, entity);
 
   // 専用クリップ未用意のため "idle" を暫定流用
@@ -695,7 +695,7 @@ std::optional<Motion> Tick(Landing& state, entt::registry& registry,
     return Neutral{};
   }
 
-  return std::nullopt;
+  return none;
 }
 
 }  // namespace PlayerMotion

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <entt/entt.hpp>
-#include <optional>
 
 #include "Component/Motion.hpp"
 #include "Component/PlayerMotion.hpp"
@@ -11,79 +10,70 @@ namespace PlayerMotion {
 
 /// @brief Neutral 状態の更新（移動・ジャンプ・向き・クリップ決定、Melee/Ranged
 /// への入場判定）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Neutral& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Neutral& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief Melee1 状態の更新（横移動停止・タイマー減算・ヒットボックス管理・
 /// コンボ予約判定）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Melee1& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Melee1& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief Melee2 状態の更新（横移動停止・タイマー減算・ヒットボックス管理・
 /// コンボ予約判定）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Melee2& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Melee2& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief Melee3 状態の更新（横移動停止・タイマー減算・ヒットボックス管理、
 /// 締め技のためコンボ継続なし）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Melee3& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Melee3& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief Ranged 状態の更新（横移動停止・タイマー減算）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Ranged& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Ranged& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief Dash 状態の更新（移動・タイマー減算・無敵の付与/除去・
 /// 後隙Aからのダッシュ攻撃キャンセル予約・後隙B開始時の遷移）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Dash& state, entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Dash& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief DashAttack 状態の更新（突進・軌道上のヒットボックス管理・後隙満了で
 /// Neutral へ戻る）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(DashAttack& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief AirAttack 状態の更新（垂直面の軌道上のヒットボックス管理・
 /// 接地で Landing へ遷移・後隙満了で Neutral へ戻る）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(AirAttack& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief AirDash 状態の更新（ダッシュ移動・無敵の付与/除去・
 /// 接地で Landing へ強制遷移）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(AirDash& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(AirDash& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 /// @brief Landing 状態の更新（横移動停止・タイマー減算・満了で Neutral へ戻る）
-/// @return 遷移先がある場合はその Motion、なければ std::nullopt
-[[nodiscard]] std::optional<Motion> Tick(Landing& state,
-                                         entt::registry& registry,
-                                         entt::entity entity,
-                                         const FrameData& frameData);
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(Landing& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
 
 }  // namespace PlayerMotion


### PR DESCRIPTION
## 概要

Issue #196 対応。`std::` のうち s3d に同等品が存在するものを s3d 側に統一する（close #196）。

## 変更内容

- `PlayerMotionSystem.hpp` / `.cpp`: `Tick` 10 関数の戻り値を `std::optional<Motion>` → `Optional<Motion>`、`std::nullopt` → `none` に置換。`#include <optional>` を削除
- `PlayerMotionSystem.cpp`: 軌道計算（DashAttack / AirAttack）の `std::sin` / `std::cos` を `Math::Sin` / `Math::Cos` に置換
- `AnimationSystem.cpp`: `std::fmod` → `Math::Fmod` に置換し、`#include <cmath>` を削除
- `Drawable.hpp` / `InputDeviceSelector.hpp`: 列挙型の基底型を `std::uint8_t` → `uint8` に置換
- `.claude/rules/cpp.md`: 「同等の関数」→「同等の型・関数」に文言を拡張し、型にもルールが及ぶことを明確化

## 実装判断

- s3d の `Optional` は `has_value()` / `operator*` の互換インターフェースを持つため、呼び出し元 `MotionSystem.cpp` は変更していない
- `std::visit` / `std::variant` は s3d に同等品がないため対象外（Issue 記載どおり）
- 挙動を変えない純粋なリファクタリング。ビルド成功・全テスト通過（219 assertions / 95 test cases）を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)