### PR TITLE
Motion の Tick 規約を MotionState concept として明文化

### DIFF
--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -39,7 +39,9 @@ void MotionSystem::Update(entt::registry& registry,
   for (const auto entity : view) {
     auto& motion = view.get<Motion>(entity);
     auto next = std::visit(
-        [&](auto& state) { return Tick(state, registry, entity, frameData); },
+        [&](MotionState auto& state) {
+          return Tick(state, registry, entity, frameData);
+        },
         motion);
     if (next.has_value()) {
       APP_LOG(U"[Motion] " + MotionName(motion) + U" → " + MotionName(*next));

--- a/Ash2/src/System/MotionSystem.hpp
+++ b/Ash2/src/System/MotionSystem.hpp
@@ -5,6 +5,15 @@
 
 struct FrameData;
 
+/// @brief Motion variant の状態型が満たすべき Tick() 契約
+/// （ADL で解決される Tick(state, registry, entity, frameData) が
+/// Optional<Motion> を返すこと）
+template <typename S>
+concept MotionState =
+    requires(S& s, entt::registry& r, entt::entity e, const FrameData& f) {
+      { Tick(s, r, e, f) } -> std::same_as<Optional<Motion>>;
+    };
+
 /// @brief Motion の状態遷移・更新を行う共通ディスパッチャ
 class MotionSystem {
  public:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -171,4 +171,4 @@
 - `Drawable` の型変更は `std::visit` を使い、DrawSystem と AnimationSystem の両方への影響を確認する。
 - 新クラス追加時は `Ash2.vcxproj` と `Ash2.vcxproj.filters` にも追加が必要。
 - `NameLookup` への挿入・削除は `NameLookupSystem::Connect` で自動化されている（`Name` コンポーネントの追加・削除に連動）。手動での `NameLookup[key] = entity` 登録は不要。
-- `Motion` に新しい状態型を追加したときは、`MotionSystem.cpp` の `MotionName()`（デバッグログ用）にも分岐を追加する。
+- `Motion` に新しい状態型を追加したときは、`MotionSystem.cpp` の `MotionName()`（デバッグログ用）にも分岐を追加する。また、`MotionSystem::Update` の `std::visit` は `MotionState` concept（`MotionSystem.hpp`）で制約されているため、新状態型は `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。


### PR DESCRIPTION
## 概要

Motion variant の全状態型に `Tick(state, registry, entity, frameData) -> Optional<Motion>` のオーバーロードが必要という暗黙の規約を、C++20 concept `MotionState` としてコードに表明する（close #215）。

## 変更内容

- `Ash2/src/System/MotionSystem.hpp` に `MotionState` concept を追加
- `Ash2/src/System/MotionSystem.cpp` の `std::visit` ラムダ引数を `MotionState auto&` に制約
- `docs/REFERENCE.md` の「部品追加時の注意」に、新状態型追加時は `MotionState` 契約を満たす `Tick` 実装が必要である旨を追記

これにより、Tick 未定義の状態型を variant に追加した場合、オーバーロード解決の長大なエラーではなく concept 名を含む制約違反エラーになる。実行時挙動の変更はない。

## 技術選択の理由

- **concept の定義場所を MotionSystem.hpp にした**: 制約付きラムダを使う唯一の箇所がディスパッチャ（MotionSystem.cpp）であるため。Component 側（Motion.hpp）は「Component はデータのみ」の方針に反し、専用ヘッダ新設は利用箇所1つに対して過剰と判断
- **`#include <concepts>` は追加しない**: Siv3D.hpp → Siv3D/Utility.hpp → Siv3D/Concepts.hpp 経由で `<concepts>` が推移的に可視であり、既存の `PhaseWithParam`（ScenarioData.cpp、#214）も同様に明示 include なしで std の concept を使っている先例に合わせた
- **concept 内の `Tick` は非修飾のまま ADL 解決に委ねる**: 変更前のラムダも非修飾 `Tick` で ADL 依存であり方針は不変。これにより MotionSystem.hpp が PlayerMotionSystem.hpp に依存せずに済む

🤖 Generated with [Claude Code](https://claude.com/claude-code)