### PR TITLE
MakeRanged の AnimationDataRegistry 参照を dataKey 経由に直す

### DIFF
--- a/Ash2/src/System/PlayerMotion/Neutral.cpp
+++ b/Ash2/src/System/PlayerMotion/Neutral.cpp
@@ -13,8 +13,6 @@ Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
                       entt::entity entity, const FrameData& frameData) {
   const auto& input = frameData.input;
   const auto& cfg = registry.ctx().get<PlayerConfig>();
-  const auto& playerData =
-      registry.ctx().get<AnimationDataRegistry>().at(U"player");
   const auto& pos = registry.get<WorldPos>(entity);
   auto& vel = registry.get<Velocity>(entity);
   auto& anim = registry.get<SpriteAnimation>(entity);
@@ -43,7 +41,7 @@ Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
       vel.w = 0.0;
       vel.d = 0.0;
       SpawnProjectile(registry, pos, anim.facingRight, cfg);
-      return MakeRanged(registry, entity, cfg, playerData, anim);
+      return MakeRanged(registry, entity, cfg, anim);
     }
     if (input.dashDown &&
         registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
@@ -62,7 +60,7 @@ Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
     vel.w = 0.0;
     vel.d = 0.0;
     SpawnProjectile(registry, pos, anim.facingRight, cfg);
-    return MakeRanged(registry, entity, cfg, playerData, anim);
+    return MakeRanged(registry, entity, cfg, anim);
   } else if (input.dashDown &&
              registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
     // 空中ダッシュへの入場（Dash::Tick が air フラグにより接地検出で Landing

--- a/Ash2/src/System/PlayerMotion/Ranged.cpp
+++ b/Ash2/src/System/PlayerMotion/Ranged.cpp
@@ -1,11 +1,14 @@
 #include <Siv3D.hpp>
 
+#include <cassert>
+
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Projectile.hpp"
 #include "Component/Stamina.hpp"
 #include "Component/Velocity.hpp"
+#include "Config/AnimationData.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/PlayerMotion/Helper.hpp"
 #include "System/PlayerMotion/Transition.hpp"
@@ -48,12 +51,19 @@ void SpawnProjectile(entt::registry& registry, const WorldPos& pos,
 }
 
 Ranged MakeRanged(entt::registry& registry, entt::entity entity,
-                  const PlayerConfig& cfg, const AnimationData& playerData,
-                  SpriteAnimation& anim) {
+                  const PlayerConfig& cfg, SpriteAnimation& anim) {
   auto& stamina = registry.get<Stamina>(entity);
   stamina.current = Max(0, stamina.current - cfg.ranged.staminaCost);
+
+  const auto& dataRegistry = registry.ctx().get<AnimationDataRegistry>();
+  assert(dataRegistry.contains(anim.dataKey) &&
+         "AnimationDataRegistry にキーが存在しない");
+  const auto& data = dataRegistry.at(anim.dataKey);
+  assert(data.clips.contains(U"ranged_attack") &&
+         "clips に ranged_attack が存在しない");
+
   SetClip(anim, U"ranged_attack");
-  return Ranged{.timer = GetClipDuration(playerData, U"ranged_attack")};
+  return Ranged{.timer = GetClipDuration(data, U"ranged_attack")};
 }
 
 Optional<Motion> Tick(Ranged& state, entt::registry& registry,

--- a/Ash2/src/System/PlayerMotion/Transition.hpp
+++ b/Ash2/src/System/PlayerMotion/Transition.hpp
@@ -6,7 +6,6 @@
 #include "Component/PlayerMotion.hpp"
 #include "Component/SpriteAnimation.hpp"
 #include "Component/WorldPos.hpp"
-#include "Config/AnimationData.hpp"
 #include "Config/PlayerConfig.hpp"
 
 namespace PlayerMotion {
@@ -20,8 +19,7 @@ Melee MakeMelee(SpriteAnimation& anim, size_t stage,
 /// @brief Ranged へ移行する（スタミナ消費、遠距離攻撃クリップの設定と timer
 /// の算出）
 Ranged MakeRanged(entt::registry& registry, entt::entity entity,
-                  const PlayerConfig& cfg, const AnimationData& playerData,
-                  SpriteAnimation& anim);
+                  const PlayerConfig& cfg, SpriteAnimation& anim);
 
 /// @brief Dash へ移行する（スタミナ消費、クリップの設定）
 /// @param air 空中発動か（true: 空中ダッシュ相当）

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -396,7 +396,8 @@
 ## アニメーションクリップ名
 
 `assets/config/animation/player.toml` のクリップ名としてコードから参照されるもの。
-クリップ名の欠落は `AnimationSystem` の `assert` で検出される。
+クリップ名の欠落は `AnimationSystem` の `assert` で検出される（`ranged_attack` は
+`MakeRanged` でも同様の assert で検出する）。
 
 | クリップ名 | 使用箇所 |
 |---|---|


### PR DESCRIPTION
close #239

## 変更概要

`MakeRanged` が `AnimationDataRegistry` を `anim.dataKey` 経由で引くようにした。

- `MakeRanged` の引数 `const AnimationData& playerData` を廃止し、関数内でレジストリを引く
- `Tick(Neutral&, ...)` 先頭の毎フレームの `at(U"player")` を削除
- `MakeRanged` に `AnimationSystem` と同じ形の assert を2つ追加
- `docs/REFERENCE.md` のクリップ名欠落の検出箇所に `MakeRanged` を追記

## 実装判断

### 引数で渡さず `MakeRanged` の中で引く

`playerData` の用途は `Ranged::timer` の算出1箇所のみで、必要なのは遠距離攻撃の入場フレームだけ。`MakeRanged` は既に `registry` / `entity` / `anim` を受け取っているため、引数を1つ減らして呼び出し2箇所の重複も同時に消した。

### `ranged_attack` クリップの assert も追加

`AnimationSystem` はキー存在とクリップ存在を対で assert している。片方だけ移植すると不揃いなパターンが残るため両方置いた。`GetClipDuration` はクリップ未発見時に 0.0 を返す設計で、これは `Ranged::timer = 0` となり遠距離攻撃が1フレームで終わる無警告の誤動作を生むため、発生源で止める価値がある。

### 見送った選択肢

- `GetClipDuration` を `Optional<double>` に変更 — 呼び出し元が1箇所で、`none` の扱いも結局 assert になるため型を増やす価値がない
- `GetClipDuration` の `find` を `at()` に変更 — ゲームループ内の throw 経路を増やす方向で、Issue の動機と逆行する

## 補足

Issue 本文の「問題2（ゲームループ内の throw 経路）」は完全には解消していない。assert は debug でのみ有効で、release では `.at()` の throw が残るため、本 PR の成果は `AnimationSystem` と同水準にそろえるところまでとなる。

assert で設定ファイル由来のデータを検証している点は `docs/coding_style/ERROR_HANDLING.md` の「外部入力・設定ファイル・ユーザー操作の検証には使わない」と齟齬があるが、`AnimationSystem` も同じ状態であり本 PR が持ち込んだ問題ではない。ここだけ `Optional` / `expected` に変えると隣接する2箇所で流儀が割れるため、齟齬の解消は #243 に分離した。

## 確認

- `tools/run-format.sh` / `tools/run-tidy.sh` / `tools/build.sh` / `tools/run-tests.sh` すべて通過
