### PR TITLE
constexpr 定数の K 接頭辞を clang-tidy で強制する #247

### DIFF
--- a/Ash2/.clang-tidy
+++ b/Ash2/.clang-tidy
@@ -46,9 +46,13 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.EnumConstantCase
     value: CamelCase
-  # constexpr 定数: PascalCase
+  # constexpr 定数: K + PascalCase
+  # 接頭辞 K を除いた残りが PascalCase か検査されるため、
+  # K の次が小文字になる語は K を重ねる（例: Knockback → KKnockbackForce）
   - key: readability-identifier-naming.ConstexprVariableCase
     value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariablePrefix
+    value: K
   # マジックナンバー: 0, 1, -1, 2 は例外
   - key: readability-magic-numbers.IgnoredIntegerValues
     value: '0;1;-1;2'

--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -24,7 +24,7 @@ inline InputState InputDeviceSelector::update() {
     m_activeDevice = Device::Keyboard;
   }
   // 最後に入力があったデバイスへ切り替える
-  const Vec2 stickAxis = XInputAction::LeftThumbDeadZone(
+  const Vec2 stickAxis = XInputAction::KLeftThumbDeadZone(
       Vec2{XInput(0).leftThumbX, XInput(0).leftThumbY});
   if (XInput(0).isConnected() &&
       (XInput(0).buttonUp.down() || XInput(0).buttonDown.down() ||

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -9,7 +9,7 @@
 struct XInputAction {
   /// 左スティックに適用するデッドゾーン（`InputDeviceSelector`
   /// もスティック傾き判定に同じ定数を参照する）
-  static constexpr DeadZone LeftThumbDeadZone{
+  static constexpr DeadZone KLeftThumbDeadZone{
       .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular};
 
   /// @brief 現在のコントローラー入力状態を InputState に変換して返す
@@ -22,7 +22,7 @@ inline InputState XInputAction::ToInputState() {
   // `XInput(0)` は const 参照のため `setLeftThumbDeadZone()` を直接呼べず、
   // ここで明示的にデッドゾーンを適用する
   const Vec2 stickAxis =
-      LeftThumbDeadZone(Vec2{pad.leftThumbX, pad.leftThumbY});
+      KLeftThumbDeadZone(Vec2{pad.leftThumbX, pad.leftThumbY});
 
   const Vec2 dpadAxis{
       (pad.buttonRight.pressed() ? 1.0 : 0.0) -

--- a/Ash2/tests/TestAnimationData.cpp
+++ b/Ash2/tests/TestAnimationData.cpp
@@ -4,7 +4,7 @@
 #include "Config/AnimationData.hpp"
 
 TEST_CASE("AnimationData::FromToml - parses top-level fields correctly") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "texture = \"assets/images/player.png\"\n"
       "width = 32\n"
       "height = 64\n"
@@ -12,7 +12,7 @@ TEST_CASE("AnimationData::FromToml - parses top-level fields correctly") {
       "[draw_offset]\n"
       "x = -8.0\n"
       "y = -32.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   const AnimationData data = AnimationData::FromToml(reader);
   REQUIRE(data.textureKey == U"assets/images/player.png");
   REQUIRE(data.size.x == 32);
@@ -22,7 +22,7 @@ TEST_CASE("AnimationData::FromToml - parses top-level fields correctly") {
 }
 
 TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "texture = \"assets/images/enemy.png\"\n"
       "width = 48\n"
       "height = 48\n"
@@ -40,7 +40,7 @@ TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
       "row = 1\n"
       "count = 6\n"
       "speed = 12.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   const AnimationData data = AnimationData::FromToml(reader);
   REQUIRE(data.clips.contains(U"idle"));
   REQUIRE(data.clips.at(U"idle").row == 0);
@@ -53,19 +53,19 @@ TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
 }
 
 TEST_CASE("AnimationData::FromToml - missing width throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "texture = \"assets/images/player.png\"\n"
       "height = 64\n"
       "\n"
       "[draw_offset]\n"
       "x = -8.0\n"
       "y = -32.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(AnimationData::FromToml(reader), Error);
 }
 
 TEST_CASE("AnimationData::FromToml - missing clip row throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "texture = \"assets/images/player.png\"\n"
       "width = 32\n"
       "height = 64\n"
@@ -77,13 +77,13 @@ TEST_CASE("AnimationData::FromToml - missing clip row throws Error") {
       "[idle]\n"
       "count = 4\n"
       "speed = 8.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(AnimationData::FromToml(reader), Error);
 }
 
 TEST_CASE("AnimationData::FromToml - reserved keys are not treated as clips") {
   // texture / width / height / draw_offset はクリップとして誤認されてはならない
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "texture = \"assets/images/player.png\"\n"
       "width = 32\n"
       "height = 64\n"
@@ -91,7 +91,7 @@ TEST_CASE("AnimationData::FromToml - reserved keys are not treated as clips") {
       "[draw_offset]\n"
       "x = 0.0\n"
       "y = 0.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   const AnimationData data = AnimationData::FromToml(reader);
   REQUIRE_FALSE(data.clips.contains(U"texture"));
   REQUIRE_FALSE(data.clips.contains(U"width"));

--- a/Ash2/tests/TestEnemyConfig.cpp
+++ b/Ash2/tests/TestEnemyConfig.cpp
@@ -4,7 +4,7 @@
 #include "Config/EnemyConfig.hpp"
 
 TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "max_hp = 100\n"
       "size_w = 60.0\n"
       "size_h = 80.0\n"
@@ -19,7 +19,7 @@ TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
       "knockback_sec = 1.00\n"
       "defeated_sec = 0.50\n"
       "respawn_sec = 1.00\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   const EnemyConfig cfg = EnemyConfig::FromToml(reader);
   REQUIRE(cfg.maxHp == 100);
   REQUIRE(cfg.size.x == 60.0);
@@ -38,7 +38,7 @@ TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
 }
 
 TEST_CASE("EnemyConfig::FromToml - missing max_hp throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "size_w = 60.0\n"
       "size_h = 80.0\n"
       "capsule_radius = 30.0\n"
@@ -52,7 +52,7 @@ TEST_CASE("EnemyConfig::FromToml - missing max_hp throws Error") {
       "knockback_sec = 1.00\n"
       "defeated_sec = 0.50\n"
       "respawn_sec = 1.00\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(EnemyConfig::FromToml(reader), Error);
 }
 

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -8,7 +8,7 @@
 namespace {
 
 /// @brief 全必須キーを満たす PlayerConfig 用 TOML（テストの基準値）
-constexpr std::string_view FullToml =
+constexpr std::string_view KFullToml =
     "speed = 150.0\n"
     "jump_speed = 400.0\n"
     "gravity = 900.0\n"
@@ -67,7 +67,7 @@ constexpr std::string_view FullToml =
 }  // namespace
 
 TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
-  const TOMLReader reader{MemoryViewReader{FullToml.data(), FullToml.size()}};
+  const TOMLReader reader{MemoryViewReader{KFullToml.data(), KFullToml.size()}};
   const PlayerConfig cfg = PlayerConfig::FromToml(reader);
   REQUIRE(cfg.speed == 150.0);
   REQUIRE(cfg.jumpSpeed == 400.0);
@@ -87,16 +87,16 @@ TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
 }
 
 TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "speed = 150.0\n"
       "jump_speed = 400.0\n"
       "gravity = 900.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
 }
 
 TEST_CASE("PlayerConfig::FromToml - missing speed throws Error") {
-  std::string toml{FullToml};
+  std::string toml{KFullToml};
   const auto pos = toml.find("speed = 150.0\n");
   REQUIRE(pos != std::string::npos);
   toml.erase(pos, std::string_view{"speed = 150.0\n"}.size());
@@ -107,7 +107,7 @@ TEST_CASE("PlayerConfig::FromToml - missing speed throws Error") {
 TEST_CASE(
     "PlayerConfig::FromToml - missing melee.stage trajectory throws Error "
     "(not \"unknown value\")") {
-  std::string toml{FullToml};
+  std::string toml{KFullToml};
   const auto pos = toml.find("trajectory = \"thrust\"\n");
   REQUIRE(pos != std::string::npos);
   toml.erase(pos, std::string_view{"trajectory = \"thrust\"\n"}.size());
@@ -125,7 +125,7 @@ TEST_CASE(
 TEST_CASE(
     "PlayerConfig::FromToml - unknown melee.stage trajectory value throws "
     "Error") {
-  std::string toml{FullToml};
+  std::string toml{KFullToml};
   const auto pos = toml.find("trajectory = \"thrust\"\n");
   REQUIRE(pos != std::string::npos);
   toml.replace(pos, std::string_view{"trajectory = \"thrust\"\n"}.size(),

--- a/Ash2/tests/TestScenarioData.cpp
+++ b/Ash2/tests/TestScenarioData.cpp
@@ -6,12 +6,12 @@
 #include "Phase/WaitPhase.hpp"
 
 TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"wait\"\n"
       "duration = 1.5\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   const ScenarioData data = ScenarioData::FromToml(reader, GetPhaseLoaders());
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
@@ -24,12 +24,12 @@ TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
 }
 
 TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "[[intro]]\n"
       "action = \"reset\"\n"
       "phase = \"wait\"\n"
       "duration = 2.0\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   const ScenarioData data = ScenarioData::FromToml(reader, GetPhaseLoaders());
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
@@ -42,38 +42,38 @@ TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
 }
 
 TEST_CASE("ScenarioData::FromToml - unknown phase name throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"nonexistent\"\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - unknown action throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "[[intro]]\n"
       "action = \"fly\"\n"
       "phase = \"wait\"\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - missing duration throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"wait\"\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - missing param throws Error") {
-  constexpr std::string_view Toml =
+  constexpr std::string_view KToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"scenario\"\n";
-  const TOMLReader reader{MemoryViewReader{Toml.data(), Toml.size()}};
+  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -345,7 +345,7 @@
 以下に正規化済み」という不変条件を持つ。この保証の責任は `toInputState()` を実装する各入力レイヤー側に
 あり、`PlayerMotion::Tick(Neutral&, ...)` は無条件にこの値を信頼してそのまま速度計算に使う
 （System 側で正規化やクランプを行わない）。`XInputAction` は左スティックのデッドゾーン定数
-（`LeftThumbDeadZone`、`InputDeviceSelector` も参照する公開 `static constexpr` メンバ）を適用し、
+（`KLeftThumbDeadZone`、`InputDeviceSelector` も参照する公開 `static constexpr` メンバ）を適用し、
 十字ボタンの軸ベクトルと加算したうえで `limitLength(1.0)` により正規化する。
 
 **フェーズの直接キー入力：** `TestMenuPhase`（↑↓/Enter）・`PlayerTestPhase`（Esc）・


### PR DESCRIPTION
close #247

## 概要

`constexpr` 定数の `K` 接頭辞を慣習から機械強制へ移行する（Issue の案A）。
`.clang-tidy` に `readability-identifier-naming.ConstexprVariablePrefix: K` を追加し、
規約に従っていなかった定数を改名した。

## 案Aを選んだ理由

案D（`K` を廃止し Siv3D 慣例の PascalCase に統一）も検討したが、案Aを採った。

決め手は**強制の非対称性**。案Aは「`K` を付けろ」を `.clang-tidy` で強制できるが、
案Dが強制できるのはケースのみで、`KFoo` も `Foo` も通ってしまうため揺れを止められない。
本プロジェクトはバイブコーディングを扱っており、規約の遵守を書き手の注意力に依存させない方が
壊れにくいと判断した。

副次的な利点として、`K` の有無が「自前の定数か Siv3D の定数か」の目印になる。
全件に `K` を付けるためこの境界が例外なく成立する。

代償として Siv3D の公表スタイルからは意図的に逸脱する。

## 検証したこと

Issue の補足にあった未検証点（`ConstexprVariablePrefix` が `static constexpr` メンバにも効くか、
`ClassConstantPrefix` との優先関係）を実測した。

`readability-identifier-naming` は宣言ごとに適用スタイルを1つだけ選び、
**設定されていないスタイルは選択候補に上がらない**。本プロジェクトは `ClassConstant*` を
一切設定していないため `ConstexprVariable` が選ばれる。

実際に `public static constexpr` メンバである `LeftThumbDeadZone` が
`invalid case style for constexpr variable` として検出されることを確認済み。
`ClassConstant` は public / private を問わず静的データメンバを対象とするスタイルのため、
この1件で private 静的メンバ（`KFontSize` 等）の側も同時に決着している。

## 変更内容

- `.clang-tidy`: `ConstexprVariablePrefix: K` を追加
- `XInputAction::LeftThumbDeadZone` → `KLeftThumbDeadZone`（`InputDeviceSelector` の参照箇所と `docs/REFERENCE.md` も追随）
- テスト側 15 件: `Toml` → `KToml`（14 件）、`FullToml` → `KFullToml`（1 件）

テスト側は Issue 本文が数えていなかった対象。`ConstexprVariable` スタイルは関数内のローカル
`constexpr` にも適用されるため対象に含まれる。`WarningsAsErrors: '*'` により未対応では
ビルド前チェックが落ちるため、同一 PR で解消した（Issue にもコメント済み）。

## ドキュメント方針

命名規則を記した文書は存在せず `.clang-tidy` が唯一の情報源だったため、
`.claude/rules/cpp.md` への追記は行っていない（機械が強制できるものは機械に任せる方針を維持）。

ただし接頭辞を除いた残りが PascalCase か検査される仕様上、`K` の次が小文字になる語は
`KKnockbackForce` のように `K` を重ねる必要がある。これは機械が説明できないため
`.clang-tidy` にコメントとして残した。

## 確認

- clang-format: 完了
- clang-tidy（全 `.cpp`）: 問題なし
- ビルド: SUCCEEDED
- テスト: 160 ケース / 384 アサーション 全通過

## 補足

`.cpp` / `.hpp` を編集するため、Issue のラベルを `chore` から `refactor` に変更した
（`docs/GIT.md` のラベル定義に従う）。