### PR TITLE
空中ダッシュ攻撃の実装

### DIFF
--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -4,8 +4,8 @@
 #include "Component/PlayerMotion.hpp"
 
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
-using Motion = std::variant<PlayerMotion::Neutral, PlayerMotion::Melee1,
-                            PlayerMotion::Melee2, PlayerMotion::Melee3,
-                            PlayerMotion::Ranged, PlayerMotion::Dash,
-                            PlayerMotion::DashAttack, PlayerMotion::AirAttack,
-                            PlayerMotion::AirDash, PlayerMotion::Landing>;
+using Motion = std::variant<
+    PlayerMotion::Neutral, PlayerMotion::Melee1, PlayerMotion::Melee2,
+    PlayerMotion::Melee3, PlayerMotion::Ranged, PlayerMotion::Dash,
+    PlayerMotion::DashAttack, PlayerMotion::AirAttack, PlayerMotion::AirDash,
+    PlayerMotion::AirDashAttack, PlayerMotion::Landing>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -79,6 +79,21 @@ struct AirAttack {
 struct AirDash {
   /// モーション開始からの経過時間（秒）
   double elapsed = 0.0;
+  /// 空中ダッシュ攻撃への遷移予約（後隙B開始時に発生）
+  bool dashAttackQueued = false;
+  /// ダッシュ移動中に記録した最終方向ベクトル（正規化済み）
+  Vec2 lastDashDir = {1.0, 0.0};
+};
+
+/// @brief 空中ダッシュ攻撃中（構え・攻撃・後隙の3区間を持ち、
+/// 接地で Landing へ遷移する）
+struct AirDashAttack {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+  /// 攻撃判定の子エンティティ
+  entt::entity hitboxEntity = entt::null;
+  /// ダッシュ時の移動方向（突進フェーズに使用、正規化済み）
+  Vec2 dashDir = {1.0, 0.0};
 };
 
 /// @brief 着地硬直中（空中アクションの接地検出から遷移する）

--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -31,6 +31,8 @@ String MotionName(const Motion& m) {
           return U"AirAttack";
         else if constexpr (std::is_same_v<T, PlayerMotion::AirDash>)
           return U"AirDash";
+        else if constexpr (std::is_same_v<T, PlayerMotion::AirDashAttack>)
+          return U"AirDashAttack";
         else if constexpr (std::is_same_v<T, PlayerMotion::Landing>)
           return U"Landing";
       },

--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -247,6 +247,15 @@ AirDash MakeAirDash(entt::registry& registry, entt::entity entity,
   return AirDash{};
 }
 
+/// @brief AirDashAttack へ移行する
+/// @param dashDir ダッシュ時の移動方向（正規化済み）
+AirDashAttack MakeAirDashAttack(SpriteAnimation& anim, Vec2 dashDir) {
+  // 専用クリップ未用意のため "melee_1" を暫定流用する
+  SetClip(anim, U"melee_1");
+  return AirDashAttack{
+      .elapsed = 0.0, .hitboxEntity = entt::null, .dashDir = dashDir};
+}
+
 }  // namespace
 
 Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
