### PR TITLE
InputDeviceSelector のデバイス切替判定に X ボタンを追加

### DIFF
--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -30,7 +30,8 @@ inline InputState InputDeviceSelector::update() {
       (XInput(0).buttonUp.down() || XInput(0).buttonDown.down() ||
        XInput(0).buttonLeft.down() || XInput(0).buttonRight.down() ||
        XInput(0).buttonA.down() || XInput(0).buttonB.down() ||
-       XInput(0).buttonY.down() || !stickAxis.isZero())) {
+       XInput(0).buttonX.down() || XInput(0).buttonY.down() ||
+       !stickAxis.isZero())) {
     m_activeDevice = Device::Gamepad;
   } else if (!Keyboard::GetAllInputs().isEmpty() ||
              !Mouse::GetAllInputs().isEmpty()) {


### PR DESCRIPTION
## 概要

Issue #201 の修正。`InputDeviceSelector::update` のゲームパッド切り替え条件に `XInput(0).buttonX.down()` を追加する。

## 背景

`XInputAction::ToInputState` では `buttonX` が遠距離攻撃（rangedAttackDown）にマップ済みだが、`InputDeviceSelector` の切り替え条件にだけ `buttonX` が抜けていた。そのためキーボードがアクティブな状態でゲームパッドの X ボタンを押してもデバイスが切り替わらず、遠距離攻撃入力が無視されていた。

## 変更内容

- `Ash2/src/Input/InputDeviceSelector.hpp`: 切り替え条件の OR 列に `XInput(0).buttonX.down()` を1項追加（一行修正）

## 確認

- format / tidy / build / test すべて通過
- コントローラー実機で、キーボードアクティブ状態から X ボタンでデバイスが切り替わり遠距離攻撃が発動することを確認済み

close #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)