### PR TITLE
Config → Phase の逆依存を解消する

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="src\Phase\TestMenuPhase.cpp" />
     <ClCompile Include="src\Phase\AnimationViewerPhase.cpp" />
     <ClCompile Include="src\Phase\WaitPhase.cpp" />
+    <ClCompile Include="src\Phase\PhaseLoaders.cpp" />
     <ClCompile Include="src\Component\Hierarchy.cpp" />
     <ClCompile Include="src\System\AnimationSystem.cpp" />
     <ClCompile Include="src\System\PlayerMotion\Helper.cpp" />
@@ -397,6 +398,7 @@
     <ClInclude Include="src\Config\ScenarioData.hpp" />
     <ClInclude Include="src\Phase\ScenarioPhase.hpp" />
     <ClInclude Include="src\Phase\WaitPhase.hpp" />
+    <ClInclude Include="src\Phase\PhaseLoaders.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\Asset.hpp" />
     <ClInclude Include="src\Debug.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -264,6 +264,9 @@
     <ClCompile Include="Phase\PhaseStack.cpp">
       <Filter>Source Files\Phase</Filter>
     </ClCompile>
+    <ClCompile Include="Phase\PhaseLoaders.cpp">
+      <Filter>Source Files\Phase</Filter>
+    </ClCompile>
     <ClCompile Include="stdafx.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1068,6 +1071,9 @@
       <Filter>Header Files\Phase</Filter>
     </ClInclude>
     <ClInclude Include="Phase\IPhase.hpp">
+      <Filter>Header Files\Phase</Filter>
+    </ClInclude>
+    <ClInclude Include="Phase\PhaseLoaders.hpp">
       <Filter>Header Files\Phase</Filter>
     </ClInclude>
     <ClInclude Include="Phase\PhaseStack.hpp">

--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -1,106 +1,11 @@
 #include "Config/ScenarioData.hpp"
 
