### PR TITLE
設定パース層を ScenarioData と同じエラー処理形式に揃える

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -161,6 +161,7 @@
     </ClCompile>
     <ClCompile Include="tests\TestAnimationData.cpp" />
     <ClCompile Include="tests\TestAttachmentSystem.cpp" />
+    <ClCompile Include="tests\TestEnemyConfig.cpp" />
     <ClCompile Include="tests\TestEnemyMotionSystem.cpp" />
     <ClCompile Include="tests\TestHitReactionSystem.cpp" />
     <ClCompile Include="tests\TestHitstopSystem.cpp" />
@@ -404,6 +405,7 @@
     <ClInclude Include="src\Config\EnemyConfig.hpp" />
     <ClInclude Include="src\Config\PlayerConfig.hpp" />
     <ClInclude Include="src\Config\ScenarioData.hpp" />
+    <ClInclude Include="src\Config\TomlFields.hpp" />
     <ClInclude Include="src\Phase\ScenarioPhase.hpp" />
     <ClInclude Include="src\Phase\WaitPhase.hpp" />
     <ClInclude Include="src\Phase\PhaseLoaders.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -315,6 +315,9 @@
     <ClCompile Include="tests\TestPlayerConfig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tests\TestEnemyConfig.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="tests\TestWaitPhase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1062,6 +1065,9 @@
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="Config\ScenarioData.hpp">
+      <Filter>Header Files\Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\TomlFields.hpp">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="Phase\ScenarioPhase.hpp">

--- a/Ash2/src/Config/AnimationData.cpp
+++ b/Ash2/src/Config/AnimationData.cpp
@@ -1,24 +1,71 @@
 #include "Config/AnimationData.hpp"
 
