### PR TITLE
空中遠距離攻撃の実装

### DIFF
--- a/Ash2/src/System/PlayerMotionSystem.cpp
+++ b/Ash2/src/System/PlayerMotionSystem.cpp
@@ -303,6 +303,15 @@ Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
     vel.w = 0.0;
     vel.d = 0.0;
     return MakeAirAttack(anim);
+  } else if (input.rangedAttackDown &&
+             registry.get<Stamina>(entity).current >= cfg.ranged.staminaCost) {
+    // 空中遠距離攻撃への入場。Ranged は地上・空中で共有するため、
+    // 着地しても Landing を挟まずタイマー満了で Neutral
+    // に戻る（地上と同一挙動）。
+    vel.w = 0.0;
+    vel.d = 0.0;
+    SpawnProjectile(registry, pos, anim.facingRight, cfg);
+    return MakeRanged(registry, entity, cfg, playerData, anim);
   } else if (input.dashDown &&
              registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
     // 空中ダッシュへの入場（AirDash::Tick が接地検出で Landing へ遷移させる）

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -191,6 +191,35 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "PlayerMotionSystem - airborne player ranged attack input transitions "
+    "Neutral to Ranged") {
+  // 空中にいる場合も遠距離攻撃入力で Ranged
+  // へ遷移し、弾エンティティが生成される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+  registry.get<WorldPos>(player).h = 100.0;
+
+  FrameData frameData{};
+  frameData.input.rangedAttackDown = true;
+
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  REQUIRE(std::holds_alternative<PlayerMotion::Ranged>(motion));
+
+  const auto& ranged = std::get<PlayerMotion::Ranged>(motion);
+  REQUIRE(ranged.timer == Approx(4.0 / 8.0));
+
+  REQUIRE(registry.get<SpriteAnimation>(player).currentClip ==
+          U"ranged_attack");
+
+  // 弾エンティティが生成されている
+  const auto bulletView = registry.view<Projectile>();
+  REQUIRE(bulletView.size() == 1);
+}
+
+TEST_CASE(
     "PlayerMotionSystem - AirAttack spawns hitbox and moves along vertical "
     "orbit during active frame") {
   // 攻撃判定区間でヒットボックスが生成され、w-h 平面上の円軌道で移動する

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -57,7 +57,7 @@
 
 エンティティの排他的な行動状態（`std::variant<PlayerMotion::Neutral, Melee1, Melee2, Melee3, Ranged, Dash, DashAttack, AirAttack, AirDash, AirDashAttack, Landing>`）。
 
-- **Ranged**: 再生中クリップの残り時間を持つ
+- **Ranged**: 再生中クリップの残り時間を持つ。`Neutral` から接地・空中いずれでも入場できる（空中発動時も専用の遷移や着地処理は持たず、Neutral 復帰までの挙動は地上と同一）
 - **Melee1 / Melee2 / Melee3**: コンボの段ごとに分けた型。モーション開始からの経過時間（`elapsed`）・攻撃判定の子エンティティ（`hitboxEntity`）を持つ。`Melee1`/`Melee2` は次段への遷移予約フラグ（`comboQueued`）を持つが、締め技の `Melee3` はコンボ継続を持たずタイマー満了で `Neutral` へ戻るのみ
 - **Dash**: 構え・ダッシュ・後隙A・後隙Bの4区間を `elapsed` 1本で管理する。ダッシュ中・後隙A・B中の攻撃入力（`attackDown`）でダッシュ攻撃を予約（`dashAttackQueued`）し、後隙B中に `DashAttack` へ遷移する。後隙B中のダッシュ入力（`dashDown`）は再ダッシュにキャンセルする。ダッシュ移動中の方向を `lastDashDir` に記録し `DashAttack::dashDir` へ引き渡す
 - **DashAttack**: 構え・攻撃・後隙の3区間を持ち、攻撃判定（`hitboxEntity`）を w-d 平面の円軌道上で更新する


### PR DESCRIPTION
## 概要

空中から遠距離攻撃を発動できるようにする（close #190）。

- `Neutral` の空中分岐に遠距離攻撃の分岐を追加（優先順: 空中近接 → 遠距離 → 空中ダッシュ、地上側と同じ並び）
- 空中から `Ranged` へ遷移し弾が1個生成されることを検証するテストを追加
- `docs/REFERENCE.md` の `Ranged` 説明に空中入場を追記

## 実装判断

- 既存の `Ranged` 状態を地上・空中で共有し、新しい状態型は追加しない（Issue が「動作仕様は地上遠距離攻撃と同じ」と明記しているため）
- 着地遷移（Landing）は追加しない。`Ranged` は地上と共有のため接地判定で Landing へ遷移させると地上遠距離が壊れる。空中で撃つと重力で落下し、着地後もタイマー満了まで `Ranged` を維持して `Neutral` に戻る。battle_design.md「空中の流れ」の「いずれも → 着地」とは差分があるが、「地上と同じ」仕様を優先した

🤖 Generated with [Claude Code](https://claude.com/claude-code)