### PR TITLE
CI でビルドとテストを実行する

### DIFF
--- a/.claude/agents/ci.md
+++ b/.claude/agents/ci.md
@@ -50,9 +50,7 @@ If the terminal output is insufficient to diagnose a failure, read `logs/build.l
 ./tools/run-tests.sh
 ```
 
-The script always exits with code 0. Determine pass/fail from the output:
-- **Pass**: output contains `All tests passed`
-- **Fail**: output contains `failed` (case-insensitive) or does not contain `All tests passed`
+The script exits with code 0 on pass, non-zero on failure. Determine pass/fail from the exit code.
 
 ## Output
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,65 @@
+name: build-test
+
+# push(main) は、PR を経ない chore コミットの検証と README バッジの更新のため
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  SIV3D_VERSION: 0.6.16
+  SIV3D_0_6_16: C:\OpenSiv3D_SDK_0.6.16
+
+jobs:
+  build-test:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Siv3D SDK
+        shell: pwsh
+        run: |
+          bitsadmin /transfer s3d-download "https://siv3d.jp/downloads/Siv3D/manual/${{ env.SIV3D_VERSION }}/OpenSiv3D_SDK_${{ env.SIV3D_VERSION }}.zip" "C:\OpenSiv3D_SDK.zip"
+          Expand-Archive -Path "C:\OpenSiv3D_SDK.zip" -DestinationPath "C:"
+
+      - name: Cache vcpkg packages
+        uses: actions/cache@v4
+        with:
+          path: Ash2/vcpkg_installed
+          key: vcpkg-x64-windows-${{ hashFiles('Ash2/vcpkg.json', 'Ash2/vcpkg-configuration.json') }}
+
+      - name: Install vcpkg dependencies
+        shell: pwsh
+        working-directory: Ash2
+        run: vcpkg install --triplet x64-windows "--x-install-root=$env:GITHUB_WORKSPACE\Ash2\vcpkg_installed\x64-windows"
+
+      # ローカルの Visual Studio と同じく、MSBuild の vcpkg 統合で
+      # entt の include パスを解決する（vcxproj には vcpkg のパスを書いていないため）
+      - name: Integrate vcpkg with MSBuild
+        shell: pwsh
+        run: vcpkg integrate install
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build (Debug)
+        shell: pwsh
+        run: |
+          msbuild Ash2\Ash2.sln `
+            -p:Configuration=Debug `
+            -p:Platform=x64 `
+            -m `
+            -v:minimal `
+            -nologo
+
+      # Siv3D の初期化に失敗するとメッセージボックスでハングする可能性があるため、
+      # ジョブ全体より短い timeout を個別に設定する
+      - name: Run tests
+        shell: bash
+        timeout-minutes: 10
+        run: ./tools/run-tests.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 沼に焚べ
 
+[![build-test](https://github.com/mori08/Ash2/actions/workflows/build-test.yml/badge.svg)](https://github.com/mori08/Ash2/actions/workflows/build-test.yml)
+[![clang-format](https://github.com/mori08/Ash2/actions/workflows/clang-format.yml/badge.svg)](https://github.com/mori08/Ash2/actions/workflows/clang-format.yml)
+[![clang-tidy](https://github.com/mori08/Ash2/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/mori08/Ash2/actions/workflows/clang-tidy.yml)
+
 疑似3D視点のベルトアクションゲーム。奥行きを持つ2D表現でのアクションを目指した作品。
 
 ## 動作環境

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -10,5 +10,17 @@ if [[ ! -f "$EXE" ]]; then
   exit 1
 fi
 
+mkdir -p "$REPO_ROOT/logs"
+LOG="$REPO_ROOT/logs/test.log"
+
 echo "Running tests: $EXE"
-ASH2_RUN_TESTS=1 "$EXE" || true
+# Siv3D の Main() は void で Catch2 の結果をプロセスの exit code に反映できないため、
+# exe の exit code は無視し、Catch2 の出力から合否を判定する
+ASH2_RUN_TESTS=1 "$EXE" 2>&1 | tee "$LOG" || true
+
+if grep -q "All tests passed" "$LOG"; then
+  exit 0
+fi
+
+echo "ERROR: テストが失敗しました（詳細は上記出力を参照）"
+exit 1


### PR DESCRIPTION
## 概要

PR ごとにビルドとテストを実行する `build-test` ワークフローを追加する（close #211）。

- `.github/workflows/build-test.yml` を追加。clang-tidy.yml で実証済みの Siv3D SDK 取得・vcpkg キャッシュ構成を流用し、MSBuild で Debug ビルド → 実 exe で Catch2 テストを実行する
- `tools/run-tests.sh` を、合否を exit code で返すよう修正
- `.claude/agents/ci.md` の「スクリプトは常に exit 0」前提の判定手順を exit code 判定に更新
- README に build-test / clang-format / clang-tidy のステータスバッジを追加

## 技術選択の理由

- **テスト合否は Catch2 出力のパースで判定**: Siv3D の `Main()` は void でプロセスの exit code に結果を反映できない（5e281f8 で `std::exit` を撤去した経緯があり、復活させない）。exe の exit code は無視し、`All tests passed` の有無をスクリプト内で判定して exit code 化した
- **vcpkg は `vcpkg integrate install` で MSBuild 統合**: vcxproj に vcpkg のパスを書いていないため、ローカルの Visual Studio と同じ統合機構で entt の include を解決する
- **paths フィルタは付けない**: ビルドに影響するファイルの列挙は漏れやすく（vcxproj・vcpkg.json・assets 等）、1 実行 2〜4 分と軽いため全 PR で実行する
- **`push`（main）でも発火させる**: PR を経ない chore コミットの検証と、README バッジ（main の最新実行結果を表示）の更新のため
- **過去の standalone 方式（#37 で撤退）とは異なるアプローチ**: Siv3D をリンクしたフルビルドの exe をそのまま実行するため、テスト都合でプロダクションコードが制約される問題は生じない

## Test plan

- [x] ローカルで `./tools/run-tests.sh` が成功時に exit 0 を返すことを確認
- [x] feature ブランチへの push 発火で CI 緑経路を確認（run 29254037490、All tests passed 274 assertions / 111 test cases）
- [x] テストを一時的に壊して CI が失敗することを確認（run 29254371529、該当アサーションのみ失敗 → job 赤）※検証コミットは履歴から削除済み
- [x] pull_request 発火のビルド・テストが緑になることを確認（run 29255014013）
- [ ] マージ後、README のバッジが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