-AnimationData AnimationData::FromToml(const TOMLValue& toml) {
-  const auto& off = toml[U"draw_offset"];
-  AnimationData data{
-      .textureKey = toml[U"texture"].getString(),
-      .size = {toml[U"width"].get<int32>(), toml[U"height"].get<int32>()},
-      .drawOffset = {off[U"x"].get<double>(), off[U"y"].get<double>()},
-  };
+#include "Config/TomlFields.hpp"
+
+namespace {
+
+/// @brief TOML から1クリップ分の AnimationClip を生成する
+/// @param name クリップ名（欠落キーのメッセージにテーブル名として前置する）
+[[nodiscard]] std::expected<AnimationClip, String> ParseClip(
+    const TOMLValue& clip, StringView name) {
+  TomlFields f{clip, U"AnimationData::ParseClip", String{name}};
+  return f.wrap(AnimationClip{
+      .row = f.get<int32>(U"row"),
+      .count = f.get<int32>(U"count"),
+      .speed = f.get<double>(U"speed"),
+  });
+}
+
+/// @brief TOML からアニメーション共有データを生成する
+[[nodiscard]] std::expected<AnimationData, String> Parse(
+    const TOMLValue& toml) {
+  TomlFields f{toml, U"AnimationData::Parse"};
+  const auto textureKey = f.get<String>(U"texture");
+  const Size size = {f.get<int32>(U"width"), f.get<int32>(U"height")};
+
+  // draw_offset は別テーブルのため、prefix 付きの別インスタンスで読む。
+  // offset.check() が先に欠落を報告し、f 側の欠落チェックは後続の
+  // f.wrap() 呼び出しで別途行われる。
+  TomlFields offset{toml[U"draw_offset"], U"AnimationData::Parse",
+                    U"draw_offset"};
+  const Vec2 drawOffset = {offset.get<double>(U"x"), offset.get<double>(U"y")};
+  if (auto result = offset.check(); !result) {
+    return std::unexpected{std::move(result).error()};
+  }
+
+  auto wrapped = f.wrap(AnimationData{
+      .textureKey = textureKey,
+      .size = size,
+      .drawOffset = drawOffset,
+  });
+  if (!wrapped) {
+    return std::unexpected{std::move(wrapped).error()};
+  }
+  AnimationData data = *std::move(wrapped);
 
   for (const auto& member : toml.tableView()) {
     if (member.name == U"texture" || member.name == U"width" ||
         member.name == U"height" || member.name == U"draw_offset") {
       continue;
     }
-    const auto& clip = member.value;
-    data.clips[member.name] = AnimationClip{
-        .row = clip[U"row"].get<int32>(),
-        .count = clip[U"count"].get<int32>(),
-        .speed = clip[U"speed"].get<double>(),
-    };
+    auto clip = ParseClip(member.value, member.name);
+    if (!clip) {
+      return std::unexpected{std::move(clip).error()};
+    }
+    data.clips[member.name] = *std::move(clip);
   }
   return data;
+}
+
+}  // namespace
+
+AnimationData AnimationData::FromToml(const TOMLValue& toml) {
+  auto parsed = Parse(toml);
+  if (!parsed) {
+    // Why not: Parse からの失敗は expected で伝播してくるが、ここは設定
+    // 読み込みの最上位境界であり、呼び出し元の GameSetup は expected を
+    // 扱わない設計のため throw で致命として確定させる。
+    throw Error{std::move(parsed).error()};
+  }
+  return *std::move(parsed);
 }

--- a/Ash2/src/Config/EnemyConfig.cpp
+++ b/Ash2/src/Config/EnemyConfig.cpp
@@ -1,19 +1,38 @@
 #include "EnemyConfig.hpp"
 
+#include "Config/TomlFields.hpp"
+
+namespace {
+
+/// @brief TOML から EnemyConfig を生成する
+[[nodiscard]] std::expected<EnemyConfig, String> Parse(const TOMLValue& toml) {
+  TomlFields f{toml, U"EnemyConfig::Parse"};
+  return f.wrap(EnemyConfig{
+      .maxHp = f.get<int32>(U"max_hp"),
+      .size = {f.get<double>(U"size_w"), f.get<double>(U"size_h")},
+      .capsuleRadius = f.get<double>(U"capsule_radius"),
+      .capsuleHeight = f.get<double>(U"capsule_height"),
+      .spawnW = f.get<double>(U"spawn_w"),
+      .staggerSec = f.get<double>(U"stagger_sec"),
+      .repelSpeed = f.get<double>(U"repel_speed"),
+      .repelSec = f.get<double>(U"repel_sec"),
+      .blowSpeedW = f.get<double>(U"blow_speed_w"),
+      .blowSpeedH = f.get<double>(U"blow_speed_h"),
+      .knockbackSec = f.get<double>(U"knockback_sec"),
+      .defeatedSec = f.get<double>(U"defeated_sec"),
+      .respawnSec = f.get<double>(U"respawn_sec"),
+  });
+}
+
+}  // namespace
+
 EnemyConfig EnemyConfig::FromToml(const TOMLValue& toml) {
-  return {
-      .maxHp = toml[U"max_hp"].get<int32>(),
-      .size = {toml[U"size_w"].get<double>(), toml[U"size_h"].get<double>()},
-      .capsuleRadius = toml[U"capsule_radius"].get<double>(),
-      .capsuleHeight = toml[U"capsule_height"].get<double>(),
-      .spawnW = toml[U"spawn_w"].get<double>(),
-      .staggerSec = toml[U"stagger_sec"].get<double>(),
-      .repelSpeed = toml[U"repel_speed"].get<double>(),
-      .repelSec = toml[U"repel_sec"].get<double>(),
-      .blowSpeedW = toml[U"blow_speed_w"].get<double>(),
-      .blowSpeedH = toml[U"blow_speed_h"].get<double>(),
-      .knockbackSec = toml[U"knockback_sec"].get<double>(),
-      .defeatedSec = toml[U"defeated_sec"].get<double>(),
-      .respawnSec = toml[U"respawn_sec"].get<double>(),
-  };
+  auto parsed = Parse(toml);
+  if (!parsed) {
+    // Why not: Parse からの失敗は expected で伝播してくるが、ここは設定
+    // 読み込みの最上位境界であり、呼び出し元の GameSetup は expected を
+    // 扱わない設計のため throw で致命として確定させる。
+    throw Error{std::move(parsed).error()};
+  }
+  return *std::move(parsed);
 }

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -1,116 +1,247 @@
 #include "PlayerConfig.hpp"
 
+#include "Config/TomlFields.hpp"
+
 namespace {
 
 /// @brief TOML 値から MotionTimeline を生成する
+/// @param section 欠落キーのメッセージに前置するテーブル名
 /// @note windup_sec/active_sec/recovery_a_sec/recovery_b_sec
 /// の4キーを持つテーブルであればよく、melee の段テーブルのように
 /// 他のキーを併せ持っていても構わない
-MotionTimeline ParseTimeline(const TOMLValue& toml) {
-  return MotionTimeline{
-      .windupSec = toml[U"windup_sec"].get<double>(),
-      .activeSec = toml[U"active_sec"].get<double>(),
-      .recoveryASec = toml[U"recovery_a_sec"].get<double>(),
-      .recoveryBSec = toml[U"recovery_b_sec"].get<double>(),
-  };
+[[nodiscard]] std::expected<MotionTimeline, String> ParseTimeline(
+    const TOMLValue& toml, StringView section) {
+  TomlFields f{toml, U"PlayerConfig::ParseTimeline", String{section}};
+  return f.wrap(MotionTimeline{
+      .windupSec = f.get<double>(U"windup_sec"),
+      .activeSec = f.get<double>(U"active_sec"),
+      .recoveryASec = f.get<double>(U"recovery_a_sec"),
+      .recoveryBSec = f.get<double>(U"recovery_b_sec"),
+  });
 }
 
 /// @brief TOML の trajectory 文字列を MeleeTrajectory へ変換する
-// 初期化経路の設定読み込みであり、expected を返せない FromToml
-// の下請けのため、不明な値は throw で致命として確定させる
-MeleeTrajectory ParseMeleeTrajectory(const String& value) {
+[[nodiscard]] std::expected<MeleeTrajectory, String> ParseMeleeTrajectory(
+    const String& value) {
   if (value == U"thrust") return MeleeTrajectory::Thrust;
   if (value == U"slash") return MeleeTrajectory::Slash;
-  throw Error{U"PlayerConfig::FromToml: 不明な melee trajectory \"" + value +
-              U"\""};
+  return std::unexpected{
+      U"PlayerConfig::ParseMeleeTrajectory: 不明な melee "
+      U"trajectory \"" +
+      value + U"\""};
 }
 
-}  // namespace
+/// @brief TOML から近接コンボ1段分の MeleeStageConfig を生成する
+/// @param index 段のインデックス（欠落キーのメッセージに `melee.stage[index]`
+/// として前置し、 実運用の複数段のうちどの段が不正かを示す）
+[[nodiscard]] std::expected<MeleeStageConfig, String> ParseMeleeStage(
+    const TOMLValue& stageToml, size_t index) {
+  const String prefix = U"melee.stage[" + Format(index) + U"]";
+  auto timeline = ParseTimeline(stageToml, prefix);
+  if (!timeline) {
+    return std::unexpected{std::move(timeline).error()};
+  }
 
-PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
-  const auto& m = toml[U"melee"];
-  const auto& r = toml[U"ranged"];
-  const auto& d = toml[U"dash"];
-  const auto& da = toml[U"dash_attack"];
-  const auto& aa = toml[U"air_attack"];
-  const auto& s = toml[U"stamina"];
-  const auto& l = toml[U"landing"];
+  TomlFields f{stageToml, U"PlayerConfig::ParseMeleeStage", prefix};
+  const auto radius = f.get<double>(U"radius");
+  const auto trajectoryStr = f.get<String>(U"trajectory");
+  const auto slashRiseHeight = f.get<double>(U"slash_rise_height");
+  const auto hitstopSec = f.get<double>(U"hitstop_sec");
+  // Why not: trajectory の変換前に check() で欠落を確定させる。変換を先に
+  // 行うと、欠落時の既定値 String{}（空文字列）が「不明な trajectory」と
+  // 誤報されてしまうため。
+  if (auto result = f.check(); !result) {
+    return std::unexpected{std::move(result).error()};
+  }
 
+  auto trajectory = ParseMeleeTrajectory(trajectoryStr);
+  if (!trajectory) {
+    return std::unexpected{std::move(trajectory).error()};
+  }
+
+  return MeleeStageConfig{
+      .timeline = *std::move(timeline),
+      .radius = radius,
+      .trajectory = *trajectory,
+      .slashRiseHeight = slashRiseHeight,
+      .hitstopSec = hitstopSec,
+  };
+}
+
+/// @brief TOML から近接攻撃の設定値を生成する
+[[nodiscard]] std::expected<MeleeConfig, String> ParseMelee(
+    const TOMLValue& m) {
   Array<MeleeStageConfig> stages;
   // Why not: m[U"stage"] がテーブル配列として存在しない場合に
   // tableArrayView() を呼ぶと不正アクセスになるため、
   // 事前に isTableArray() で存在確認する。
   if (const auto& stageValue = m[U"stage"]; stageValue.isTableArray()) {
+    size_t index = 0;
     for (const auto& stageToml : stageValue.tableArrayView()) {
-      stages.push_back(MeleeStageConfig{
-          .timeline = ParseTimeline(stageToml),
-          .radius = stageToml[U"radius"].get<double>(),
-          .trajectory =
-              ParseMeleeTrajectory(stageToml[U"trajectory"].get<String>()),
-          .slashRiseHeight = stageToml[U"slash_rise_height"].get<double>(),
-          .hitstopSec = stageToml[U"hitstop_sec"].get<double>(),
-      });
+      auto stage = ParseMeleeStage(stageToml, index);
+      if (!stage) {
+        return std::unexpected{std::move(stage).error()};
+      }
+      stages.push_back(*std::move(stage));
+      ++index;
     }
   }
-  // Why not: 空の stages を許すと Tick(Melee&, ...) の
-  // stages[state.stage] アクセスが不正になるが、ここは設定読み込みの
-  // 最上位境界であり、呼び出し元の GameSetup は expected を扱わない
-  // 設計のため throw で致命として確定させる。
+  // stages が空だと Tick(Melee&, ...) の stages[state.stage] アクセスが
+  // 不正になるため許容しない
   if (stages.isEmpty()) {
-    throw Error{U"PlayerConfig::FromToml: melee.stage がありません"};
+    return std::unexpected{
+        U"PlayerConfig::ParseMelee: melee.stage がありません"};
   }
 
-  return {
-      .speed = toml[U"speed"].get<double>(),
-      .jumpSpeed = toml[U"jump_speed"].get<double>(),
-      .gravity = toml[U"gravity"].get<double>(),
-      .melee =
-          {
-              .capMidH = m[U"cap_mid_h"].get<double>(),
-              .reach = m[U"reach"].get<double>(),
-              .damage = m[U"damage"].get<int32>(),
-              .stages = std::move(stages),
-          },
-      .ranged =
-          {
-              .reach = r[U"reach"].get<double>(),
-              .radius = r[U"radius"].get<double>(),
-              .damage = r[U"damage"].get<int32>(),
-              .bulletSpeed = r[U"bullet_speed"].get<double>(),
-              .spawnHeight = r[U"spawn_height"].get<double>(),
-              .staminaCost = r[U"stamina_cost"].get<int32>(),
-          },
-      .dash =
-          {
-              .speed = d[U"speed"].get<double>(),
-              .timeline = ParseTimeline(d),
-              .staminaCost = d[U"stamina_cost"].get<int32>(),
-          },
-      .dashAttack =
-          {
-              .timeline = ParseTimeline(da),
-              .speed = da[U"speed"].get<double>(),
-              .orbitRadius = da[U"orbit_radius"].get<double>(),
-              .radius = da[U"radius"].get<double>(),
-              .damage = da[U"damage"].get<int32>(),
-              .hitstopSec = da[U"hitstop_sec"].get<double>(),
-          },
-      .airAttack =
-          {
-              .timeline = ParseTimeline(aa),
-              .orbitRadius = aa[U"orbit_radius"].get<double>(),
-              .radius = aa[U"radius"].get<double>(),
-              .damage = aa[U"damage"].get<int32>(),
-              .hitstopSec = aa[U"hitstop_sec"].get<double>(),
-          },
-      .stamina =
-          {
-              .recoveryDelay = s[U"recovery_delay"].get<double>(),
-              .recoveryRate = s[U"recovery_rate"].get<double>(),
-          },
-      .landing =
-          {
-              .recoverySec = l[U"recovery_sec"].get<double>(),
-          },
-  };
+  TomlFields f{m, U"PlayerConfig::ParseMelee", U"melee"};
+  return f.wrap(MeleeConfig{
+      .capMidH = f.get<double>(U"cap_mid_h"),
+      .reach = f.get<double>(U"reach"),
+      .damage = f.get<int32>(U"damage"),
+      .stages = std::move(stages),
+  });
+}
+
+/// @brief TOML から遠距離攻撃の設定値を生成する
+[[nodiscard]] std::expected<RangedConfig, String> ParseRanged(
+    const TOMLValue& r) {
+  TomlFields f{r, U"PlayerConfig::ParseRanged", U"ranged"};
+  return f.wrap(RangedConfig{
+      .reach = f.get<double>(U"reach"),
+      .radius = f.get<double>(U"radius"),
+      .damage = f.get<int32>(U"damage"),
+      .bulletSpeed = f.get<double>(U"bullet_speed"),
+      .spawnHeight = f.get<double>(U"spawn_height"),
+      .staminaCost = f.get<int32>(U"stamina_cost"),
+  });
+}
+
+/// @brief TOML からダッシュの設定値を生成する
+[[nodiscard]] std::expected<DashConfig, String> ParseDash(const TOMLValue& d) {
+  auto timeline = ParseTimeline(d, U"dash");
+  if (!timeline) {
+    return std::unexpected{std::move(timeline).error()};
+  }
+
+  TomlFields f{d, U"PlayerConfig::ParseDash", U"dash"};
+  return f.wrap(DashConfig{
+      .speed = f.get<double>(U"speed"),
+      .timeline = *std::move(timeline),
+      .staminaCost = f.get<int32>(U"stamina_cost"),
+  });
+}
+
+/// @brief TOML からダッシュ攻撃の設定値を生成する
+[[nodiscard]] std::expected<DashAttackConfig, String> ParseDashAttack(
+    const TOMLValue& da) {
+  auto timeline = ParseTimeline(da, U"dash_attack");
+  if (!timeline) {
+    return std::unexpected{std::move(timeline).error()};
+  }
+
+  TomlFields f{da, U"PlayerConfig::ParseDashAttack", U"dash_attack"};
+  return f.wrap(DashAttackConfig{
+      .timeline = *std::move(timeline),
+      .speed = f.get<double>(U"speed"),
+      .orbitRadius = f.get<double>(U"orbit_radius"),
+      .radius = f.get<double>(U"radius"),
+      .damage = f.get<int32>(U"damage"),
+      .hitstopSec = f.get<double>(U"hitstop_sec"),
+  });
+}
+
+/// @brief TOML から空中攻撃の設定値を生成する
+[[nodiscard]] std::expected<AirAttackConfig, String> ParseAirAttack(
+    const TOMLValue& aa) {
+  auto timeline = ParseTimeline(aa, U"air_attack");
+  if (!timeline) {
+    return std::unexpected{std::move(timeline).error()};
+  }
+
+  TomlFields f{aa, U"PlayerConfig::ParseAirAttack", U"air_attack"};
+  return f.wrap(AirAttackConfig{
+      .timeline = *std::move(timeline),
+      .orbitRadius = f.get<double>(U"orbit_radius"),
+      .radius = f.get<double>(U"radius"),
+      .damage = f.get<int32>(U"damage"),
+      .hitstopSec = f.get<double>(U"hitstop_sec"),
+  });
+}
+
+/// @brief TOML からスタミナ回復の設定値を生成する
+[[nodiscard]] std::expected<StaminaConfig, String> ParseStamina(
+    const TOMLValue& s) {
+  TomlFields f{s, U"PlayerConfig::ParseStamina", U"stamina"};
+  return f.wrap(StaminaConfig{
+      .recoveryDelay = f.get<double>(U"recovery_delay"),
+      .recoveryRate = f.get<double>(U"recovery_rate"),
+  });
+}
+
+/// @brief TOML から着地硬直の設定値を生成する
+[[nodiscard]] std::expected<LandingConfig, String> ParseLanding(
+    const TOMLValue& l) {
+  TomlFields f{l, U"PlayerConfig::ParseLanding", U"landing"};
+  return f.wrap(LandingConfig{
+      .recoverySec = f.get<double>(U"recovery_sec"),
+  });
+}
+
+/// @brief TOML からプレイヤー設定を生成する
+[[nodiscard]] std::expected<PlayerConfig, String> Parse(const TOMLValue& toml) {
+  auto melee = ParseMelee(toml[U"melee"]);
+  if (!melee) {
+    return std::unexpected{std::move(melee).error()};
+  }
+  auto ranged = ParseRanged(toml[U"ranged"]);
+  if (!ranged) {
+    return std::unexpected{std::move(ranged).error()};
+  }
+  auto dash = ParseDash(toml[U"dash"]);
+  if (!dash) {
+    return std::unexpected{std::move(dash).error()};
+  }
+  auto dashAttack = ParseDashAttack(toml[U"dash_attack"]);
+  if (!dashAttack) {
+    return std::unexpected{std::move(dashAttack).error()};
+  }
+  auto airAttack = ParseAirAttack(toml[U"air_attack"]);
+  if (!airAttack) {
+    return std::unexpected{std::move(airAttack).error()};
+  }
+  auto stamina = ParseStamina(toml[U"stamina"]);
+  if (!stamina) {
+    return std::unexpected{std::move(stamina).error()};
+  }
+  auto landing = ParseLanding(toml[U"landing"]);
+  if (!landing) {
+    return std::unexpected{std::move(landing).error()};
+  }
+
+  TomlFields f{toml, U"PlayerConfig::Parse"};
+  return f.wrap(PlayerConfig{
+      .speed = f.get<double>(U"speed"),
+      .jumpSpeed = f.get<double>(U"jump_speed"),
+      .gravity = f.get<double>(U"gravity"),
+      .melee = *std::move(melee),
+      .ranged = *std::move(ranged),
+      .dash = *std::move(dash),
+      .dashAttack = *std::move(dashAttack),
+      .airAttack = *std::move(airAttack),
+      .stamina = *std::move(stamina),
+      .landing = *std::move(landing),
+  });
+}
+
+}  // namespace
+
+PlayerConfig PlayerConfig::FromToml(const TOMLValue& toml) {
+  auto parsed = Parse(toml);
+  if (!parsed) {
+    // Why not: Parse からの失敗は expected で伝播してくるが、ここは設定
+    // 読み込みの最上位境界であり、呼び出し元の GameSetup は expected を
+    // 扱わない設計のため throw で致命として確定させる。
+    throw Error{std::move(parsed).error()};
+  }
+  return *std::move(parsed);
 }

--- a/Ash2/src/Config/TomlFields.hpp
+++ b/Ash2/src/Config/TomlFields.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <expected>
+
+/// @brief TOML テーブルの必須キーを読み、欠落キーをまとめて記録する
+///
+/// 1インスタンスが1テーブル・1プレフィックスを担当する。get() は欠落時に
+/// 既定値 T{} を返して読み進め、check()/wrap() でまとめて失敗に畳む。
+class TomlFields {
+ public:
+  /// @param context メッセージ先頭に付ける関数名
+  /// @param prefix メッセージ内でキー名に前置するテーブル名
+  TomlFields(TOMLValue table, String context, String prefix = {})
+      : m_table{std::move(table)},
+        m_context{std::move(context)},
+        m_prefix{std::move(prefix)} {}
+
+  /// @brief 必須キーを読む
+  /// @return 欠落時は T{}（キー名を記録して読み進める）
+  template <class T>
+  [[nodiscard]] T get(StringView key) {
+    if (auto value = m_table[String{key}].getOpt<T>()) {
+      return *std::move(value);
+    }
+    m_missing.push_back(m_prefix.isEmpty() ? String{key}
+                                           : (m_prefix + U"." + String{key}));
+    return T{};
+  }
+
+  /// @brief 記録した欠落を確認する
+  /// @return 欠落があれば全欠落キーを並べた unexpected
+  [[nodiscard]] std::expected<void, String> check() const {
+    if (m_missing.isEmpty()) {
+      return {};
+    }
+    return std::unexpected{m_context + U": キーがありません: " +
+                           m_missing.join(U", ", U"", U"")};
+  }
+
+  /// @brief 記録した欠落を expected に畳む
+  /// @return 欠落がなければ value、あれば check() と同じ unexpected
+  template <class T>
+  [[nodiscard]] std::expected<T, String> wrap(T value) const {
+    if (auto result = check(); !result) {
+      return std::unexpected{std::move(result).error()};
+    }
+    return value;
+  }
+
+ private:
+  TOMLValue m_table;
+  String m_context;
+  String m_prefix;
+  Array<String> m_missing;
+};

--- a/Ash2/tests/TestAnimationData.cpp
+++ b/Ash2/tests/TestAnimationData.cpp
@@ -52,6 +52,35 @@ TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
   REQUIRE(data.clips.at(U"walk").speed == 12.0);
 }
 
+TEST_CASE("AnimationData::FromToml - missing width throws Error") {
+  constexpr std::string_view Toml =
+      "texture = \"assets/images/player.png\"\n"
+      "height = 64\n"
+      "\n"
+      "[draw_offset]\n"
+      "x = -8.0\n"
+      "y = -32.0\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(AnimationData::FromToml(reader), Error);
+}
+
+TEST_CASE("AnimationData::FromToml - missing clip row throws Error") {
+  constexpr std::string_view Toml =
+      "texture = \"assets/images/player.png\"\n"
+      "width = 32\n"
+      "height = 64\n"
+      "\n"
+      "[draw_offset]\n"
+      "x = -8.0\n"
+      "y = -32.0\n"
+      "\n"
+      "[idle]\n"
+      "count = 4\n"
+      "speed = 8.0\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(AnimationData::FromToml(reader), Error);
+}
+
 TEST_CASE("AnimationData::FromToml - reserved keys are not treated as clips") {
   // texture / width / height / draw_offset はクリップとして誤認されてはならない
   constexpr std::string_view Toml =

--- a/Ash2/tests/TestEnemyConfig.cpp
+++ b/Ash2/tests/TestEnemyConfig.cpp
@@ -1,0 +1,59 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+
+#include "Config/EnemyConfig.hpp"
+
+TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
+  constexpr std::string_view Toml =
+      "max_hp = 100\n"
+      "size_w = 60.0\n"
+      "size_h = 80.0\n"
+      "capsule_radius = 30.0\n"
+      "capsule_height = 80.0\n"
+      "spawn_w = 150.0\n"
+      "stagger_sec = 0.15\n"
+      "repel_speed = 250.0\n"
+      "repel_sec = 0.20\n"
+      "blow_speed_w = 300.0\n"
+      "blow_speed_h = 300.0\n"
+      "knockback_sec = 1.00\n"
+      "defeated_sec = 0.50\n"
+      "respawn_sec = 1.00\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const EnemyConfig cfg = EnemyConfig::FromToml(reader);
+  REQUIRE(cfg.maxHp == 100);
+  REQUIRE(cfg.size.x == 60.0);
+  REQUIRE(cfg.size.y == 80.0);
+  REQUIRE(cfg.capsuleRadius == 30.0);
+  REQUIRE(cfg.capsuleHeight == 80.0);
+  REQUIRE(cfg.spawnW == 150.0);
+  REQUIRE(cfg.staggerSec == 0.15);
+  REQUIRE(cfg.repelSpeed == 250.0);
+  REQUIRE(cfg.repelSec == 0.20);
+  REQUIRE(cfg.blowSpeedW == 300.0);
+  REQUIRE(cfg.blowSpeedH == 300.0);
+  REQUIRE(cfg.knockbackSec == 1.00);
+  REQUIRE(cfg.defeatedSec == 0.50);
+  REQUIRE(cfg.respawnSec == 1.00);
+}
+
+TEST_CASE("EnemyConfig::FromToml - missing max_hp throws Error") {
+  constexpr std::string_view Toml =
+      "size_w = 60.0\n"
+      "size_h = 80.0\n"
+      "capsule_radius = 30.0\n"
+      "capsule_height = 80.0\n"
+      "spawn_w = 150.0\n"
+      "stagger_sec = 0.15\n"
+      "repel_speed = 250.0\n"
+      "repel_sec = 0.20\n"
+      "blow_speed_w = 300.0\n"
+      "blow_speed_h = 300.0\n"
+      "knockback_sec = 1.00\n"
+      "defeated_sec = 0.50\n"
+      "respawn_sec = 1.00\n";
+  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(EnemyConfig::FromToml(reader), Error);
+}
+
+#endif

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -1,30 +1,89 @@
 #ifdef _DEBUG
 #include <ThirdParty/Catch2/catch.hpp>
+#include <string>
+#include <tuple>
 
 #include "Config/PlayerConfig.hpp"
 
+namespace {
+
+/// @brief 全必須キーを満たす PlayerConfig 用 TOML（テストの基準値）
+constexpr std::string_view FullToml =
+    "speed = 150.0\n"
+    "jump_speed = 400.0\n"
+    "gravity = 900.0\n"
+    "[melee]\n"
+    "cap_mid_h = 30.0\n"
+    "reach = 60.0\n"
+    "damage = 20\n"
+    "[[melee.stage]]\n"
+    "windup_sec = 0.1\n"
+    "active_sec = 0.1\n"
+    "recovery_a_sec = 0.1\n"
+    "recovery_b_sec = 0.1\n"
+    "radius = 20.0\n"
+    "trajectory = \"thrust\"\n"
+    "slash_rise_height = 0.0\n"
+    "hitstop_sec = 0.05\n"
+    "[ranged]\n"
+    "reach = 200.0\n"
+    "radius = 15.0\n"
+    "damage = 15\n"
+    "bullet_speed = 300.0\n"
+    "spawn_height = 0.0\n"
+    "stamina_cost = 30\n"
+    "[dash]\n"
+    "speed = 600.0\n"
+    "windup_sec = 0.0\n"
+    "active_sec = 0.15\n"
+    "recovery_a_sec = 0.15\n"
+    "recovery_b_sec = 0.15\n"
+    "stamina_cost = 20\n"
+    "[dash_attack]\n"
+    "windup_sec = 0.05\n"
+    "active_sec = 0.35\n"
+    "recovery_a_sec = 0.20\n"
+    "recovery_b_sec = 0.00\n"
+    "speed = 300.0\n"
+    "orbit_radius = 50.0\n"
+    "radius = 25.0\n"
+    "damage = 25\n"
+    "hitstop_sec = 0.08\n"
+    "[air_attack]\n"
+    "windup_sec = 0.05\n"
+    "active_sec = 0.25\n"
+    "recovery_a_sec = 0.20\n"
+    "recovery_b_sec = 0.00\n"
+    "orbit_radius = 50.0\n"
+    "radius = 25.0\n"
+    "damage = 25\n"
+    "hitstop_sec = 0.08\n"
+    "[stamina]\n"
+    "recovery_delay = 2.0\n"
+    "recovery_rate = 0.5\n"
+    "[landing]\n"
+    "recovery_sec = 0.20\n";
+
+}  // namespace
+
 TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
-  constexpr std::string_view Toml =
-      "speed = 150.0\n"
-      "jump_speed = 400.0\n"
-      "gravity = 900.0\n"
-      "[[melee.stage]]\n"
-      "windup_sec = 0.1\n"
-      "active_sec = 0.1\n"
-      "recovery_a_sec = 0.1\n"
-      "recovery_b_sec = 0.1\n"
-      "radius = 20.0\n"
-      "trajectory = \"thrust\"\n"
-      "slash_rise_height = 0.0\n"
-      "hitstop_sec = 0.05\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{FullToml.data(), FullToml.size()}};
   const PlayerConfig cfg = PlayerConfig::FromToml(reader);
   REQUIRE(cfg.speed == 150.0);
   REQUIRE(cfg.jumpSpeed == 400.0);
   REQUIRE(cfg.gravity == 900.0);
+  REQUIRE(cfg.melee.capMidH == 30.0);
+  REQUIRE(cfg.melee.reach == 60.0);
+  REQUIRE(cfg.melee.damage == 20);
   REQUIRE(cfg.melee.stages.size() == 1);
   REQUIRE(cfg.melee.stages[0].trajectory == MeleeTrajectory::Thrust);
   REQUIRE(cfg.melee.stages[0].radius == 20.0);
+  REQUIRE(cfg.ranged.damage == 15);
+  REQUIRE(cfg.dash.speed == 600.0);
+  REQUIRE(cfg.dashAttack.damage == 25);
+  REQUIRE(cfg.airAttack.damage == 25);
+  REQUIRE(cfg.stamina.recoveryRate == 0.5);
+  REQUIRE(cfg.landing.recoverySec == 0.20);
 }
 
 TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {
@@ -33,6 +92,45 @@ TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {
       "jump_speed = 400.0\n"
       "gravity = 900.0\n";
   const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
+}
+
+TEST_CASE("PlayerConfig::FromToml - missing speed throws Error") {
+  std::string toml{FullToml};
+  const auto pos = toml.find("speed = 150.0\n");
+  REQUIRE(pos != std::string::npos);
+  toml.erase(pos, std::string_view{"speed = 150.0\n"}.size());
+  const TOMLReader reader{MemoryViewReader{toml.data(), toml.size()}};
+  REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
+}
+
+TEST_CASE(
+    "PlayerConfig::FromToml - missing melee.stage trajectory throws Error "
+    "(not \"unknown value\")") {
+  std::string toml{FullToml};
+  const auto pos = toml.find("trajectory = \"thrust\"\n");
+  REQUIRE(pos != std::string::npos);
+  toml.erase(pos, std::string_view{"trajectory = \"thrust\"\n"}.size());
+  const TOMLReader reader{MemoryViewReader{toml.data(), toml.size()}};
+  try {
+    std::ignore = PlayerConfig::FromToml(reader);
+    FAIL("PlayerConfig::FromToml should throw when trajectory is missing");
+  } catch (const Error& e) {
+    const String& message = e.what();
+    REQUIRE(message.contains(U"キーがありません"));
+    REQUIRE_FALSE(message.contains(U"不明な"));
+  }
+}
+
+TEST_CASE(
+    "PlayerConfig::FromToml - unknown melee.stage trajectory value throws "
+    "Error") {
+  std::string toml{FullToml};
+  const auto pos = toml.find("trajectory = \"thrust\"\n");
+  REQUIRE(pos != std::string::npos);
+  toml.replace(pos, std::string_view{"trajectory = \"thrust\"\n"}.size(),
+               "trajectory = \"spin\"\n");
+  const TOMLReader reader{MemoryViewReader{toml.data(), toml.size()}};
   REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
 }
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -272,6 +272,12 @@
 ## 設定（Config）
 
 `Ash2/src/Config/` 配下。TOML から `FromToml()` で構築し、`registry.ctx()` に格納する。
+`PlayerConfig`/`EnemyConfig`/`AnimationData` はいずれも、必須キーが欠落していると
+`FromToml` が `Error` を投げる（下位の `Parse` 系関数が `std::expected` で失敗を伝播し、
+`FromToml` がそれを致命として確定させる）。
+
+[`TomlFields`](../Ash2/src/Config/TomlFields.hpp) は1テーブル分の必須キー読み出しと
+欠落キーの記録をまとめるヘルパーで、上記3設定の `Parse` 系関数が共通で使う。
 
 ### [`PlayerConfig`](../Ash2/src/Config/PlayerConfig.hpp)
 
@@ -430,6 +436,7 @@
 | `TestProjectileSystem.cpp` | `ProjectileSystem` の消滅条件 |
 | `TestNameLookup.cpp` | `NameLookupSystem` のシグナル同期 |
 | `TestPlayerConfig.cpp` | `PlayerConfig::FromToml` |
+| `TestEnemyConfig.cpp` | `EnemyConfig::FromToml` |
 | `TestAnimationData.cpp` | `AnimationData::FromToml` |
 | `TestScenarioData.cpp` | `ScenarioData::FromToml` |
 | `TestPhaseStack.cpp` | `PhaseStack` の push / pop / reset |


### PR DESCRIPTION
close #240

## 概要

`PlayerConfig` / `EnemyConfig` / `AnimationData` のパース層を、参照実装である `ScenarioData` と同じ3層構造に揃えた。

- 下位のパース関数はすべて `std::expected<T, String>` 返し（`[[nodiscard]]` 付き）
- 全54キーを `get<T>()` から `getOpt<T>()` に移行し、キー欠落を失敗として検出する
- `throw Error{...}` は各 `FromToml` の1箇所のみ。Why not コメント付き

これまでは `get<T>()` がキー欠落時に既定値を黙って返していたため、設定ファイルの打ち間違いが検出されなかった。

## TomlFields を新設した理由

対象キーは全54件（PlayerConfig 34 / EnemyConfig 13 / AnimationData 7）ある。1キーごとに `getOpt` + 早期 return を書くと `PlayerConfig.cpp` が116行から250行規模に膨らみ、集約初期化の可読性が失われる。設定キーを1つ増やすたびに定型を数行書く負債にもなる。

そこで、1テーブル分の必須キー読み出しと欠落キーの記録をまとめるヘッダオンリーのヘルパー `TomlFields` を新設した。

- `get<T>(key)` は欠落時にキー名を記録して `T{}` を返し、読み進める
- `wrap<T>(value)` が記録した欠落をまとめて `std::unexpected` に畳む

集約初期化の形を保てるうえ、打ち間違いが複数あっても1回の起動ですべて報告される。

キーごとに `expected` を返して短絡する案も検討したが、C++ は集約初期化の途中から関数を抜けられないため、可読性と型安全性を両立できない。短絡版の `TomlFields` を作っても `get()` は何かを返さねばならず `T{}` 契約は残るため、蓄積方式を選んだ。

## check() を分けた理由

`wrap()` は最終的な構造体が組み上がった時点でしか畳めない。`melee.stage` の `trajectory` は読んだ String をさらに列挙値へ変換するため、欠落時の `String{}` をそのまま変換に渡すと「不明な trajectory」と誤報してしまう。

そのため `check()` を分け、変換の手前で欠落を確定させている。54キー中この1箇所のみが該当する。`wrap()` は `check()` を使って実装し、判定ロジックは1箇所に保っている。

## エラーメッセージ

`U"関数名: 内容"` の形式を維持している。

```
PlayerConfig::ParseRanged: キーがありません: ranged.reach, ranged.damage
```

`melee.stage` については、実運用の TOML が3段あり、どの段が不正か示せないと検出の役に立たないため、prefix に段のインデックスを入れて `melee.stage[1].trajectory` の形にした。

## 既知の制限

- キーは存在するが型が違う場合（例: `speed = 6` と整数で書く）も「キーがありません」と報告される。現行アセットは全て小数点付きのため実害はない
- テーブルをまたぐ欠落は、先に検査した側のみ報告される

## 確認

- format / tidy / build すべて警告0
- テスト160ケース・384アサーション全通過
- アプリを起動し、実運用の `App/assets/config/*.toml` が読み込めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)