### PR TITLE
ScenarioData のエラー処理を std::expected に移行

### DIFF
--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -1,5 +1,6 @@
 #include "Config/ScenarioData.hpp"
 
+#include <expected>
 #include <functional>
 
 #include "Phase/AnimationViewerPhase.hpp"
@@ -31,69 +32,108 @@ class PhaseMaker : public IPhaseMaker {
 };
 
 /// @brief TOML 値から PhaseMaker<T> を生成する関数の型
-using PhaseLoader = std::function<IPhaseMaker::Ptr(const TOMLValue&)>;
+using PhaseLoader =
+    std::function<std::expected<IPhaseMaker::Ptr, String>(const TOMLValue&)>;
 
 /// @brief 型 T に対する PhaseLoader を生成するヘルパー
-/// @param parse TOML 値から T::Param を生成するラムダ
+/// @param parse TOML 値から T::Param を生成するラムダ（失敗時は
+/// unexpected でエラーメッセージを返す）
 template <PhaseWithParam T, typename F>
 PhaseLoader MakeLoader(F&& parse) {
-  return [p = std::forward<F>(parse)](const TOMLValue& step) {
-    return std::make_shared<const PhaseMaker<T>>(p(step));
+  return [p = std::forward<F>(parse)](
+             const TOMLValue& step) -> std::expected<IPhaseMaker::Ptr, String> {
+    auto param = p(step);
+    if (!param) {
+      return std::unexpected{std::move(param).error()};
+    }
+    return std::make_shared<const PhaseMaker<T>>(*std::move(param));
   };
 }
 
 /// @brief フェーズ名 → PhaseLoader のマップ
 const HashTable<String, PhaseLoader> kPhaseLoaders{
-    {U"player_test", MakeLoader<PlayerTestPhase>([](const TOMLValue&) {
-       return PlayerTestPhase::Param{};
-     })},
-    {U"test_menu", MakeLoader<TestMenuPhase>([](const TOMLValue&) {
-       return TestMenuPhase::Param{};
-     })},
+    {U"player_test",
+     MakeLoader<PlayerTestPhase>(
+         [](const TOMLValue&) -> std::expected<PlayerTestPhase::Param, String> {
+           return PlayerTestPhase::Param{};
+         })},
+    {U"test_menu",
+     MakeLoader<TestMenuPhase>(
+         [](const TOMLValue&) -> std::expected<TestMenuPhase::Param, String> {
+           return TestMenuPhase::Param{};
+         })},
     {U"animation_viewer",
-     MakeLoader<AnimationViewerPhase>([](const TOMLValue& step) {
-       return AnimationViewerPhase::Param{
-           .dataKey = step[U"param"].get<String>(),
-       };
-     })},
-    {U"scenario", MakeLoader<ScenarioPhase>([](const TOMLValue& step) {
-       return ScenarioPhase::Param{
-           .sectionName = step[U"param"].get<String>(),
-       };
-     })},
-    {U"wait", MakeLoader<WaitPhase>([](const TOMLValue& step) {
-       return WaitPhase::Param{
-           .duration = step[U"duration"].get<double>(),
-       };
-     })},
+     MakeLoader<AnimationViewerPhase>(
+         [](const TOMLValue& step)
+             -> std::expected<AnimationViewerPhase::Param, String> {
+           const auto dataKey = step[U"param"].getOpt<String>();
+           if (!dataKey) {
+             return std::unexpected{
+                 U"ScenarioData::ParseStep: animation_viewer に param があ"
+                 U"りません"};
+           }
+           return AnimationViewerPhase::Param{.dataKey = *dataKey};
+         })},
+    {U"scenario",
+     MakeLoader<ScenarioPhase>(
+         [](const TOMLValue& step)
+             -> std::expected<ScenarioPhase::Param, String> {
+           const auto sectionName = step[U"param"].getOpt<String>();
+           if (!sectionName) {
+             return std::unexpected{
+                 U"ScenarioData::ParseStep: scenario に param がありません"};
+           }
+           return ScenarioPhase::Param{.sectionName = *sectionName};
+         })},
+    {U"wait",
+     MakeLoader<WaitPhase>(
+         [](const TOMLValue& step) -> std::expected<WaitPhase::Param, String> {
+           const auto duration = step[U"duration"].getOpt<double>();
+           if (!duration) {
+             return std::unexpected{
+                 U"ScenarioData::ParseStep: wait に duration がありません"};
+           }
+           return WaitPhase::Param{.duration = *duration};
+         })},
 };
 
 /// @brief TOML の 1 ステップ値を ScenarioStep に変換する
 /// @note "make" アクションは別 Issue で対応予定のためエラーとする