@@ -638,7 +647,8 @@ Optional<Motion> Tick(AirDash& state, entt::registry& registry,
 
   const double dashStart = dash.windupSec;
   const double dashEnd = dash.windupSec + dash.dashSec;
-  const double recoveryBEnd = dashEnd + dash.recoveryASec + dash.recoveryBSec;
+  const double recoveryAEnd = dashEnd + dash.recoveryASec;
+  const double recoveryBEnd = recoveryAEnd + dash.recoveryBSec;
 
   state.elapsed += frameData.dt;
 
@@ -657,25 +667,110 @@ Optional<Motion> Tick(AirDash& state, entt::registry& registry,
 
   // ダッシュ移動中：フリー方向、無方向なら facingRight から前方
   // 垂直速度は移動区間中 0 に固定する（重力の影響を受けない、暫定仕様）
+  // 移動中に方向ベクトルを lastDashDir へ記録する（後隙では vel
+  // がゼロになるため後隙より前に必ず記録を終える）
   if (state.elapsed >= dashStart && state.elapsed < dashEnd) {
     vel.h = 0.0;
     if (!input.moveAxis.isZero()) {
       const Vec2 dir = input.moveAxis.normalized();
       vel.w = dir.x * dash.speed;
       vel.d = dir.y * dash.speed;
+      state.lastDashDir = dir;
     } else {
       const double sign = anim.facingRight ? 1.0 : -1.0;
       vel.w = sign * dash.speed;
       vel.d = 0.0;
+      state.lastDashDir = Vec2{sign, 0.0};
     }
   } else {
     vel.w = 0.0;
     vel.d = 0.0;
   }
 
-  // 接地せずに終わった場合はタイマー満了で Neutral へ戻る
-  // （AirDash は再ダッシュ・ダッシュ攻撃キャンセルを持たない）
+  // 後隙B終了時：常に Neutral へ戻る（AirDashAttack 遷移より先に評価する）
   if (state.elapsed >= recoveryBEnd) {
+    return Neutral{};
+  }
+
+  // 後隙B中：前フレームまでに予約済みなら空中ダッシュ攻撃へ遷移
+  // 入力受付より先に評価することで、今フレームの入力は次フレーム以降に発動する
+  if (state.elapsed >= recoveryAEnd && state.dashAttackQueued) {
+    return MakeAirDashAttack(anim, state.lastDashDir);
+  }
+
+  // ダッシュ中・後隙A・B中の攻撃入力で遷移を予約する
+  // （AirDashAttack チェック後に評価）
+  if (state.elapsed >= dashStart && input.attackDown) {
+    state.dashAttackQueued = true;
+  }
+
+  return none;
+}
+
+Optional<Motion> Tick(AirDashAttack& state, entt::registry& registry,
+                      entt::entity entity, const FrameData& frameData) {
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& da = cfg.dashAttack;
+  const auto& pos = registry.get<WorldPos>(entity);
+  auto& vel = registry.get<Velocity>(entity);
+  auto& anim = registry.get<SpriteAnimation>(entity);
+
+  const double activeStart = da.windupSec;
+  const double activeEnd = da.windupSec + da.activeSec;
+  const double recoveryEnd = activeEnd + da.recoverySec;
+
+  state.elapsed += frameData.dt;
+
+  // 接地検出は後隙中も含め毎フレーム優先して評価する（タイマー満了判定より先）
+  if (pos.isOnGround()) {
+    if (state.hitboxEntity != entt::null) {
+      Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
+      state.hitboxEntity = entt::null;
+    }
+    return Landing{.timer = cfg.landing.recoverySec};
+  }
+
+  // 攻撃判定区間：ヒットボックスの生成・軌道更新・後隙以降の破棄
+  if (state.elapsed >= activeStart && state.elapsed < activeEnd) {
+    if (state.hitboxEntity == entt::null) {
+      state.hitboxEntity =
+          SpawnMeleeHitbox(registry, entity, pos, cfg, da.radius);
+      // Attack コンポーネントのダメージをダッシュ攻撃用に上書きする
+      registry.get<Attack>(state.hitboxEntity).damage = da.damage;
+    }
+
+    const double progress =
+        (state.elapsed - activeStart) / (activeEnd - activeStart);
+    const auto offset = DashAttackOrbOffset(progress, cfg);
+
+    auto& localOffset = registry.get<LocalOffset>(state.hitboxEntity);
+    localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
+  }
+
+  if (state.elapsed >= activeEnd && state.hitboxEntity != entt::null) {
+    Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
+    state.hitboxEntity = entt::null;
+  }
+
+  // 突進フェーズ（構え）：ダッシュ方向へ移動
+  // 垂直速度は AirDash の暫定仕様に合わせ 0 に固定する（重力の影響を受けない）
+  if (state.elapsed < activeStart) {
+    vel.w = state.dashDir.x * da.speed;
+    vel.d = state.dashDir.y * da.speed;
+    vel.h = 0.0;
+  } else {
+    vel.w = 0.0;
+    vel.d = 0.0;
+  }
+
+  if (state.dashDir.x > 0.0) {
+    anim.facingRight = true;
+  } else if (state.dashDir.x < 0.0) {
+    anim.facingRight = false;
+  }
+
+  // 接地せずに終わった場合はタイマー満了で Neutral へ戻る
+  if (state.elapsed >= recoveryEnd) {
     return Neutral{};
   }
 

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -64,9 +64,19 @@ namespace PlayerMotion {
                                     const FrameData& frameData);
 
 /// @brief AirDash 状態の更新（ダッシュ移動・無敵の付与/除去・
-/// 接地で Landing へ強制遷移）
+/// 接地で Landing へ強制遷移・後隙Bからの空中ダッシュ攻撃キャンセル予約・
+/// 後隙B開始時の遷移）
 /// @return 遷移先がある場合はその Motion、なければ none
 [[nodiscard]] Optional<Motion> Tick(AirDash& state, entt::registry& registry,
+                                    entt::entity entity,
+                                    const FrameData& frameData);
+
+/// @brief AirDashAttack 状態の更新（突進・w-d
+/// 平面の軌道上のヒットボックス管理・接地で Landing へ遷移・
+/// 後隙満了で Neutral へ戻る）
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(AirDashAttack& state,
+                                    entt::registry& registry,
                                     entt::entity entity,
                                     const FrameData& frameData);
 

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -53,6 +53,13 @@ void SetupContext(entt::registry& registry) {
                .recoveryASec = 0.15,
                .recoveryBSec = 0.15,
                .staminaCost = 20},
+      .dashAttack = {.windupSec = 0.05,
+                     .activeSec = 0.20,
+                     .recoverySec = 0.20,
+                     .speed = 600.0,
+                     .orbitRadius = 30.0,
+                     .radius = 20.0,
+                     .damage = 20},
       .airAttack = {.windupSec = 0.05,
                     .activeSec = 0.25,
                     .recoverySec = 0.20,
@@ -1230,6 +1237,140 @@ TEST_CASE(
 
   // recoveryBEnd は windupSec+dashSec+recoveryASec+recoveryBSec = 0.45
   registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.44});
+
+  const FrameData frameData{.dt = 0.02};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash queues air dash attack on attack input "
+    "during recovery B") {
+  // 後隙B中（recoveryAEnd 以降）の近接攻撃入力で dashAttackQueued が立つ
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
+
+  // dashEnd(0.15) + recoveryASec(0.15) = 0.30 が recoveryAEnd
+  registry.replace<Motion>(player, PlayerMotion::AirDash{.elapsed = 0.29});
+
+  FrameData frameData{.dt = 0.02};
+  frameData.input.attackDown = true;
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::AirDash>(motion));
+  REQUIRE(std::get<PlayerMotion::AirDash>(motion).dashAttackQueued);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDash transitions to AirDashAttack when "
+    "dashAttackQueued at recovery A end") {
+  // 後隙A終了時に予約済みなら空中ダッシュ攻撃へ遷移し、方向を引き継ぐ
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
+
+  // recoveryAEnd(0.30) を跨ぐ dt
+  registry.replace<Motion>(
+      player, PlayerMotion::AirDash{.elapsed = 0.29,
+                                    .dashAttackQueued = true,
+                                    .lastDashDir = Vec2{0.0, 1.0}});
+
+  const FrameData frameData{.dt = 0.02};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::AirDashAttack>(motion));
+
+  const auto& airDashAttack = std::get<PlayerMotion::AirDashAttack>(motion);
+  REQUIRE(airDashAttack.elapsed == Approx(0.0));
+  REQUIRE(airDashAttack.hitboxEntity == entt::entity{entt::null});
+  REQUIRE(airDashAttack.dashDir.x == Approx(0.0));
+  REQUIRE(airDashAttack.dashDir.y == Approx(1.0));
+
+  REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_1");
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDashAttack spawns hitbox and moves along w-d "
+    "orbit during active frame") {
+  // 攻撃判定区間でヒットボックスが生成され、w-d 平面上の円軌道で移動する
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 100.0;  // 空中（接地遷移を避ける）
+
+  registry.replace<Motion>(
+      player, PlayerMotion::AirDashAttack{.elapsed = 0.0,
+                                          .hitboxEntity = entt::null,
+                                          .dashDir = Vec2{1.0, 0.0}});
+
+  // windupSec(0.05) を跨ぎ、activeSec(0.20) 中の進行度 0.25 地点まで進める
+  const FrameData frameData{.dt = 0.10};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& airDashAttack = std::get<PlayerMotion::AirDashAttack>(motion);
+  REQUIRE(airDashAttack.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(airDashAttack.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(
+      airDashAttack.hitboxEntity));
+
+  // 進行度0.25 → 円上の点（w=0、h=capMidH(40.0)、d=orbitRadius(30.0)）
+  const auto& localOffset =
+      registry.get<LocalOffset>(airDashAttack.hitboxEntity);
+  REQUIRE(localOffset.value.w == Approx(0.0).margin(0.001));
+  REQUIRE(localOffset.value.h == Approx(40.0));
+  REQUIRE(localOffset.value.d == Approx(30.0));
+
+  const auto& attack = registry.get<Attack>(airDashAttack.hitboxEntity);
+  REQUIRE(attack.damage == 20);
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDashAttack transitions to Landing when player "
+    "lands, destroying leftover hitbox") {
+  // 後隙中でも接地したら Landing へ強制遷移し、ヒットボックスは破棄される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 0.0;  // 接地
+
+  const auto hitbox = registry.create();
+  registry.emplace<LocalOffset>(hitbox);
+  registry.emplace<Collider>(hitbox);
+  registry.replace<Motion>(player, PlayerMotion::AirDashAttack{
+                                       .elapsed = 0.1, .hitboxEntity = hitbox});
+
+  const FrameData frameData{.dt = 0.01};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Landing>(motion));
+  REQUIRE_FALSE(registry.valid(hitbox));
+
+  const auto& landing = std::get<PlayerMotion::Landing>(motion);
+  REQUIRE(landing.timer == Approx(0.20));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - AirDashAttack transitions to Neutral on recovery "
+    "timeout while still airborne") {
+  // 接地せずに後隙が満了した場合はタイマー満了で Neutral へ戻る
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 500.0;  // 十分な高さで着地しない
+
+  // recoveryEnd は windupSec+activeSec+recoverySec = 0.05+0.20+0.20 = 0.45
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::AirDashAttack{.elapsed = 0.44, .hitboxEntity = entt::null});
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -55,14 +55,15 @@
 
 #### `Motion`
 
-エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, AirAttack, AirDash, Landing>`）。
+エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, AirAttack, AirDash, AirDashAttack, Landing>`）。
 
 - **Ranged**: 再生中クリップの残り時間を持つ
 - **Melee1 / Melee2 / Melee3**: コンボの段ごとに分けた型。モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ
 - **Dash**: 構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。ダッシュ中・後隙A・B中の攻撃入力（`attackDown`）でダッシュ攻撃を予約（`dashAttackQueued`）し、後隙B中に `DashAttack` へ遷移する。後隙B中のダッシュ入力（`dashDown`）は再ダッシュにキャンセルする。ダッシュ移動中の方向を `lastDashDir` に記録し `DashAttack::dashDir` へ引き渡す
 - **DashAttack**: 構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-d 平面の円軌道上で更新する
 - **AirAttack**: `Neutral` が空中（`!WorldPos::isOnGround()`）で攻撃入力を受けたときに入場する。構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-h 平面（垂直面）の円軌道上で更新する。後隙中も含め毎フレーム接地を検出し、接地した時点で（残っていればヒットボックスを破棄したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る。リアクション Lv2・スタミナ枯渇時の威力低下は `DashAttack` 同様に未実装（暫定のダメージ+ヒットストップのみ、本格対応は #134 のスコープ）
