### PR TITLE
MotionSystem のデバッグ用 MotionName() を削除

### DIFF
--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -3,46 +3,9 @@
 #include "System/MotionSystem.hpp"
 
 #include "Component/Hitstop.hpp"
-#include "Debug.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/EnemyMotionSystem.hpp"
 #include "System/PlayerMotionSystem.hpp"
-
-#ifdef _DEBUG
-namespace {
-String MotionName(const Motion& m) {
-  return std::visit(
-      [](const auto& s) -> String {
-        using T = std::decay_t<decltype(s)>;
-        if constexpr (std::is_same_v<T, PlayerMotion::Neutral>)
-          return U"Neutral";
-        else if constexpr (std::is_same_v<T, PlayerMotion::Melee>)
-          return U"Melee" + Format(s.stage + 1);
-        else if constexpr (std::is_same_v<T, PlayerMotion::Ranged>)
-          return U"Ranged";
-        else if constexpr (std::is_same_v<T, PlayerMotion::Dash>)
-          return s.air ? U"AirDash" : U"Dash";
-        else if constexpr (std::is_same_v<T, PlayerMotion::DashAttack>)
-          return s.air ? U"AirDashAttack" : U"DashAttack";
-        else if constexpr (std::is_same_v<T, PlayerMotion::AirAttack>)
-          return U"AirAttack";
-        else if constexpr (std::is_same_v<T, PlayerMotion::Landing>)
-          return U"Landing";
-        else if constexpr (std::is_same_v<T, EnemyMotion::Idle>)
-          return U"EnemyIdle";
-        else if constexpr (std::is_same_v<T, EnemyMotion::Stagger>)
-          return U"EnemyStagger";
-        else if constexpr (std::is_same_v<T, EnemyMotion::Repel>)
-          return U"EnemyRepel";
-        else if constexpr (std::is_same_v<T, EnemyMotion::Knockback>)
-          return U"EnemyKnockback";
-        else if constexpr (std::is_same_v<T, EnemyMotion::Defeated>)
-          return U"EnemyDefeated";
-      },
-      m);
-}
-}  // namespace
-#endif
 
 void MotionSystem::Update(entt::registry& registry,
                           const FrameData& frameData) {
@@ -61,7 +24,6 @@ void MotionSystem::Update(entt::registry& registry,
         },
         motion);
     if (next.has_value()) {
-      APP_LOG(U"[Motion] " + MotionName(motion) + U" → " + MotionName(*next));
       registry.replace<Motion>(entity, *next);
     }
   }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -155,7 +155,7 @@
 | システム | タイミング | 処理 |
 |---|---|---|
 | [`HitstopSystem::Update`](../Ash2/src/System/HitstopSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の前） | `Hitstop` を持つエンティティの残り時間を減算し、0 以下になったら除去する |
-| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Motion` の全状態ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了、無敵の付与/除去、接地検出）を行う。`Hitstop` を持つエンティティには dt = 0 の `FrameData` を渡し、タイムラインを凍結したまま入力の予約（`comboQueued` 等）だけ拾わせる。デバッグビルドでは遷移を `APP_LOG` に出力する |
+| [`MotionSystem::Update`](../Ash2/src/System/MotionSystem.hpp) | フェーズ内（PlayerTestPhase、HitstopSystem の後） | `Motion` の全状態ごとの `Tick()` を呼び、移動・ジャンプ・向き・クリップ決定・状態遷移（攻撃判定/弾エンティティ生成、タイマー満了、無敵の付与/除去、接地検出）を行う。`Hitstop` を持つエンティティには dt = 0 の `FrameData` を渡し、タイムラインを凍結したまま入力の予約（`comboQueued` 等）だけ拾わせる |
 | [`StaminaSystem::Update`](../Ash2/src/System/StaminaSystem.hpp) | フェーズ内（PlayerTestPhase、MotionSystem の後） | `Player + Stamina + Motion` を持つエンティティのスタミナを回復する。Neutral 状態のみ `recoveryDelay` 秒の待機後に不足分に比例した速度（`recoveryRate`）で回復し、端数は `accum` に積み立てて誤差を防ぐ |
 | [`MovementSystem::Update`](../Ash2/src/System/MovementSystem.hpp) | フェーズ内（PlayerTestPhase、StaminaSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity` エンティティ（Player・弾・Enemy）の位置を `vel * dt` で更新 |
 | [`GravitySystem::Update`](../Ash2/src/System/GravitySystem.hpp) | フェーズ内（PlayerTestPhase、MovementSystem の後） | `Hitstop` を持たない `WorldPos`+`Velocity`+`Gravity` エンティティに重力加速（次フレーム用）と地面クランプ（今フレームの `pos.h`・`vel.h` を 0 にする）を適用 |
@@ -442,6 +442,6 @@
 - `Drawable` の型変更は `std::visit` を使い、DrawSystem と AnimationSystem の両方への影響を確認する。
 - 新クラス追加時は `Ash2.vcxproj` と `Ash2.vcxproj.filters` にも追加が必要。
 - `NameLookup` への挿入・削除は `NameLookupSystem::Connect` で自動化されている（`Name` コンポーネントの追加・削除に連動）。手動での `NameLookup[key] = entity` 登録は不要。
-- `Motion` に新しい状態型を追加したときは、`MotionSystem.cpp` の `MotionName()`（デバッグログ用）にも分岐を追加する。また、`MotionSystem::Update` の `std::visit` は `MotionState` concept（`MotionSystem.hpp`）で制約されているため、新状態型は `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。
+- `Motion` に新しい状態型を追加したときは、その型に `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。`MotionSystem::Update` の `std::visit` が `MotionState` concept（`MotionSystem.hpp`）で制約されているため。
 - 新フェーズを追加し TOML から `push`/`reset` できるようにするときは、`Phase/PhaseLoaders.cpp` の `GetPhaseLoaders()` にもエントリを追加する。
 - 新しいアニメーションクリップを参照するときは `assets/config/animation/*.toml` 側にも追加する（欠落は `AnimationSystem` の `assert` で落ちる）。


### PR DESCRIPTION
close #238

## 変更概要

Debug ビルド専用のログ用関数 `MotionName()` を削除した。

- `Ash2/src/System/MotionSystem.cpp`
  - `#ifdef _DEBUG` の無名 namespace ブロック（`MotionName()` の定義）を削除
  - `MotionSystem::Update` 内の `APP_LOG` 呼び出しを削除
  - 使われなくなる `#include "Debug.hpp"` を削除
  - 68 行 → 31 行
- `docs/REFERENCE.md`
  - システム一覧の `MotionSystem::Update` から `APP_LOG` 出力の記述を削除
  - 「部品追加時の注意」から `MotionName()` への言及を削除

## 実装判断

### `Optional<String>` 化ではなく削除を選んだ

Issue で検討された「プレイヤー状態のみ名前を返す `Optional<String>` 化」は採らなかった。
敵の分岐が消えて自然な最終 `else` は書けるが、約 20 行が残るうえ、
新しいプレイヤー状態を追加したときに黙ってログに出なくなる罠も残るため。

遷移の正しさは `Ash2/tests/TestPlayerMotionSystem.cpp` と `TestEnemyMotionSystem.cpp` が固定している。
特定の遷移を追う必要が生じた場合は、その場に一時的な `APP_LOG` を足せば足りる。

### 「部品追加時の注意」の文を組み直した

`MotionName()` の記述だけを抜くと文の係り受けが壊れるため、
`Tick()` の実装要件を主文にし、`MotionState` concept による制約を理由として後ろに置く形にした。

### `Debug.hpp` 自体は残した

`Main.cpp` が `APP_LOG` を使い続けるため。

## 確認

- format / tidy / build / test すべて通過
- Release ビルドの出力物に差はない（元々 `APP_LOG` は `static_cast<void>(0)` に展開され、`MotionName()` も除外されていた）