-ScenarioStep ParseStep(const TOMLValue& step) {
-  const auto action = step[U"action"].get<String>();
+[[nodiscard]] std::expected<ScenarioStep, String> ParseStep(
+    const TOMLValue& step) {
+  const auto action = step[U"action"].getOpt<String>();
+  if (!action) {
+    return std::unexpected{U"ScenarioData::ParseStep: action がありません"};
+  }
 
-  if (action == U"push" || action == U"reset") {
-    const auto phaseName = step[U"phase"].get<String>();
-    const auto it = kPhaseLoaders.find(phaseName);
+  if (*action == U"push" || *action == U"reset") {
+    const auto phaseName = step[U"phase"].getOpt<String>();
+    if (!phaseName) {
+      return std::unexpected{U"ScenarioData::ParseStep: phase がありません"};
+    }
+    const auto it = kPhaseLoaders.find(*phaseName);
     if (it == kPhaseLoaders.end()) {
-      throw Error{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
-                  phaseName + U"\""};
+      return std::unexpected{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
+                             *phaseName + U"\""};
     }
     auto maker = it->second(step);
-    if (action == U"push") {
-      return StepPush{.maker = std::move(maker)};
+    if (!maker) {
+      return std::unexpected{std::move(maker).error()};
     }
-    return StepReset{.maker = std::move(maker)};
+    if (*action == U"push") {
+      return StepPush{.maker = *std::move(maker)};
+    }
+    return StepReset{.maker = *std::move(maker)};
   }
 
-  if (action == U"make") {
-    throw Error{
-        U"ScenarioData::FromToml: \"make\" アクションは未対応です（Issue #67 "
-        U"スコープ外）"};
+  if (*action == U"make") {
+    return std::unexpected{
+        U"ScenarioData::ParseStep: \"make\" アクションは未対応です（Issue "
+        U"#67 スコープ外）"};
   }
 
-  throw Error{U"ScenarioData::FromToml: 不明なアクション \"" + action + U"\""};
+  return std::unexpected{U"ScenarioData::ParseStep: 不明なアクション \"" +
+                         *action + U"\""};
 }
 
 }  // namespace
@@ -104,7 +144,15 @@ ScenarioData ScenarioData::FromToml(const TOMLValue& toml) {
   for (const auto& member : toml.tableView()) {
     Array<ScenarioStep> steps;
     for (const auto& step : member.value.tableArrayView()) {
-      steps.push_back(ParseStep(step));
+      auto parsed = ParseStep(step);
+      if (!parsed) {
+        // Why not: ParseStep からの失敗は expected で伝播してくるが、
+        // ここは設定読み込みの最上位境界であり、呼び出し元の
+        // GameSetup は expected を扱わない設計のため throw
+        // で致命として確定させる。
+        throw Error{std::move(parsed).error()};
+      }
+      steps.push_back(*std::move(parsed));
     }
     data.sections[member.name] = std::move(steps);
   }

--- a/Ash2/tests/TestScenarioData.cpp
+++ b/Ash2/tests/TestScenarioData.cpp
@@ -58,4 +58,22 @@ TEST_CASE("ScenarioData::FromToml - unknown action throws Error") {
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
 }
 
+TEST_CASE("ScenarioData::FromToml - missing duration throws Error") {
+  constexpr std::string_view Toml =
+      "[[intro]]\n"
+      "action = \"push\"\n"
+      "phase = \"wait\"\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
+}
+
+TEST_CASE("ScenarioData::FromToml - missing param throws Error") {
+  constexpr std::string_view Toml =
+      "[[intro]]\n"
+      "action = \"push\"\n"
+      "phase = \"scenario\"\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
+}
+
 #endif


### PR DESCRIPTION
## 概要

docs/ERROR_HANDLING.md のエラー処理規範に ScenarioData を適合させる。close #208

## 変更内容

- `ParseStep`・各フェーズローダ・`MakeLoader` を throw から `std::expected<T, String>` 返しに変更（本プロジェクト初の `std::expected` 採用）
- TOML の `get<T>()` を `getOpt<T>()` に置き換え、キー欠落・型不一致を黙って既定値にせず失敗として検出（`action`・`phase`・`param`・`duration`）
- throw は `FromToml` 内の1箇所（最上位境界での致命確定）に集約し、Why not コメントを添付
- `duration` 欠落・`param` 欠落の異常系テストを2件追加

## 技術選択の理由

- `FromToml` の公開シグネチャ（`ScenarioData` 返し＋throw）は維持した。兄弟の `PlayerConfig` / `AnimationData` の `FromToml` と挙動を揃え、呼び出し元 `GameSetup` と既存テストを無改修で通すため
- エラーメッセージの接頭辞を実際の発生元 `ScenarioData::ParseStep:` に統一した（従来は `FromToml:` 表記が混在していたため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)