-- **AirDash**: `Neutral` が空中（`!WorldPos::isOnGround()`）でダッシュ入力を受けたときに入場する。基本仕様は `Dash` と同じで `DashConfig` を流用し、構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。地上 `Dash` と異なり再ダッシュ・ダッシュ攻撃へのキャンセルは持たず（空中ダッシュ攻撃は #189 のスコープ）、ダッシュ移動区間中は垂直速度を 0 に固定して重力の影響を受けない（暫定仕様）。構え・ダッシュ中は `Invincible` を付与し後隙入りで除去する。後隙中も含め毎フレーム接地を検出し、接地した時点で（`Invincible` を除去したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る
+- **AirDash**: `Neutral` が空中（`!WorldPos::isOnGround()`）でダッシュ入力を受けたときに入場する。基本仕様は `Dash` と同じで `DashConfig` を流用し、構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。地上 `Dash` と異なり再ダッシュへのキャンセルは持たないが、地上 `Dash` と同じパターンでダッシュ中・後隙A・B中の攻撃入力（`attackDown`）で空中ダッシュ攻撃を予約（`dashAttackQueued`）し、後隙B中に `AirDashAttack` へ遷移する。ダッシュ移動区間中は垂直速度を 0 に固定して重力の影響を受けず（暫定仕様）、移動中の方向を `lastDashDir` に記録し `AirDashAttack::dashDir` へ引き渡す。構え・ダッシュ中は `Invincible` を付与し後隙入りで除去する。後隙中も含め毎フレーム接地を検出し、接地した時点で（`Invincible` を除去したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る
+- **AirDashAttack**: `AirDash` の後隙B中に空中ダッシュ攻撃の入力を予約すると遷移する。構え・攻撃・後隙の3区間を持ち、設定値は地上 `DashAttack` と共通の `DashAttackConfig`（`cfg.dashAttack`）を流用する。攻撃判定（`hitboxEntity`）は `DashAttack` と同じ w-d 平面の円軌道上で更新する。突進フェーズ（構え）中は `AirDash` の暫定仕様に合わせ垂直速度を 0 に固定する。後隙中も含め毎フレーム接地を検出し、接地した時点で（残っていればヒットボックスを破棄したうえで）`Landing` へ強制遷移する。接地せずに後隙が満了した場合はタイマー満了で `Neutral` へ戻る。`Invincible` は付与しない（地上 `DashAttack` と同様）
 - **Landing**: 着地硬直のタイマー状態。空中アクションの接地検出から遷移する
 
 ---


