### PR TITLE
HitSystemの判定ロジックをcppファイルに分離

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="src\System\EnemyMotionSystem.cpp" />
     <ClCompile Include="src\System\EnemySystem.cpp" />
     <ClCompile Include="src\System\HitReactionSystem.cpp" />
+    <ClCompile Include="src\System\HitSystem.cpp" />
     <ClCompile Include="src\System\ProjectileSystem.cpp" />
     <ClCompile Include="src\System\MovementSystem.cpp" />
     <ClCompile Include="src\System\GravitySystem.cpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -231,6 +231,9 @@
     <ClCompile Include="System\HitReactionSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\HitSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="System\ProjectileSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>

--- a/Ash2/src/System/HitSystem.cpp
+++ b/Ash2/src/System/HitSystem.cpp
@@ -1,0 +1,105 @@
+#include "System/HitSystem.hpp"
+
+#include "Component/Attack.hpp"
+#include "Component/Collider.hpp"
+#include "Component/Hp.hpp"
+#include "Component/Invincible.hpp"
+#include "Component/WorldPos.hpp"
+
+namespace {
+/// @brief 線分を表す内部構造体
+struct Segment {
+  Vec3 start;
+  Vec3 end;
+};
+
+/// @brief 2線分間の最近接距離の二乗を返す
+[[nodiscard]] double SegmentDistSq(Segment segA, Segment segB) {
+  // 線分の長さの二乗がこの値以下のとき点とみなす
+  constexpr double KDegenerateThreshold = 1e-10;
+
+  const Vec3 d1 = segA.end - segA.start;
+  const Vec3 d2 = segB.end - segB.start;
+  const Vec3 r = segA.start - segB.start;
+  const double a = d1.dot(d1);
+  const double e = d2.dot(d2);
+  const double f = d2.dot(r);
+
+  double s = 0.0;
+  double t = 0.0;
+
+  if (a <= KDegenerateThreshold && e <= KDegenerateThreshold) {
+    return r.dot(r);
+  }
+  if (a <= KDegenerateThreshold) {
+    t = Clamp(f / e, 0.0, 1.0);
+  } else {
+    const double c = d1.dot(r);
+    if (e <= KDegenerateThreshold) {
+      s = Clamp(-c / a, 0.0, 1.0);
+    } else {
+      const double b = d1.dot(d2);
+      const double denom = a * e - b * b;
+      s = (denom != 0.0) ? Clamp((b * f - c * e) / denom, 0.0, 1.0) : 0.0;
+      t = (b * s + f) / e;
+      if (t < 0.0) {
+        t = 0.0;
+        s = Clamp(-c / a, 0.0, 1.0);
+      } else if (t > 1.0) {
+        t = 1.0;
+        s = Clamp((b - c) / a, 0.0, 1.0);
+      }
+    }
+  }
+
+  const Vec3 closest1 = segA.start + d1 * s;
+  const Vec3 closest2 = segB.start + d2 * t;
+  return (closest1 - closest2).dot(closest1 - closest2);
+}
+}  // namespace
+
+Array<HitPair> HitSystem::Update(entt::registry& registry) {
+  Array<HitPair> hits;
+
+  auto attackers = registry.view<WorldPos, Collider, Attack>();
+  auto targets =
+      registry.view<WorldPos, Collider, Hp>(entt::exclude<Invincible>);
+
+  for (auto&& [attacker, aPos, aCol, atk] : attackers.each()) {
+    // root が設定されている場合はルートの Attack を参照してヒット管理する
+    const auto rootEntity = (atk.root != entt::null) ? atk.root : attacker;
+    // root は破棄済み・Attack 非保持の可能性があるため参照前に検証する
+    // （attacker 自身が root の場合は attackers
+    // ビューの走査対象なので必ず有効） valid
+    // を先に評価する短絡順序を維持し、破棄済みエンティティへの all_of/get
+    // 呼び出し（未定義動作）を避ける
+    if (!registry.valid(rootEntity) || !registry.all_of<Attack>(rootEntity))
+      continue;
+    auto& rootAtk = registry.get<Attack>(rootEntity);
+
+    const Vec3 worldA{aPos.w, aPos.h, aPos.d};
+    const Vec3 ap1 = worldA + aCol.segmentStart;
+    const Vec3 ap2 = worldA + aCol.segmentEnd;
+
+    for (auto&& [target, tPos, tCol, hp] : targets.each()) {
+      if (attacker == target) continue;
+      if (rootEntity == target) continue;
+      if (rootAtk.hitTargets.contains(target)) continue;
+
+      const Vec3 worldT{tPos.w, tPos.h, tPos.d};
+      const Vec3 tp1 = worldT + tCol.segmentStart;
+      const Vec3 tp2 = worldT + tCol.segmentEnd;
+
+      const double sumR = aCol.radius + tCol.radius;
+      if (SegmentDistSq(Segment{.start = ap1, .end = ap2},
+                        Segment{.start = tp1, .end = tp2}) >= sumR * sumR)
+        continue;
+
+      rootAtk.hitTargets.emplace(target);
+      hp.current = Max(0, hp.current - rootAtk.damage);
+      hits.push_back(HitPair{.attacker = rootEntity, .target = target});
+    }
+  }
+
+  return hits;
+}

--- a/Ash2/src/System/HitSystem.hpp
+++ b/Ash2/src/System/HitSystem.hpp
@@ -3,12 +3,6 @@
 
 #include <entt/entt.hpp>
 
