### PR TITLE
HitSystem が Attack::root の有効性を検証してから参照するよう修正

### DIFF
--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -87,6 +87,13 @@ inline Array<HitPair> HitSystem::Update(entt::registry& registry) {
   for (auto&& [attacker, aPos, aCol, atk] : attackers.each()) {
     // root が設定されている場合はルートの Attack を参照してヒット管理する
     const auto rootEntity = (atk.root != entt::null) ? atk.root : attacker;
+    // root は破棄済み・Attack 非保持の可能性があるため参照前に検証する
+    // （attacker 自身が root の場合は attackers
+    // ビューの走査対象なので必ず有効） valid
+    // を先に評価する短絡順序を維持し、破棄済みエンティティへの all_of/get
+    // 呼び出し（未定義動作）を避ける
+    if (!registry.valid(rootEntity) || !registry.all_of<Attack>(rootEntity))
+      continue;
     auto& rootAtk = registry.get<Attack>(rootEntity);
 
     const Vec3 worldA{aPos.w, aPos.h, aPos.d};

--- a/Ash2/tests/TestHitSystem.cpp
+++ b/Ash2/tests/TestHitSystem.cpp
@@ -86,4 +86,62 @@ TEST_CASE("HitSystem - multi-collider attack hits target only once") {
   REQUIRE(hits.size() == 1);
 }
 
+TEST_CASE("HitSystem - collider with destroyed root is skipped") {
+  // 破棄済みの root
+  // を参照するコライダーはスキップされ、クラッシュもダメージもない
+  entt::registry registry;
+
+  // 破棄済みの root エンティティ（生成直後に破棄し、無効な entity にする）
+  auto root = registry.create();
+  registry.destroy(root);
+
+  // 攻撃コライダー（無効な root を参照）
+  auto attacker = registry.create();
+  registry.emplace<WorldPos>(attacker, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(attacker, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                                .segmentEnd = {0.0, 0.0, 0.0},
+                                                .radius = 10.0});
+  registry.emplace<Attack>(attacker, Attack{.damage = 5, .root = root});
+
+  // 被弾エンティティ（重なる位置）
+  auto target = registry.create();
+  registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 10.0});
+  registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
+
+  const auto hits = HitSystem::Update(registry);
+  REQUIRE(registry.get<Hp>(target).current == 100);
+  REQUIRE(hits.isEmpty());
+}
+
+TEST_CASE("HitSystem - collider with root lacking Attack is skipped") {
+  // Attack を持たない root を参照するコライダーはスキップされる
+  entt::registry registry;
+
+  // Attack を持たない root エンティティ
+  auto root = registry.create();
+
+  // 攻撃コライダー（Attack 非保持の root を参照）
+  auto attacker = registry.create();
+  registry.emplace<WorldPos>(attacker, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(attacker, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                                .segmentEnd = {0.0, 0.0, 0.0},
+                                                .radius = 10.0});
+  registry.emplace<Attack>(attacker, Attack{.damage = 5, .root = root});
+
+  // 被弾エンティティ（重なる位置）
+  auto target = registry.create();
+  registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
+  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
+                                              .segmentEnd = {0.0, 0.0, 0.0},
+                                              .radius = 10.0});
+  registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
+
+  const auto hits = HitSystem::Update(registry);
+  REQUIRE(registry.get<Hp>(target).current == 100);
+  REQUIRE(hits.isEmpty());
+}
+
 #endif


### PR DESCRIPTION
## 概要

Issue #200 の修正。`HitSystem::Update` が `atk.root` を検証せずに `registry.get<Attack>(rootEntity)` を呼んでおり、root が破棄済み・`Attack` 非保持の場合に未定義動作となる潜在バグを修正する。

## 変更内容

- `Ash2/src/System/HitSystem.hpp`: root 参照前に `registry.valid(rootEntity) && registry.all_of<Attack>(rootEntity)` を検証し、不成立ならそのコライダーをスキップする。スキップはコライダー単位で、他の有効な判定は継続する
- `Ash2/tests/TestHitSystem.cpp`: 破棄済み root・`Attack` 非保持 root の2ケースで、クラッシュせずダメージも入らないことを検証する回帰テストを追加

## 実装判断

- Issue で挙がっていた「skip」案と「assert 契約」案のうち skip 案を採用した。assert は追加したテストが意図的に「無効な root」を構築するため、テスト実行が assert で中断してしまい両立できなかった（計画上も assert は任意項目）
- `valid` を短絡評価の左に置き、破棄済みエンティティへの `all_of`/`get` 呼び出しを確実に回避している

close #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