### PR DESCRIPTION
## 概要

空中ダッシュからの攻撃アクション（空中ダッシュ攻撃）を実装する。close #189

## 変更内容

- `PlayerMotion::AirDashAttack` を新規追加し、`Motion` variant に登録
- `AirDash` に攻撃入力の予約フラグ（`dashAttackQueued`）と方向記録（`lastDashDir`）を追加し、後隙B開始時に `AirDashAttack` へ遷移
- 接地時は着地硬直（`Landing`）へ強制遷移（ヒットボックスが残っていれば破棄）
- テスト5件追加（入場予約・遷移と方向引き継ぎ・ヒットボックス生成と軌道・接地時の破棄と Landing 遷移・後隙満了で Neutral 遷移）
- `docs/REFERENCE.md` を更新

## 技術選択の理由

- 設定値・ヒットボックス軌道は地上ダッシュ攻撃と共通のため、既存の `DashAttackConfig` と `DashAttackOrbOffset` を再利用し、新しい TOML キーは追加していない
- 突進フェーズ中の垂直速度は `AirDash` の暫定仕様に合わせて 0 固定とした（motion_design.md に空中ダッシュ攻撃中の垂直速度の規定がないため）
- 無敵（`Invincible`）は付与しない（地上ダッシュ攻撃と同様、motion_design.md にも規定なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)