-#include "Component/Attack.hpp"
-#include "Component/Collider.hpp"
-#include "Component/Hp.hpp"
-#include "Component/Invincible.hpp"
-#include "Component/WorldPos.hpp"
-
 /// @brief 攻撃側・被弾側のエンティティの組
 struct HitPair {
   entt::entity attacker;
@@ -22,103 +16,4 @@ class HitSystem {
   /// にダメージを適用する
   /// @return このフレームで新たに成立したヒットの一覧
   [[nodiscard]] static Array<HitPair> Update(entt::registry& registry);
-
- private:
-  /// @brief 線分を表す内部構造体
-  struct Segment {
-    Vec3 start;
-    Vec3 end;
-  };
-
-  /// @brief 2線分間の最近接距離の二乗を返す
-  [[nodiscard]] static double SegmentDistSq(Segment segA, Segment segB);
 };
-
-inline double HitSystem::SegmentDistSq(Segment segA, Segment segB) {
-  // 線分の長さの二乗がこの値以下のとき点とみなす
-  constexpr double KDegenerateThreshold = 1e-10;
-
-  const Vec3 d1 = segA.end - segA.start;
-  const Vec3 d2 = segB.end - segB.start;
-  const Vec3 r = segA.start - segB.start;
-  const double a = d1.dot(d1);
-  const double e = d2.dot(d2);
-  const double f = d2.dot(r);
-
-  double s = 0.0;
-  double t = 0.0;
-
-  if (a <= KDegenerateThreshold && e <= KDegenerateThreshold) {
-    return r.dot(r);
-  }
-  if (a <= KDegenerateThreshold) {
-    t = Clamp(f / e, 0.0, 1.0);
-  } else {
-    const double c = d1.dot(r);
-    if (e <= KDegenerateThreshold) {
-      s = Clamp(-c / a, 0.0, 1.0);
-    } else {
-      const double b = d1.dot(d2);
-      const double denom = a * e - b * b;
-      s = (denom != 0.0) ? Clamp((b * f - c * e) / denom, 0.0, 1.0) : 0.0;
-      t = (b * s + f) / e;
-      if (t < 0.0) {
-        t = 0.0;
-        s = Clamp(-c / a, 0.0, 1.0);
-      } else if (t > 1.0) {
-        t = 1.0;
-        s = Clamp((b - c) / a, 0.0, 1.0);
-      }
-    }
-  }
-
-  const Vec3 closest1 = segA.start + d1 * s;
-  const Vec3 closest2 = segB.start + d2 * t;
-  return (closest1 - closest2).dot(closest1 - closest2);
-}
-
-inline Array<HitPair> HitSystem::Update(entt::registry& registry) {
-  Array<HitPair> hits;
-
-  auto attackers = registry.view<WorldPos, Collider, Attack>();
-  auto targets =
-      registry.view<WorldPos, Collider, Hp>(entt::exclude<Invincible>);
-
-  for (auto&& [attacker, aPos, aCol, atk] : attackers.each()) {
-    // root が設定されている場合はルートの Attack を参照してヒット管理する
-    const auto rootEntity = (atk.root != entt::null) ? atk.root : attacker;
-    // root は破棄済み・Attack 非保持の可能性があるため参照前に検証する
-    // （attacker 自身が root の場合は attackers
-    // ビューの走査対象なので必ず有効） valid
-    // を先に評価する短絡順序を維持し、破棄済みエンティティへの all_of/get
-    // 呼び出し（未定義動作）を避ける
-    if (!registry.valid(rootEntity) || !registry.all_of<Attack>(rootEntity))
-      continue;
-    auto& rootAtk = registry.get<Attack>(rootEntity);
-
-    const Vec3 worldA{aPos.w, aPos.h, aPos.d};
-    const Vec3 ap1 = worldA + aCol.segmentStart;
-    const Vec3 ap2 = worldA + aCol.segmentEnd;
-
-    for (auto&& [target, tPos, tCol, hp] : targets.each()) {
-      if (attacker == target) continue;
-      if (rootEntity == target) continue;
-      if (rootAtk.hitTargets.contains(target)) continue;
-
-      const Vec3 worldT{tPos.w, tPos.h, tPos.d};
-      const Vec3 tp1 = worldT + tCol.segmentStart;
-      const Vec3 tp2 = worldT + tCol.segmentEnd;
-
-      const double sumR = aCol.radius + tCol.radius;
-      if (SegmentDistSq(Segment{.start = ap1, .end = ap2},
-                        Segment{.start = tp1, .end = tp2}) >= sumR * sumR)
-        continue;
-
-      rootAtk.hitTargets.emplace(target);
-      hp.current = Max(0, hp.current - rootAtk.damage);
-      hits.push_back(HitPair{.attacker = rootEntity, .target = target});
-    }
-  }
-
-  return hits;
-}


### PR DESCRIPTION
close #177

## 変更概要

- `HitSystem.hpp` に `inline` 実装されていた `SegmentDistSq`（線分間最近接距離）と `Update`（攻撃側×被弾側の全探索）を新規 `HitSystem.cpp` へ移動
- `Segment` 構造体と `SegmentDistSq` は他 System の既存規約（StaminaSystem 等）に合わせ、ヘッダの `private:` セクションではなく .cpp の無名名前空間のフリー関数として配置
- `HitPair` は HitReactionSystem が参照するためヘッダに残置
- `Ash2.vcxproj` / `Ash2.vcxproj.filters` に ClCompile エントリを追加

## 技術選択の理由

- private static メンバ宣言をヘッダに残す案は、内部詳細がヘッダに残り既存規約とも不揃いのため見送り、無名名前空間方式を採用
- 挙動変更なし（移動したコードはコメント含め移動前と同一）。全探索の最適化は Issue 記載どおりスコープ外

## 確認

- format / tidy / build / test すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)