### PR TITLE
PhaseMaker / MakeLoader のテンプレート制約を concept 化 #214

### DIFF
--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -10,9 +10,14 @@
 
 namespace {
 
-/// @brief 型 T のパラメータを保持し、make() で T を生成する IPhaseMaker
-/// @tparam T IPhase を継承するフェーズクラス（T::Param を持つこと）
+/// @brief IPhase を継承し、const Param& から構築可能な Param を持つフェーズ型
 template <typename T>
+concept PhaseWithParam = std::derived_from<T, IPhase> &&
+                         std::move_constructible<typename T::Param> &&
+                         std::constructible_from<T, const typename T::Param&>;
+
+/// @brief 型 T のパラメータを保持し、make() で T を生成する IPhaseMaker
+template <PhaseWithParam T>
 class PhaseMaker : public IPhaseMaker {
  public:
   explicit PhaseMaker(typename T::Param param) : m_param(std::move(param)) {}
@@ -29,9 +34,8 @@ class PhaseMaker : public IPhaseMaker {
 using PhaseLoader = std::function<IPhaseMaker::Ptr(const TOMLValue&)>;
 
 /// @brief 型 T に対する PhaseLoader を生成するヘルパー
-/// @tparam T IPhase を継承するフェーズクラス（T::Param を持つこと）
 /// @param parse TOML 値から T::Param を生成するラムダ
-template <typename T, typename F>
+template <PhaseWithParam T, typename F>
 PhaseLoader MakeLoader(F&& parse) {
   return [p = std::forward<F>(parse)](const TOMLValue& step) {
     return std::make_shared<const PhaseMaker<T>>(p(step));


### PR DESCRIPTION
## 概要

`ScenarioData.cpp` の `PhaseMaker<T>` / `MakeLoader<T,F>` が Doxygen コメント2箇所の重複記載で表現していた暗黙のテンプレート制約を、C++20 concept `PhaseWithParam` に昇格させる。close #214

## 変更内容

- 無名名前空間の先頭（`PhaseMaker` 定義の直前）に `PhaseWithParam` concept を定義
  - `std::derived_from<T, IPhase>` + `std::move_constructible<typename T::Param>` + `std::constructible_from<T, const typename T::Param&>` の組み合わせ
- `PhaseMaker<T>` と `MakeLoader<T,F>` の両方の `T` に適用（違反が呼び出し箇所で顕在化するよう `MakeLoader` 側にも制約を置く）
- 重複していた旧 `@tparam T` コメント2箇所を削除し、制約説明を concept 定義の `///` コメントに一本化

## 技術選択の理由

- `MakeLoader` の `F` への `requires` 節（`std::invocable` + `convertible_to`）は追加しない。`T` 側の制約だけで受け入れ条件を満たし、過剰になるため（Issue 記載の「着手時に要否を判断」の結論）
- `#include <concepts>` は追加しない。`<Siv3D.hpp>` 経由で推移的に届き、`DrawSystem.cpp` が `std::ranges::sort` を `<algorithm>` 明示 include なしで使う既存流儀に合わせた

## 確認

- format / tidy / build / tests（111件）すべて通過
- 既存5フェーズ（PlayerTest / TestMenu / AnimationViewer / Scenario / Wait）はすべて制約を満たすことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)