### PR TITLE
melee.stages が空の場合を FromToml で致命として確定させる

### DIFF
--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -40,8 +40,6 @@ PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
   // Why not: m[U"stage"] がテーブル配列として存在しない場合に
   // tableArrayView() を呼ぶと不正アクセスになるため、
   // 事前に isTableArray() で存在確認する。
-  // キー欠落時は空の stages のままとし、旧 get<T>() のデフォルト値
-  // 挙動に倣って寛容に扱う。
   if (const auto& stageValue = m[U"stage"]; stageValue.isTableArray()) {
     for (const auto& stageToml : stageValue.tableArrayView()) {
       stages.push_back(MeleeStageConfig{
@@ -53,6 +51,13 @@ PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
           .hitstopSec = stageToml[U"hitstop_sec"].get<double>(),
       });
     }
+  }
+  // Why not: 空の stages を許すと Tick(Melee&, ...) の
+  // stages[state.stage] アクセスが不正になるが、ここは設定読み込みの
+  // 最上位境界であり、呼び出し元の GameSetup は expected を扱わない
+  // 設計のため throw で致命として確定させる。
+  if (stages.isEmpty()) {
+    throw Error{U"PlayerConfig::FromToml: melee.stage がありません"};
   }
 
   return {

--- a/Ash2/src/System/PlayerMotion/Melee.cpp
+++ b/Ash2/src/System/PlayerMotion/Melee.cpp
@@ -78,6 +78,8 @@ Optional<Motion> Tick(Melee& state, entt::registry& registry,
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& melee = cfg.melee;
+  assert(state.stage < melee.stages.size() &&
+         "state.stage は melee.stages の範囲内でなければならない");
   const auto& stageCfg = melee.stages[state.stage];
   const auto& timeline = stageCfg.timeline;
   const auto& input = frameData.input;

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -7,12 +7,33 @@ TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
   constexpr std::string_view Toml =
       "speed = 150.0\n"
       "jump_speed = 400.0\n"
-      "gravity = 900.0\n";
+      "gravity = 900.0\n"
+      "[[melee.stage]]\n"
+      "windup_sec = 0.1\n"
+      "active_sec = 0.1\n"
+      "recovery_a_sec = 0.1\n"
+      "recovery_b_sec = 0.1\n"
+      "radius = 20.0\n"
+      "trajectory = \"thrust\"\n"
+      "slash_rise_height = 0.0\n"
+      "hitstop_sec = 0.05\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
   const PlayerConfig cfg = PlayerConfig::FromToml(reader);
   REQUIRE(cfg.speed == 150.0);
   REQUIRE(cfg.jumpSpeed == 400.0);
   REQUIRE(cfg.gravity == 900.0);
+  REQUIRE(cfg.melee.stages.size() == 1);
+  REQUIRE(cfg.melee.stages[0].trajectory == MeleeTrajectory::Thrust);
+  REQUIRE(cfg.melee.stages[0].radius == 20.0);
+}
+
+TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {
+  constexpr std::string_view Toml =
+      "speed = 150.0\n"
+      "jump_speed = 400.0\n"
+      "gravity = 900.0\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
 }
 
 TEST_CASE("PlayerConfig - can set speed directly") {

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -301,6 +301,8 @@
   `Attack.hitstopSec` へ渡す停止時間で、段・アクションごとに調整できる（`RangedConfig` は持たない。
   弾は `reaction` が `None` で無反応の仕様のため）
 - 近接攻撃はスタミナを消費しない（`MeleeConfig` は `staminaCost` を持たない）
+- `[[melee.stage]]` が0件（欠落含む）の場合、`FromToml` は `Error` を投げる
+  （`Tick(Melee&, ...)` の `stages[state.stage]` アクセスを不正にしないため）
 
 ### [`EnemyConfig`](../Ash2/src/Config/EnemyConfig.hpp)
 


### PR DESCRIPTION
close #237

## 概要

`melee.stages` が空のまま `Tick(Melee&, ...)` に到達すると `melee.stages[state.stage]` が範囲外アクセス（未定義動作）になる問題を解消する。

- `PlayerConfig::FromToml` の段パースループ直後に `stages.isEmpty()` の検証を追加し、空なら `throw Error{U"PlayerConfig::FromToml: melee.stage がありません"}` で致命として確定させる
- `Tick(Melee&, ...)` の添字直前に `assert` を置き、添字が範囲内であるという契約を明示する
- `[[melee.stage]]` の欠落時に throw することを検証するテストを追加し、既存テストの TOML にも段を1件追加して `stages` のパースをカバーする
- `docs/REFERENCE.md` の `PlayerConfig` 節に throw する旨を追記する

## 実装判断

### throw の位置を `FromToml` 本体にした理由

`ScenarioData::FromToml` が「設定読み込みの最上位境界であり、呼び出し元の `GameSetup` は `expected` を扱わない設計のため throw で致命として確定させる」という形を既に取っており、それに揃えた。Why not コメントもこの表現に倣っている。

同ファイルの `ParseMeleeTrajectory` は「`expected` を返せない `FromToml` の下請けのため」という理由で throw しているが、この文言は流用していない。下位関数が `expected` を経ずに throw する形は #240 で是正する対象のため。

### `Tick(Neutral&, ...)` 側でガードしなかった理由

Melee 入場条件に `!cfg.melee.stages.isEmpty()` を足す案も検討したが、設定不備が「攻撃が出ない」形でしか現れず原因の特定が遅れる。また設定不備の種類が増えるたびに同種の分岐がモーション側へ散る。起動時（Debug の F5 では押した時点）に判明する形を選んだ。

### 空チェックが `isTableArray()` の分岐も兼ねる

`m[U"stage"]` がテーブル配列でない場合（キー欠落・型違いの両方）も `stages` は空のままになるため、ループ後の1箇所で両方を拾える。

### `assert` を設定不備の検出に使っていない

`assert` はリリースビルドで消えるうえ、`ERROR_HANDLING.md` は外部入力・設定ファイルの検証に `assert` を使わないとしている。設定の検証は `FromToml` の throw が担い、`assert` はコード側の不変条件（`hasNextStage` による上限ガードと `FromToml` の空検証で保証される）の明示に限定した。

## スコープ外

- 下位パース関数の `expected` 化と `get<T>()` → `getOpt<T>()` の移行は #240 に切り出した
- `s3d::Error` は `std::exception` を継承しないため `Main.cpp` の `catch (const std::exception&)` では捕捉されず `crash.log` に残らない。既存の `ParseMeleeTrajectory` の throw も同じ状態であり、本 PR が作った問題ではないため対象外とした
- 段数が `melee_N` クリップ数を超える設定は `AnimationSystem` の assert で落ちる。本 PR の対象外

## 確認

format・tidy・build・test をすべて通過（153 テストケース / 351 アサーション）。`assets/config/player.toml` は3段を持つため、正常な設定での挙動は変わらない。
