### PR TITLE
同一フレームのジャンプ＋攻撃/ダッシュ入力で地上専用モーションが上昇しながら発動する不具合を修正

### DIFF
--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -272,10 +272,6 @@ Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
   vel.w = input.moveAxis.x * cfg.speed;
   vel.d = input.moveAxis.y * cfg.speed;
 
-  if (input.jumpDown && pos.isOnGround()) {
-    vel.h = cfg.jumpSpeed;
-  }
-
   if (vel.w > 0.0) {
     anim.facingRight = true;
   } else if (vel.w < 0.0) {
@@ -311,6 +307,10 @@ Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
              registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
     // 空中ダッシュへの入場（AirDash::Tick が接地検出で Landing へ遷移させる）
     return MakeAirDash(registry, entity, cfg, anim);
+  }
+
+  if (input.jumpDown && pos.isOnGround()) {
+    vel.h = cfg.jumpSpeed;
   }
 
   // ロコモーションクリップ（idle/move/jump）

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -315,6 +315,63 @@ TEST_CASE("PlayerMotionSystem - jump input immediately switches to jump clip") {
   REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"jump");
 }
 
+TEST_CASE(
+    "PlayerMotionSystem - simultaneous jump and melee attack input "
+    "transitions to Melee1 without vertical velocity") {
+  // 同一フレームのジャンプ＋近接攻撃入力は Melee1 へ遷移し、上昇しない
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  FrameData frameData{};
+  frameData.input.jumpDown = true;
+  frameData.input.attackDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Melee1>(motion));
+  REQUIRE(registry.get<Velocity>(player).h == Approx(0.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - simultaneous jump and ranged attack input "
+    "transitions to Ranged without vertical velocity") {
+  // 同一フレームのジャンプ＋遠距離攻撃入力は Ranged へ遷移し、上昇しない
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  FrameData frameData{};
+  frameData.input.jumpDown = true;
+  frameData.input.rangedAttackDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Ranged>(motion));
+  REQUIRE(registry.get<Velocity>(player).h == Approx(0.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - simultaneous jump and dash input transitions to "
+    "Dash without vertical velocity") {
+  // 同一フレームのジャンプ＋ダッシュ入力は Dash へ遷移し、上昇しない
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  FrameData frameData{};
+  frameData.input.jumpDown = true;
+  frameData.input.dashDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
+  REQUIRE(registry.get<Velocity>(player).h == Approx(0.0));
+}
+
 TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee1 to Neutral") {
   // elapsed が windupSec+activeSec+recoverySec を超え、comboQueued
   // が立っていない場合は Melee1 から Neutral


### PR DESCRIPTION
## 概要

Issue #199 の修正。`Tick(Neutral&)` がジャンプ入力で `vel.h = jumpSpeed` を設定した後に攻撃・ダッシュの入場判定を行っていたため、Space と攻撃/ダッシュを同時押しするとジャンプ初速が残ったまま地上専用モーション（Melee1 / Ranged / Dash）が上昇しながら発動していた。

## 変更内容

- `Ash2/src/System/PlayerMotionSystem.cpp`: `Tick(Neutral&)` 内のジャンプ処理ブロックを、地上・空中モーション入場判定の後、ロコモーションクリップ判定の前へ移動。地上モーションへの入場は早期 return するため、入場が決まったフレームではジャンプが無効化される
- `Ash2/tests/TestPlayerMotionSystem.cpp`: 同一フレームのジャンプ＋近接/遠距離/ダッシュ入力で、対応するモーションへ遷移しつつ `vel.h` が 0 のままであることを検証するテストを3件追加

## 技術選択の理由

Issue に提案されていた2案のうち、処理順の変更（提案A）を採用した。

- **採用: 入場判定をジャンプ処理より先に評価する** — 修正が1箇所に集約され、Dash が `vel` をリセットしない差異も含めて一括で解決できる
- **不採用: 地上モーション入場時に `vel.h = 0` へリセットする** — Melee1・Ranged・Dash の3箇所へ個別にリセットを書く必要があり、修正が分散する

battle_design.md では近接・ダッシュ・遠距離は地上専用と定められており、同時押し時にジャンプ入力を無効化する挙動は設計と整合する。

## 動作確認

- format / tidy / build / test すべて通過
- ジャンプ単独入力の既存テスト（jump クリップへの即時切り替え）もパスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)