-#include <expected>
-#include <functional>
-
-#include "Phase/AnimationViewerPhase.hpp"
-#include "Phase/PlayerTestPhase.hpp"
-#include "Phase/ScenarioPhase.hpp"
-#include "Phase/TestMenuPhase.hpp"
-#include "Phase/WaitPhase.hpp"
-
 namespace {
-
-/// @brief IPhase を継承し、const Param& から構築可能な Param を持つフェーズ型
-template <typename T>
-concept PhaseWithParam = std::derived_from<T, IPhase> &&
-                         std::move_constructible<typename T::Param> &&
-                         std::constructible_from<T, const typename T::Param&>;
-
-/// @brief 型 T のパラメータを保持し、make() で T を生成する IPhaseMaker
-template <PhaseWithParam T>
-class PhaseMaker : public IPhaseMaker {
- public:
-  explicit PhaseMaker(typename T::Param param) : m_param(std::move(param)) {}
-
-  [[nodiscard]] std::unique_ptr<IPhase> make() const override {
-    return std::make_unique<T>(m_param);
-  }
-
- private:
-  typename T::Param m_param;
-};
-
-/// @brief TOML 値から PhaseMaker<T> を生成する関数の型
-using PhaseLoader =
-    std::function<std::expected<IPhaseMaker::Ptr, String>(const TOMLValue&)>;
-
-/// @brief 型 T に対する PhaseLoader を生成するヘルパー
-/// @param parse TOML 値から T::Param を生成するラムダ（失敗時は
-/// unexpected でエラーメッセージを返す）
-template <PhaseWithParam T, typename F>
-PhaseLoader MakeLoader(F&& parse) {
-  return [p = std::forward<F>(parse)](
-             const TOMLValue& step) -> std::expected<IPhaseMaker::Ptr, String> {
-    auto param = p(step);
-    if (!param) {
-      return std::unexpected{std::move(param).error()};
-    }
-    return std::make_shared<const PhaseMaker<T>>(*std::move(param));
-  };
-}
-
-/// @brief フェーズ名 → PhaseLoader のマップ
-const HashTable<String, PhaseLoader> kPhaseLoaders{
-    {U"player_test",
-     MakeLoader<PlayerTestPhase>(
-         [](const TOMLValue&) -> std::expected<PlayerTestPhase::Param, String> {
-           return PlayerTestPhase::Param{};
-         })},
-    {U"test_menu",
-     MakeLoader<TestMenuPhase>(
-         [](const TOMLValue&) -> std::expected<TestMenuPhase::Param, String> {
-           return TestMenuPhase::Param{};
-         })},
-    {U"animation_viewer",
-     MakeLoader<AnimationViewerPhase>(
-         [](const TOMLValue& step)
-             -> std::expected<AnimationViewerPhase::Param, String> {
-           const auto dataKey = step[U"param"].getOpt<String>();
-           if (!dataKey) {
-             return std::unexpected{
-                 U"ScenarioData::ParseStep: animation_viewer に param があ"
-                 U"りません"};
-           }
-           return AnimationViewerPhase::Param{.dataKey = *dataKey};
-         })},
-    {U"scenario",
-     MakeLoader<ScenarioPhase>(
-         [](const TOMLValue& step)
-             -> std::expected<ScenarioPhase::Param, String> {
-           const auto sectionName = step[U"param"].getOpt<String>();
-           if (!sectionName) {
-             return std::unexpected{
-                 U"ScenarioData::ParseStep: scenario に param がありません"};
-           }
-           return ScenarioPhase::Param{.sectionName = *sectionName};
-         })},
-    {U"wait",
-     MakeLoader<WaitPhase>(
-         [](const TOMLValue& step) -> std::expected<WaitPhase::Param, String> {
-           const auto duration = step[U"duration"].getOpt<double>();
-           if (!duration) {
-             return std::unexpected{
-                 U"ScenarioData::ParseStep: wait に duration がありません"};
-           }
-           return WaitPhase::Param{.duration = *duration};
-         })},
-};
 
 /// @brief TOML の 1 ステップ値を ScenarioStep に変換する
 /// @note "make" アクションは別 Issue で対応予定のためエラーとする
 [[nodiscard]] std::expected<ScenarioStep, String> ParseStep(
-    const TOMLValue& step) {
+    const TOMLValue& step, const PhaseLoaderTable& loaders) {
   const auto action = step[U"action"].getOpt<String>();
   if (!action) {
     return std::unexpected{U"ScenarioData::ParseStep: action がありません"};
@@ -111,8 +16,8 @@ const HashTable<String, PhaseLoader> kPhaseLoaders{
     if (!phaseName) {
       return std::unexpected{U"ScenarioData::ParseStep: phase がありません"};
     }
-    const auto it = kPhaseLoaders.find(*phaseName);
-    if (it == kPhaseLoaders.end()) {
+    const auto it = loaders.find(*phaseName);
+    if (it == loaders.end()) {
       return std::unexpected{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
                              *phaseName + U"\""};
     }
@@ -138,13 +43,14 @@ const HashTable<String, PhaseLoader> kPhaseLoaders{
 
 }  // namespace
 
-ScenarioData ScenarioData::FromToml(const TOMLValue& toml) {
+ScenarioData ScenarioData::FromToml(const TOMLValue& toml,
+                                    const PhaseLoaderTable& loaders) {
   ScenarioData data;
 
   for (const auto& member : toml.tableView()) {
     Array<ScenarioStep> steps;
     for (const auto& step : member.value.tableArrayView()) {
-      auto parsed = ParseStep(step);
+      auto parsed = ParseStep(step, loaders);
       if (!parsed) {
         // Why not: ParseStep からの失敗は expected で伝播してくるが、
         // ここは設定読み込みの最上位境界であり、呼び出し元の

--- a/Ash2/src/Config/ScenarioData.hpp
+++ b/Ash2/src/Config/ScenarioData.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <Siv3D.hpp>
 
+#include <expected>
+#include <functional>
 #include <memory>
 #include <variant>
 
@@ -15,6 +17,13 @@ struct IPhaseMaker {
   /// @brief 保持しているパラメータから IPhase インスタンスを生成する
   [[nodiscard]] virtual std::unique_ptr<IPhase> make() const = 0;
 };
+
+/// @brief TOML 値から IPhaseMaker を生成する関数の型
+using PhaseLoader =
+    std::function<std::expected<IPhaseMaker::Ptr, String>(const TOMLValue&)>;
+
+/// @brief フェーズ名 → PhaseLoader のマップ
+using PhaseLoaderTable = HashTable<String, PhaseLoader>;
 
 /// @brief シナリオのステップ：フェーズをスタックに積む
 struct StepPush {
@@ -35,5 +44,7 @@ struct ScenarioData {
   HashTable<String, Array<ScenarioStep>> sections;
 
   /// @brief TOML からシナリオデータを生成する
-  [[nodiscard]] static ScenarioData FromToml(const TOMLValue& toml);
+  /// @param loaders フェーズ名 → PhaseLoader のマップ（呼び出し元が用意する）
+  [[nodiscard]] static ScenarioData FromToml(const TOMLValue& toml,
+                                             const PhaseLoaderTable& loaders);
 };

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -6,6 +6,7 @@
 #include "Config/AnimationData.hpp"
 #include "Config/PlayerConfig.hpp"
 #include "Config/ScenarioData.hpp"
+#include "Phase/PhaseLoaders.hpp"
 #include "System/HierarchySystem.hpp"
 #include "System/NameLookup.hpp"
 
@@ -37,7 +38,8 @@ void InitializeRegistry(entt::registry& registry) {
   LoadAnimations(registry);
 
   const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
-  registry.ctx().emplace<ScenarioData>(ScenarioData::FromToml(scenarioToml));
+  registry.ctx().emplace<ScenarioData>(
+      ScenarioData::FromToml(scenarioToml, GetPhaseLoaders()));
 }
 
 void ReloadConfig(entt::registry& registry) {

--- a/Ash2/src/Phase/PhaseLoaders.cpp
+++ b/Ash2/src/Phase/PhaseLoaders.cpp
@@ -1,0 +1,96 @@
+#include "Phase/PhaseLoaders.hpp"
+
+#include "Phase/AnimationViewerPhase.hpp"
+#include "Phase/PlayerTestPhase.hpp"
+#include "Phase/ScenarioPhase.hpp"
+#include "Phase/TestMenuPhase.hpp"
+#include "Phase/WaitPhase.hpp"
+
+namespace {
+
+/// @brief IPhase を継承し、const Param& から構築可能な Param を持つフェーズ型
+template <typename T>
+concept PhaseWithParam = std::derived_from<T, IPhase> &&
+                         std::move_constructible<typename T::Param> &&
+                         std::constructible_from<T, const typename T::Param&>;
+
+/// @brief 型 T のパラメータを保持し、make() で T を生成する IPhaseMaker
+template <PhaseWithParam T>
+class PhaseMaker : public IPhaseMaker {
+ public:
+  explicit PhaseMaker(typename T::Param param) : m_param(std::move(param)) {}
+
+  [[nodiscard]] std::unique_ptr<IPhase> make() const override {
+    return std::make_unique<T>(m_param);
+  }
+
+ private:
+  typename T::Param m_param;
+};
+
+/// @brief 型 T に対する PhaseLoader を生成するヘルパー
+/// @param parse TOML 値から T::Param を生成するラムダ（失敗時は
+/// unexpected でエラーメッセージを返す）
+template <PhaseWithParam T, typename F>
+PhaseLoader MakeLoader(F&& parse) {
+  return [p = std::forward<F>(parse)](
+             const TOMLValue& step) -> std::expected<IPhaseMaker::Ptr, String> {
+    auto param = p(step);
+    if (!param) {
+      return std::unexpected{std::move(param).error()};
+    }
+    return std::make_shared<const PhaseMaker<T>>(*std::move(param));
+  };
+}
+
+}  // namespace
+
+const PhaseLoaderTable& GetPhaseLoaders() {
+  static const PhaseLoaderTable loaders{
+      {U"player_test",
+       MakeLoader<PlayerTestPhase>(
+           [](const TOMLValue&)
+               -> std::expected<PlayerTestPhase::Param, String> {
+             return PlayerTestPhase::Param{};
+           })},
+      {U"test_menu",
+       MakeLoader<TestMenuPhase>(
+           [](const TOMLValue&) -> std::expected<TestMenuPhase::Param, String> {
+             return TestMenuPhase::Param{};
+           })},
+      {U"animation_viewer",
+       MakeLoader<AnimationViewerPhase>(
+           [](const TOMLValue& step)
+               -> std::expected<AnimationViewerPhase::Param, String> {
+             const auto dataKey = step[U"param"].getOpt<String>();
+             if (!dataKey) {
+               return std::unexpected{
+                   U"ScenarioData::ParseStep: animation_viewer に param があ"
+                   U"りません"};
+             }
+             return AnimationViewerPhase::Param{.dataKey = *dataKey};
+           })},
+      {U"scenario",
+       MakeLoader<ScenarioPhase>(
+           [](const TOMLValue& step)
+               -> std::expected<ScenarioPhase::Param, String> {
+             const auto sectionName = step[U"param"].getOpt<String>();
+             if (!sectionName) {
+               return std::unexpected{
+                   U"ScenarioData::ParseStep: scenario に param がありません"};
+             }
+             return ScenarioPhase::Param{.sectionName = *sectionName};
+           })},
+      {U"wait",
+       MakeLoader<WaitPhase>([](const TOMLValue& step)
+                                 -> std::expected<WaitPhase::Param, String> {
+         const auto duration = step[U"duration"].getOpt<double>();
+         if (!duration) {
+           return std::unexpected{
+               U"ScenarioData::ParseStep: wait に duration がありません"};
+         }
+         return WaitPhase::Param{.duration = *duration};
+       })},
+  };
+  return loaders;
+}

--- a/Ash2/src/Phase/PhaseLoaders.hpp
+++ b/Ash2/src/Phase/PhaseLoaders.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include "Config/ScenarioData.hpp"
+
+/// @brief 実装済みフェーズ名 → PhaseLoader のマップを返す
+[[nodiscard]] const PhaseLoaderTable& GetPhaseLoaders();

--- a/Ash2/tests/TestScenarioData.cpp
+++ b/Ash2/tests/TestScenarioData.cpp
@@ -2,6 +2,7 @@
 #include <ThirdParty/Catch2/catch.hpp>
 
 #include "Config/ScenarioData.hpp"
+#include "Phase/PhaseLoaders.hpp"
 #include "Phase/WaitPhase.hpp"
 
 TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
@@ -11,7 +12,7 @@ TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
       "phase = \"wait\"\n"
       "duration = 1.5\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
-  const ScenarioData data = ScenarioData::FromToml(reader);
+  const ScenarioData data = ScenarioData::FromToml(reader, GetPhaseLoaders());
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
   const auto& step = data.sections.at(U"intro")[0];
@@ -29,7 +30,7 @@ TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
       "phase = \"wait\"\n"
       "duration = 2.0\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
-  const ScenarioData data = ScenarioData::FromToml(reader);
+  const ScenarioData data = ScenarioData::FromToml(reader, GetPhaseLoaders());
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
   const auto& step = data.sections.at(U"intro")[0];
@@ -46,7 +47,7 @@ TEST_CASE("ScenarioData::FromToml - unknown phase name throws Error") {
       "action = \"push\"\n"
       "phase = \"nonexistent\"\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
-  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
+  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - unknown action throws Error") {
@@ -55,7 +56,7 @@ TEST_CASE("ScenarioData::FromToml - unknown action throws Error") {
       "action = \"fly\"\n"
       "phase = \"wait\"\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
-  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
+  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - missing duration throws Error") {
@@ -64,7 +65,7 @@ TEST_CASE("ScenarioData::FromToml - missing duration throws Error") {
       "action = \"push\"\n"
       "phase = \"wait\"\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
-  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
+  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - missing param throws Error") {
@@ -73,7 +74,7 @@ TEST_CASE("ScenarioData::FromToml - missing param throws Error") {
       "action = \"push\"\n"
       "phase = \"scenario\"\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
-  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader), Error);
+  REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 #endif

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -96,7 +96,8 @@
 | [`WaitPhase`](../Ash2/src/Phase/WaitPhase.hpp) | `wait` | 指定秒数待機して Pop |
 
 [`Config/ScenarioData`](../Ash2/src/Config/ScenarioData.hpp) がシナリオロード時に各ステップを `IPhaseMaker`（型消去された `make() -> unique_ptr<IPhase>`）を持つ `ScenarioStep`（`StepPush`/`StepReset`）に変換する。
-変換テーブルは [`Config/ScenarioData.cpp`](../Ash2/src/Config/ScenarioData.cpp) の `kPhaseLoaders` で定義されており、**新フェーズ追加時はここにもエントリを追加する必要がある。**
+変換テーブルは [`Phase/PhaseLoaders.cpp`](../Ash2/src/Phase/PhaseLoaders.cpp) の `GetPhaseLoaders()` で定義されており、**新フェーズ追加時はここにもエントリを追加する必要がある。**
+`ScenarioData::FromToml` はこのテーブルを `PhaseLoaderTable` として引数で受け取る（Config 層から具象フェーズへの依存を作らないため）。呼び出し元は `GameSetup` が `GetPhaseLoaders()` を渡して配線する。
 
 ---
 
@@ -183,3 +184,4 @@
 - 新クラス追加時は `Ash2.vcxproj` と `Ash2.vcxproj.filters` にも追加が必要。
 - `NameLookup` への挿入・削除は `NameLookupSystem::Connect` で自動化されている（`Name` コンポーネントの追加・削除に連動）。手動での `NameLookup[key] = entity` 登録は不要。
 - `Motion` に新しい状態型を追加したときは、`MotionSystem.cpp` の `MotionName()`（デバッグログ用）にも分岐を追加する。また、`MotionSystem::Update` の `std::visit` は `MotionState` concept（`MotionSystem.hpp`）で制約されているため、新状態型は `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。
+- 新フェーズを追加し TOML から `push`/`reset` できるようにするときは、`Phase/PhaseLoaders.cpp` の `GetPhaseLoaders()` にもエントリを追加する。


### PR DESCRIPTION
## 概要

`Config/ScenarioData.cpp` が具象 Phase 5 つに include 依存していた逆依存を解消する。close #213

## 変更内容

- `Ash2/src/Phase/PhaseLoaders.hpp` / `.cpp` を新設し、フェーズ名 → ローダーの登録テーブルと `PhaseWithParam` / `PhaseMaker` / `MakeLoader` を移設した
- `Config/ScenarioData.hpp` に型別名 `PhaseLoader` / `PhaseLoaderTable` を追加し、`ScenarioData::FromToml` がローダーテーブルを引数で受け取る形にした
- 配線は Config と Phase の両方を束ねる `GameSetup` が行う
- `docs/REFERENCE.md` のテーブル所在・`ScenarioData` の説明・部品追加時の注意を更新した

## 技術的な判断

- Issue にあった「例外として ARCHITECTURE.md に明文化する」案は見送った。明文化ではフェーズを追加するたびに Config 側を編集する摩擦が残るため
- `FromToml` の `loaders` 引数にデフォルト値は付けていない。デフォルト値を持たせると Config が具象フェーズ一覧を知る必要が戻るため
- `GetPhaseLoaders()` は関数内 static でテーブルを保持し `const&` を返す。名前空間スコープの静的初期化順序の問題を避けるため
- 挙動は変えていない。エラーメッセージ文字列と TOML スキーマは既存のまま

## 確認

- format / tidy / build / test すべて通過（113 テストケース・276 アサーション成功）