### PR TITLE
攻撃判定エフェクトの消え際（フェードアウト）の実装

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -80,3 +80,6 @@ recovery_rate  = 0.5
 
 [landing]
 recovery_sec = 0.20
+
+[attack_effect]
+fade_sec = 0.30

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="src\System\MotionSystem.cpp" />
     <ClCompile Include="src\System\EnemyMotionSystem.cpp" />
     <ClCompile Include="src\System\EnemySystem.cpp" />
+    <ClCompile Include="src\System\FadeOutSystem.cpp" />
     <ClCompile Include="src\System\HitReactionSystem.cpp" />
     <ClCompile Include="src\System\HitSystem.cpp" />
     <ClCompile Include="src\System\ProjectileSystem.cpp" />
@@ -163,6 +164,7 @@
     <ClCompile Include="tests\TestAttachmentSystem.cpp" />
     <ClCompile Include="tests\TestEnemyConfig.cpp" />
     <ClCompile Include="tests\TestEnemyMotionSystem.cpp" />
+    <ClCompile Include="tests\TestFadeOutSystem.cpp" />
     <ClCompile Include="tests\TestHitReactionSystem.cpp" />
     <ClCompile Include="tests\TestHitstopSystem.cpp" />
     <ClCompile Include="tests\TestHitSystem.cpp" />
@@ -436,6 +438,8 @@
     <ClInclude Include="src\System\ProjectileSystem.hpp" />
     <ClInclude Include="src\System\EnemyMotionSystem.hpp" />
     <ClInclude Include="src\System\EnemySystem.hpp" />
+    <ClInclude Include="src\Component\FadeOut.hpp" />
+    <ClInclude Include="src\System\FadeOutSystem.hpp" />
     <ClInclude Include="src\Component\Gravity.hpp" />
     <ClInclude Include="src\System\MovementSystem.hpp" />
     <ClInclude Include="src\System\GravitySystem.hpp" />
@@ -443,6 +447,7 @@
     <ClInclude Include="src\System\HitstopSystem.hpp" />
     <ClInclude Include="src\System\StaminaSystem.hpp" />
     <ClInclude Include="src\Component\Invincible.hpp" />
+    <ClInclude Include="src\Component\DrawColor.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App\example\obj\blacksmith.obj">

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -228,6 +228,9 @@
     <ClCompile Include="System\EnemySystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
+    <ClCompile Include="System\FadeOutSystem.cpp">
+      <Filter>Source Files\System</Filter>
+    </ClCompile>
     <ClCompile Include="System\HitReactionSystem.cpp">
       <Filter>Source Files\System</Filter>
     </ClCompile>
@@ -289,6 +292,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestEnemyMotionSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\TestFadeOutSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="tests\TestHitReactionSystem.cpp">
@@ -1160,6 +1166,12 @@
     <ClInclude Include="System\EnemySystem.hpp">
       <Filter>Header Files\System</Filter>
     </ClInclude>
+    <ClInclude Include="Component\FadeOut.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="System\FadeOutSystem.hpp">
+      <Filter>Header Files\System</Filter>
+    </ClInclude>
     <ClInclude Include="Component\Gravity.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
@@ -1173,6 +1185,9 @@
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="Component\Invincible.hpp">
+      <Filter>Header Files\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="Component\DrawColor.hpp">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
     <ClInclude Include="System\HitstopSystem.hpp">

--- a/Ash2/src/Component/DrawColor.hpp
+++ b/Ash2/src/Component/DrawColor.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <Siv3D.hpp>
+
+/// @brief DrawColor を持たないエンティティに使う既定色（白・不透明）
+inline constexpr ColorF KDefaultDrawColor{1.0};
+
+/// @brief このエンティティを描画するときの色
+///
+/// 図形では塗り色、テクスチャでは乗算色として使う。
+struct DrawColor {
+  ColorF color = KDefaultDrawColor;
+};

--- a/Ash2/src/Component/Drawable.hpp
+++ b/Ash2/src/Component/Drawable.hpp
@@ -21,7 +21,6 @@ enum class DrawAnchor : uint8 {
 struct RectDrawable {
   /// 描画サイズ（幅・高さ）
   SizeF size;
-  ColorF color;
   /// none = 枠線なし
   Optional<BorderStyle> border;
   DrawAnchor anchor = DrawAnchor::Center;
@@ -30,7 +29,6 @@ struct RectDrawable {
 /// @brief 円描画データ
 struct CircleDrawable {
   double radius;
-  ColorF color;
   /// none = 枠線なし
   Optional<BorderStyle> border;
 };
@@ -42,7 +40,6 @@ struct PieDrawable {
   double startAngle;
   /// ラジアン
   double angle;
-  ColorF color;
   /// none = 枠線なし
   Optional<BorderStyle> border;
 };

--- a/Ash2/src/Component/FadeOut.hpp
+++ b/Ash2/src/Component/FadeOut.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+/// @brief 透過しながら消滅する途中であることを示すコンポーネント
+struct FadeOut {
+  /// フェード全体の長さ（秒）
+  double duration = 0.0;
+  /// 残り時間（秒）
+  double remaining = 0.0;
+};

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -187,6 +187,15 @@ namespace {
   });
 }
 
+/// @brief TOML から攻撃演出共通の設定値を生成する
+[[nodiscard]] std::expected<AttackEffectConfig, String> ParseAttackEffect(
+    const TOMLValue& ae) {
+  TomlFields f{ae, U"PlayerConfig::ParseAttackEffect", U"attack_effect"};
+  return f.wrap(AttackEffectConfig{
+      .fadeSec = f.get<double>(U"fade_sec"),
+  });
+}
+
 /// @brief TOML からプレイヤー設定を生成する
 [[nodiscard]] std::expected<PlayerConfig, String> Parse(const TOMLValue& toml) {
   auto melee = ParseMelee(toml[U"melee"]);
@@ -217,6 +226,10 @@ namespace {
   if (!landing) {
     return std::unexpected{std::move(landing).error()};
   }
+  auto attackEffect = ParseAttackEffect(toml[U"attack_effect"]);
+  if (!attackEffect) {
+    return std::unexpected{std::move(attackEffect).error()};
+  }
 
   TomlFields f{toml, U"PlayerConfig::Parse"};
   return f.wrap(PlayerConfig{
@@ -230,6 +243,7 @@ namespace {
       .airAttack = *std::move(airAttack),
       .stamina = *std::move(stamina),
       .landing = *std::move(landing),
+      .attackEffect = *std::move(attackEffect),
   });
 }
 

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -154,6 +154,12 @@ struct LandingConfig {
   double recoverySec;
 };
 
+/// @brief 攻撃演出共通の設定値
+struct AttackEffectConfig {
+  /// ヒットボックス解放後のフェードアウト時間（秒）
+  double fadeSec = 0.0;
+};
+
 /// @brief プレイヤーの設定値
 struct PlayerConfig {
   /// 横移動速度（ピクセル/秒）
@@ -169,6 +175,7 @@ struct PlayerConfig {
   AirAttackConfig airAttack;
   StaminaConfig stamina;
   LandingConfig landing;
+  AttackEffectConfig attackEffect;
 
   /// @brief TOML からプレイヤー設定を生成する
   [[nodiscard]] static PlayerConfig FromToml(const TOMLValue& toml);

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -1,9 +1,11 @@
 #include "Phase/PlayerTestPhase.hpp"
 
 #include "Component/Collider.hpp"
+#include "Component/DrawColor.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Enemy.hpp"
 #include "Component/EnemyMotion.hpp"
+#include "Component/FadeOut.hpp"
 #include "Component/Gravity.hpp"
 #include "Component/Hierarchy.hpp"
 #include "Component/Hp.hpp"
@@ -22,6 +24,7 @@
 #include "System/AnimationSystem.hpp"
 #include "System/AttachmentSystem.hpp"
 #include "System/EnemySystem.hpp"
+#include "System/FadeOutSystem.hpp"
 #include "System/GravitySystem.hpp"
 #include "System/HitReactionSystem.hpp"
 #include "System/HitSystem.hpp"
@@ -72,10 +75,10 @@ entt::entity PlayerTestPhase::spawnEnemy(entt::registry& registry) {
   // 加速度を与える（EnemyConfig は専用の重力値を持たない）
   registry.emplace<Gravity>(enemy, Gravity{.accel = playerCfg.gravity});
   registry.emplace<Motion>(enemy, EnemyMotion::Idle{});
-  registry.emplace<Drawable>(enemy,
-                             RectDrawable{.size = enemyCfg.size,
-                                          .color = KDummyColor,
-                                          .anchor = DrawAnchor::BottomCenter});
+  registry.emplace<Drawable>(
+      enemy,
+      RectDrawable{.size = enemyCfg.size, .anchor = DrawAnchor::BottomCenter});
+  registry.emplace<DrawColor>(enemy, DrawColor{.color = KDummyColor});
   registry.emplace<Collider>(
       enemy, Collider{.segmentStart = Vec3{0.0, 0.0, 0.0},
                       .segmentEnd = Vec3{0.0, enemyCfg.capsuleHeight, 0.0},
@@ -100,6 +103,7 @@ IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
   HitReactionSystem::Apply(registry, hits);
   ProjectileSystem::Update(registry);
   EnemySystem::Update(registry);
+  FadeOutSystem::Update(registry, dt);
 
   AnimationSystem::Update(registry, dt);
 
@@ -145,6 +149,12 @@ void PlayerTestPhase::onBeforePop(entt::registry& registry) {
   // 弾は独立エンティティ（m_playerRoot の子孫ではない）なので、
   // Projectile タグで検索して個別に破棄する
   for (const auto entity : registry.view<Projectile>()) {
+    registry.destroy(entity);
+  }
+
+  // フェード中のヒットボックスも m_playerRoot から Detach 済みの独立
+  // エンティティなので、FadeOut タグで検索して個別に破棄する
+  for (const auto entity : registry.view<FadeOut>()) {
     registry.destroy(entity);
   }
 }

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -1,5 +1,6 @@
 #include "System/DrawSystem.hpp"
 
+#include "Component/DrawColor.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/WorldPos.hpp"
 #include "Util/Overloaded.hpp"
@@ -10,12 +11,16 @@ void DrawSystem::Draw(const entt::registry& registry) {
   struct DrawEntry {
     std::reference_wrapper<const WorldPos> pos;
     std::reference_wrapper<const Drawable> drawable;
+    ColorF color;
   };
 
   Array<DrawEntry> entries;
   for (const auto& [entity, pos, drawable] :
        registry.view<const WorldPos, const Drawable>().each()) {
-    entries.push_back({std::cref(pos), std::cref(drawable)});
+    const auto* drawColor = registry.try_get<DrawColor>(entity);
+    entries.push_back(
+        {std::cref(pos), std::cref(drawable),
+         (drawColor != nullptr) ? drawColor->color : KDefaultDrawColor});
   }
 
   std::ranges::sort(entries, [](const DrawEntry& a, const DrawEntry& b) {
@@ -24,9 +29,10 @@ void DrawSystem::Draw(const entt::registry& registry) {
 
   for (const auto& entry : entries) {
     const Vec2 screenPos = cameraOffset + entry.pos.get().toScreen();
+    const ColorF& color = entry.color;
     std::visit(
         Overloaded{
-            [&screenPos](const RectDrawable& shape) {
+            [&screenPos, &color](const RectDrawable& shape) {
               const RectF rect = [&] {
                 switch (shape.anchor) {
                   case DrawAnchor::BottomCenter:
@@ -38,21 +44,21 @@ void DrawSystem::Draw(const entt::registry& registry) {
                                  shape.size.y};
                 }
               }();
-              rect.draw(shape.color);
+              rect.draw(color);
               if (shape.border) {
                 rect.drawFrame(shape.border->thickness, shape.border->color);
               }
             },
-            [&screenPos](const CircleDrawable& shape) {
+            [&screenPos, &color](const CircleDrawable& shape) {
               const Circle circle{screenPos, shape.radius};
-              circle.draw(shape.color);
+              circle.draw(color);
               if (shape.border) {
                 circle.drawFrame(shape.border->thickness, shape.border->color);
               }
             },
-            [&screenPos](const PieDrawable& shape) {
+            [&screenPos, &color](const PieDrawable& shape) {
               const Circle circle{screenPos, shape.radius};
-              circle.drawPie(shape.startAngle, shape.angle, shape.color);
+              circle.drawPie(shape.startAngle, shape.angle, color);
               if (shape.border) {
                 const auto& b = *shape.border;
                 circle.drawArc(shape.startAngle, shape.angle, 0.0, b.thickness,
@@ -66,15 +72,15 @@ void DrawSystem::Draw(const entt::registry& registry) {
                 Line{screenPos, p2}.draw(b.thickness, b.color);
               }
             },
-            [&screenPos](const TextureDrawable& shape) {
+            [&screenPos, &color](const TextureDrawable& shape) {
               const Vec2 anchorPos = screenPos + shape.drawOffset;
               switch (shape.anchor) {
                 case DrawAnchor::BottomCenter:
-                  shape.region.draw(Arg::bottomCenter(anchorPos));
+                  shape.region.draw(Arg::bottomCenter(anchorPos), color);
                   break;
                 case DrawAnchor::Center:
                 default:
-                  shape.region.draw(Arg::center(anchorPos));
+                  shape.region.draw(Arg::center(anchorPos), color);
                   break;
               }
             },

--- a/Ash2/src/System/EnemyMotionSystem.cpp
+++ b/Ash2/src/System/EnemyMotionSystem.cpp
@@ -2,6 +2,7 @@
 
 #include "System/EnemyMotionSystem.hpp"
 
+#include "Component/DrawColor.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
@@ -81,12 +82,8 @@ Optional<Motion> Tick(Defeated& state, entt::registry& registry,
   const auto& cfg = registry.ctx().get<EnemyConfig>();
   state.remaining -= frameData.dt;
 
-  if (auto* drawable = registry.try_get<Drawable>(entity);
-      drawable != nullptr) {
-    if (auto* rect = std::get_if<RectDrawable>(drawable); rect != nullptr) {
-      rect->color.a = Max(0.0, state.remaining / cfg.defeatedSec);
-    }
-  }
+  registry.get_or_emplace<DrawColor>(entity).color.a =
+      Max(0.0, state.remaining / cfg.defeatedSec);
 
   return none;
 }

--- a/Ash2/src/System/EnemyMotionSystem.hpp
+++ b/Ash2/src/System/EnemyMotionSystem.hpp
@@ -39,7 +39,7 @@ namespace EnemyMotion {
                                     entt::entity entity,
                                     const FrameData& frameData);
 
-/// @brief Defeated 状態の更新（RectDrawable::color.a
+/// @brief Defeated 状態の更新（DrawColor::color.a
 /// を残り時間比でフェードアウトさせながら残り時間を減算する。満了後の破棄は
 /// EnemySystem が行う）
 /// @return 常に none

--- a/Ash2/src/System/FadeOutSystem.cpp
+++ b/Ash2/src/System/FadeOutSystem.cpp
@@ -1,0 +1,24 @@
+#include <Siv3D.hpp>
+
+#include "System/FadeOutSystem.hpp"
+
+#include "Component/DrawColor.hpp"
+#include "Component/FadeOut.hpp"
+
+void FadeOutSystem::Update(entt::registry& registry, double dt) {
+  // view.each() の走査中に destroy() すると走査が壊れるため、破棄対象は
+  // 収集してからループの外でまとめて破棄する
+  Array<entt::entity> toDestroy;
+
+  for (auto&& [entity, fade] : registry.view<FadeOut>().each()) {
+    fade.remaining -= dt;
+    const double ratio =
+        (fade.duration > 0.0) ? Max(0.0, fade.remaining / fade.duration) : 0.0;
+    registry.get_or_emplace<DrawColor>(entity).color.a = ratio;
+    if (fade.remaining <= 0.0) toDestroy.push_back(entity);
+  }
+
+  for (const auto entity : toDestroy) {
+    registry.destroy(entity);
+  }
+}

--- a/Ash2/src/System/FadeOutSystem.hpp
+++ b/Ash2/src/System/FadeOutSystem.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <entt/entt.hpp>
+
+/// @brief 消滅演出中のエンティティを透過させ、満了したら破棄するシステム
+class FadeOutSystem {
+ public:
+  /// @brief FadeOut の残り時間を減算して DrawColor::color.a
+  /// に反映し、尽きたエンティティを破棄する
+  static void Update(entt::registry& registry, double dt);
+};

--- a/Ash2/src/System/PlayerMotion/AirAttack.cpp
+++ b/Ash2/src/System/PlayerMotion/AirAttack.cpp
@@ -1,6 +1,5 @@
 #include <Siv3D.hpp>
 
-#include "Component/Hierarchy.hpp"
 #include "Component/ReactionLevel.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/PlayerMotion/Helper.hpp"
@@ -50,8 +49,8 @@ Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
   // 接地検出は後隙中も含め毎フレーム優先して評価する（タイマー満了判定より先）
   if (pos.isOnGround()) {
     if (state.hitboxEntity != entt::null) {
-      Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
-      state.hitboxEntity = entt::null;
+      state.hitboxEntity = ReleaseAttackHitbox(registry, state.hitboxEntity,
+                                               cfg.attackEffect.fadeSec);
     }
     return Landing{.timer = cfg.landing.recoverySec};
   }
@@ -65,7 +64,8 @@ Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
                      HitboxSpec{.radius = aa.radius,
                                 .damage = aa.damage,
                                 .reaction = ReactionLevel::Repel,
-                                .hitstopSec = aa.hitstopSec},
+                                .hitstopSec = aa.hitstopSec,
+                                .fadeSec = cfg.attackEffect.fadeSec},
                      state.hitboxEntity, offsetFn);
 
   // 接地せずに終わった場合はタイマー満了で Neutral へ戻る

--- a/Ash2/src/System/PlayerMotion/DashAttack.cpp
+++ b/Ash2/src/System/PlayerMotion/DashAttack.cpp
@@ -1,6 +1,5 @@
 #include <Siv3D.hpp>
 
-#include "Component/Hierarchy.hpp"
 #include "Component/ReactionLevel.hpp"
 #include "Component/Velocity.hpp"
 #include "Component/WorldPos.hpp"
@@ -55,8 +54,8 @@ Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
   // 空中発動時のみ。地上 DashAttack は接地遷移を持たない）
   if (state.air && pos.isOnGround()) {
     if (state.hitboxEntity != entt::null) {
-      Hierarchy::DestroyWithChildren(registry, state.hitboxEntity);
-      state.hitboxEntity = entt::null;
+      state.hitboxEntity = ReleaseAttackHitbox(registry, state.hitboxEntity,
+                                               cfg.attackEffect.fadeSec);
     }
     return Landing{.timer = cfg.landing.recoverySec};
   }
@@ -70,7 +69,8 @@ Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
                      HitboxSpec{.radius = da.radius,
                                 .damage = da.damage,
                                 .reaction = ReactionLevel::Repel,
-                                .hitstopSec = da.hitstopSec},
+                                .hitstopSec = da.hitstopSec,
+                                .fadeSec = cfg.attackEffect.fadeSec},
                      state.hitboxEntity, offsetFn);
 
   // 突進フェーズ（構え）：ダッシュ方向へ移動

--- a/Ash2/src/System/PlayerMotion/Helper.cpp
+++ b/Ash2/src/System/PlayerMotion/Helper.cpp
@@ -4,7 +4,9 @@
 
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
+#include "Component/DrawColor.hpp"
 #include "Component/Drawable.hpp"
+#include "Component/FadeOut.hpp"
 #include "Component/Hierarchy.hpp"
 #include "Component/LocalOffset.hpp"
 #include "Component/Velocity.hpp"
@@ -35,8 +37,8 @@ entt::entity SpawnAttackHitbox(entt::registry& registry, entt::entity owner,
   registry.emplace<Attack>(hitbox, Attack{.damage = spec.damage,
                                           .hitstopSec = spec.hitstopSec,
                                           .reaction = spec.reaction});
-  registry.emplace<Drawable>(
-      hitbox, CircleDrawable{.radius = spec.radius, .color = KMeleeOrbColor});
+  registry.emplace<Drawable>(hitbox, CircleDrawable{.radius = spec.radius});
+  registry.emplace<DrawColor>(hitbox, DrawColor{.color = KMeleeOrbColor});
   return hitbox;
 }
 
@@ -53,6 +55,19 @@ void StopHorizontalMovement(entt::registry& registry, entt::entity entity) {
   auto& vel = registry.get<Velocity>(entity);
   vel.w = 0.0;
   vel.d = 0.0;
+}
+
+entt::entity ReleaseAttackHitbox(entt::registry& registry,
+                                 entt::entity hitboxEntity, double fadeSec) {
+  Hierarchy::Detach(registry, hitboxEntity);
+  registry.remove<Attack>(hitboxEntity);
+  if (fadeSec <= 0.0) {
+    registry.destroy(hitboxEntity);
+  } else {
+    registry.emplace_or_replace<FadeOut>(
+        hitboxEntity, FadeOut{.duration = fadeSec, .remaining = fadeSec});
+  }
+  return entt::null;
 }
 
 void UpdateAttackHitbox(entt::registry& registry, entt::entity owner,
@@ -73,10 +88,9 @@ void UpdateAttackHitbox(entt::registry& registry, entt::entity owner,
     localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
   }
 
-  // 後隙以降：ヒットボックスが残っていれば破棄する
+  // 後隙以降：ヒットボックスが残っていれば解放する
   if (elapsed >= timeline.activeEnd() && hitboxEntity != entt::null) {
-    Hierarchy::DestroyWithChildren(registry, hitboxEntity);
-    hitboxEntity = entt::null;
+    hitboxEntity = ReleaseAttackHitbox(registry, hitboxEntity, spec.fadeSec);
   }
 }
 

--- a/Ash2/src/System/PlayerMotion/Helper.hpp
+++ b/Ash2/src/System/PlayerMotion/Helper.hpp
@@ -23,6 +23,8 @@ struct HitboxSpec {
   ReactionLevel reaction = ReactionLevel::None;
   /// ヒット成立時に攻撃側・被弾側へ付与するヒットストップ時間（秒）
   double hitstopSec = 0.0;
+  /// 解放時のフェードアウト時間（秒）。0 以下なら即座に破棄する
+  double fadeSec = 0.0;
 };
 
 /// @brief クリップが変化していれば差し替え、再生位置をリセットする
@@ -30,6 +32,15 @@ void SetClip(SpriteAnimation& anim, const String& clip);
 
 /// @brief 横方向の速度を止める
 void StopHorizontalMovement(entt::registry& registry, entt::entity entity);
+
+/// @brief ヒットボックスを攻撃判定から解放し、消滅演出へ引き渡す
+///
+/// `Hierarchy::Detach` で親から切り離し、`Attack` を外して当たり判定から除外
+/// したうえで `FadeOut` を付与する。`fadeSec` が 0 以下の場合はフェードを
+/// 挟まず即座に破棄する。
+/// @return entt::null（呼び出し側の hitboxEntity 変数への代入に使う）
+entt::entity ReleaseAttackHitbox(entt::registry& registry,
+                                 entt::entity hitboxEntity, double fadeSec);
 
 /// @brief 攻撃判定の発生区間に応じてヒットボックスを生成・更新・破棄する
 /// @param timeline 攻撃のタイムライン（active 区間の判定に使用）

--- a/Ash2/src/System/PlayerMotion/Melee.cpp
+++ b/Ash2/src/System/PlayerMotion/Melee.cpp
@@ -97,7 +97,8 @@ Optional<Motion> Tick(Melee& state, entt::registry& registry,
                      HitboxSpec{.radius = stageCfg.radius,
                                 .damage = melee.damage,
                                 .reaction = reaction,
-                                .hitstopSec = stageCfg.hitstopSec},
+                                .hitstopSec = stageCfg.hitstopSec,
+                                .fadeSec = cfg.attackEffect.fadeSec},
                      state.hitboxEntity, offsetFn);
 
   if (hasNextStage) {

--- a/Ash2/src/System/PlayerMotion/Ranged.cpp
+++ b/Ash2/src/System/PlayerMotion/Ranged.cpp
@@ -4,6 +4,7 @@
 
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
+#include "Component/DrawColor.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/Projectile.hpp"
 #include "Component/Stamina.hpp"
@@ -45,8 +46,9 @@ void SpawnProjectile(entt::registry& registry, const WorldPos& pos,
                                          .radius = cfg.ranged.radius,
                                      });
   registry.emplace<Attack>(bullet, Attack{.damage = cfg.ranged.damage});
-  registry.emplace<Drawable>(bullet, CircleDrawable{.radius = cfg.ranged.radius,
-                                                    .color = KBulletColor});
+  registry.emplace<Drawable>(bullet,
+                             CircleDrawable{.radius = cfg.ranged.radius});
+  registry.emplace<DrawColor>(bullet, DrawColor{.color = KBulletColor});
   registry.emplace<Projectile>(bullet);
 }
 

--- a/Ash2/tests/TestEnemyMotionSystem.cpp
+++ b/Ash2/tests/TestEnemyMotionSystem.cpp
@@ -2,6 +2,7 @@
 #include <ThirdParty/Catch2/catch.hpp>
 #include <entt/entt.hpp>
 
+#include "Component/DrawColor.hpp"
 #include "Component/Drawable.hpp"
 #include "Component/EnemyMotion.hpp"
 #include "Component/Hitstop.hpp"
@@ -51,8 +52,7 @@ TEST_CASE("EnemyMotionSystem - Stagger shrinks RectDrawable vertically") {
   SetupContext(registry);
   const auto enemy =
       MakeEnemy(registry, EnemyMotion::Stagger{.remaining = 0.15});
-  registry.emplace<Drawable>(
-      enemy, RectDrawable{.size = {60.0, 80.0}, .color = ColorF{1.0}});
+  registry.emplace<Drawable>(enemy, RectDrawable{.size = {60.0, 80.0}});
 
   const FrameData frameData{.dt = 0.075};
   MotionSystem::Update(registry, frameData);
@@ -72,8 +72,7 @@ TEST_CASE(
   SetupContext(registry);
   const auto enemy =
       MakeEnemy(registry, EnemyMotion::Stagger{.remaining = 0.01});
-  registry.emplace<Drawable>(
-      enemy, RectDrawable{.size = {60.0, 60.0}, .color = ColorF{1.0}});
+  registry.emplace<Drawable>(enemy, RectDrawable{.size = {60.0, 60.0}});
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -180,6 +179,37 @@ TEST_CASE("EnemyMotionSystem - Knockback transitions to Idle on expiry") {
       std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy)));
 }
 
+TEST_CASE("EnemyMotionSystem - Defeated fades DrawColor::color.a") {
+  // 残り時間比（remaining / defeatedSec）で DrawColor::color.a
+  // をフェードさせる（Drawable の形状は問わない）
+  entt::registry registry;
+  SetupContext(registry);
+  const auto enemy =
+      MakeEnemy(registry, EnemyMotion::Defeated{.remaining = 0.25});
+  registry.emplace<Drawable>(enemy, RectDrawable{.size = {60.0, 80.0}});
+
+  const FrameData frameData{.dt = 0.0};
+  MotionSystem::Update(registry, frameData);
+
+  REQUIRE(registry.get<DrawColor>(enemy).color.a == Approx(0.5));
+}
+
+TEST_CASE(
+    "EnemyMotionSystem - Defeated emplaces DrawColor even without "
+    "Drawable") {
+  // Drawable を持たない敵でも DrawColor が付与される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto enemy =
+      MakeEnemy(registry, EnemyMotion::Defeated{.remaining = 0.50});
+
+  const FrameData frameData{.dt = 0.0};
+  MotionSystem::Update(registry, frameData);
+
+  REQUIRE(registry.all_of<DrawColor>(enemy));
+  REQUIRE(registry.get<DrawColor>(enemy).color.a == Approx(1.0));
+}
+
 TEST_CASE("EnemySystem - destroys entity when Defeated has expired") {
   entt::registry registry;
   SetupContext(registry);
@@ -219,8 +249,7 @@ TEST_CASE("EnemyMotionSystem - Hitstop freezes Stagger remaining and size") {
   SetupContext(registry);
   const auto enemy =
       MakeEnemy(registry, EnemyMotion::Stagger{.remaining = 0.15});
-  registry.emplace<Drawable>(
-      enemy, RectDrawable{.size = {60.0, 80.0}, .color = ColorF{1.0}});
+  registry.emplace<Drawable>(enemy, RectDrawable{.size = {60.0, 80.0}});
   registry.emplace<Hitstop>(enemy, Hitstop{.remaining = 0.1});
 
   const FrameData frameData{.dt = 0.075};

--- a/Ash2/tests/TestFadeOutSystem.cpp
+++ b/Ash2/tests/TestFadeOutSystem.cpp
@@ -1,0 +1,105 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/DrawColor.hpp"
+#include "Component/Drawable.hpp"
+#include "Component/FadeOut.hpp"
+#include "System/FadeOutSystem.hpp"
+
+TEST_CASE("FadeOutSystem - decreases DrawColor::color.a with remaining time") {
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 0.5, .remaining = 0.5});
+
+  FadeOutSystem::Update(registry, 0.2);
+
+  REQUIRE(registry.get<DrawColor>(entity).color.a == Approx(0.6));
+}
+
+TEST_CASE("FadeOutSystem - destroys entity once remaining reaches zero") {
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 0.5, .remaining = 0.1});
+
+  FadeOutSystem::Update(registry, 0.1);
+
+  REQUIRE_FALSE(registry.valid(entity));
+}
+
+TEST_CASE("FadeOutSystem - keeps entity while remaining time is left") {
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 0.5, .remaining = 0.3});
+
+  FadeOutSystem::Update(registry, 0.1);
+
+  REQUIRE(registry.valid(entity));
+}
+
+TEST_CASE("FadeOutSystem - emplaces DrawColor when entity has none") {
+  // 未所持のエンティティでも白からフェードが始まる
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 1.0, .remaining = 1.0});
+
+  REQUIRE_FALSE(registry.all_of<DrawColor>(entity));
+
+  FadeOutSystem::Update(registry, 0.25);
+
+  REQUIRE(registry.all_of<DrawColor>(entity));
+  REQUIRE(registry.get<DrawColor>(entity).color.a == Approx(0.75));
+}
+
+TEST_CASE("FadeOutSystem - preserves existing RGB while updating alpha") {
+  // emplace_or_replace ではなく get_or_emplace で確保するため、既存の RGB
+  // は白へ戻らない
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<DrawColor>(entity,
+                              DrawColor{.color = ColorF{0.2, 0.5, 0.9}});
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 1.0, .remaining = 1.0});
+
+  FadeOutSystem::Update(registry, 0.5);
+
+  const auto& color = registry.get<DrawColor>(entity).color;
+  REQUIRE(color.r == Approx(0.2));
+  REQUIRE(color.g == Approx(0.5));
+  REQUIRE(color.b == Approx(0.9));
+  REQUIRE(color.a == Approx(0.5));
+}
+
+TEST_CASE("FadeOutSystem - treats non-positive duration as zero opacity") {
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 0.0, .remaining = 0.5});
+
+  FadeOutSystem::Update(registry, 0.0);
+
+  REQUIRE(registry.get<DrawColor>(entity).color.a == Approx(0.0));
+}
+
+TEST_CASE("FadeOutSystem - does not touch entities without Drawable") {
+  // Drawable の variant を一切知らないため、持たないエンティティでも落ちない
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<FadeOut>(entity, FadeOut{.duration = 0.5, .remaining = 0.5});
+
+  REQUIRE_FALSE(registry.all_of<Drawable>(entity));
+  FadeOutSystem::Update(registry, 0.1);
+
+  REQUIRE(registry.valid(entity));
+  REQUIRE_FALSE(registry.all_of<Drawable>(entity));
+}
+
+TEST_CASE("FadeOutSystem - leaves entities without FadeOut untouched") {
+  entt::registry registry;
+  const auto entity = registry.create();
+
+  FadeOutSystem::Update(registry, 0.1);
+
+  REQUIRE(registry.valid(entity));
+  REQUIRE_FALSE(registry.all_of<DrawColor>(entity));
+}
+
+#endif

--- a/Ash2/tests/TestHitReactionSystem.cpp
+++ b/Ash2/tests/TestHitReactionSystem.cpp
@@ -236,8 +236,7 @@ TEST_CASE(
   SetupContext(registry);
   const auto target = MakeTarget(registry, 50.0);
   registry.replace<Motion>(target, EnemyMotion::Stagger{.remaining = 0.05});
-  registry.emplace<Drawable>(
-      target, RectDrawable{.size = {60.0, 40.0}, .color = Palette::White});
+  registry.emplace<Drawable>(target, RectDrawable{.size = {60.0, 40.0}});
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Blow);
 
   HitReactionSystem::Apply(registry,

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -62,7 +62,9 @@ constexpr std::string_view KFullToml =
     "recovery_delay = 2.0\n"
     "recovery_rate = 0.5\n"
     "[landing]\n"
-    "recovery_sec = 0.20\n";
+    "recovery_sec = 0.20\n"
+    "[attack_effect]\n"
+    "fade_sec = 0.30\n";
 
 }  // namespace
 
@@ -84,6 +86,7 @@ TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
   REQUIRE(cfg.airAttack.damage == 25);
   REQUIRE(cfg.stamina.recoveryRate == 0.5);
   REQUIRE(cfg.landing.recoverySec == 0.20);
+  REQUIRE(cfg.attackEffect.fadeSec == 0.30);
 }
 
 TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -4,6 +4,8 @@
 
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
+#include "Component/FadeOut.hpp"
+#include "Component/Hierarchy.hpp"
 #include "Component/Hitstop.hpp"
 #include "Component/Invincible.hpp"
 #include "Component/LocalOffset.hpp"
@@ -99,6 +101,7 @@ void SetupContext(entt::registry& registry) {
                     .damage = 15,
                     .hitstopSec = 0.08},
       .landing = {.recoverySec = 0.20},
+      .attackEffect = {.fadeSec = 0.30},
   });
 
   AnimationDataRegistry animReg;
@@ -339,7 +342,12 @@ TEST_CASE(
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Landing>(motion));
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 
   const auto& landing = std::get<PlayerMotion::Landing>(motion);
   REQUIRE(landing.timer == Approx(0.20));
@@ -445,7 +453,7 @@ TEST_CASE(
 TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee to Neutral") {
   // elapsed が windupSec+activeSec+recoveryBSec を超え、comboQueued
   // が立っていない場合は Melee から Neutral
-  // へ遷移し、ヒットボックスが残っていれば破棄する
+  // へ遷移し、ヒットボックスが残っていれば解放する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -461,7 +469,12 @@ TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee to Neutral") {
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 }
 
 TEST_CASE("PlayerMotionSystem - timer expiry transitions Ranged to Neutral") {
@@ -528,7 +541,7 @@ TEST_CASE(
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 destroys hitbox when entering "
     "recovery") {
-  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが破棄される
+  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -547,7 +560,12 @@ TEST_CASE(
   const auto& motion = registry.get<Motion>(player);
   const auto& melee = std::get<PlayerMotion::Melee>(motion);
   REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 }
 
 TEST_CASE("PlayerMotionSystem - Melee stage 0 stops horizontal movement") {
@@ -794,7 +812,7 @@ TEST_CASE(
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 destroys hitbox when entering "
     "recovery") {
-  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが破棄される
+  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -813,7 +831,12 @@ TEST_CASE(
   const auto& motion = registry.get<Motion>(player);
   const auto& melee = std::get<PlayerMotion::Melee>(motion);
   REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 }
 
 TEST_CASE(
@@ -1003,7 +1026,7 @@ TEST_CASE(
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 2 destroys hitbox when entering "
     "recovery") {
-  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが破棄される
+  // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -1022,7 +1045,12 @@ TEST_CASE(
   const auto& motion = registry.get<Motion>(player);
   const auto& melee = std::get<PlayerMotion::Melee>(motion);
   REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 }
 
 TEST_CASE(
@@ -1347,7 +1375,7 @@ TEST_CASE(
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 recovery dash input is ignored "
     "without leftover hitbox") {
-  // Melee 後隙からダッシュへキャンセルする際、ヒットボックスは既に破棄済み
+  // Melee 後隙からダッシュへキャンセルする際、ヒットボックスは既に解放済み
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -1355,7 +1383,7 @@ TEST_CASE(
   const auto hitbox = registry.create();
   registry.emplace<LocalOffset>(hitbox);
   registry.emplace<Collider>(hitbox);
-  // activeEnd(0.15) を跨ぐ dt でヒットボックスが破棄される
+  // activeEnd(0.15) を跨ぐ dt でヒットボックスが解放される
   registry.replace<Motion>(
       player,
       PlayerMotion::Melee{.stage = 0, .elapsed = 0.14, .hitboxEntity = hitbox});
@@ -1366,7 +1394,12 @@ TEST_CASE(
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 }
 
 TEST_CASE(
@@ -1677,7 +1710,12 @@ TEST_CASE(
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Landing>(motion));
-  REQUIRE_FALSE(registry.valid(hitbox));
+  // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
+  // へ引き渡す（親からも切り離される）
+  REQUIRE(registry.valid(hitbox));
+  REQUIRE_FALSE(registry.all_of<Attack>(hitbox));
+  REQUIRE(registry.all_of<FadeOut>(hitbox));
+  REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 
   const auto& landing = std::get<PlayerMotion::Landing>(motion);
   REQUIRE(landing.timer == Approx(0.20));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -184,7 +184,8 @@ Debug ビルドでは F5（`InputState::reloadConfig`）で再読込でき、`Pl
 - **ビルドは `tools/build.sh`、実行は `tools/run.sh` で行う。** デバッガを使った調査は
   ユーザーが Visual Studio 2022 で行う
 - **破棄は親から。** `Hierarchy` を持つエンティティは `Hierarchy::DestroyWithChildren` で破棄し、
-  子（攻撃判定の珠）が孤児になるのを防ぐ。独立エンティティである弾はタグで検索して個別に破棄する
+  子（攻撃判定の珠）が孤児になるのを防ぐ。独立エンティティ（弾、フェード中に親から
+  `Detach` された珠）はタグ（`Projectile`/`FadeOut`）で検索して個別に破棄する
 - **ビューの走査中に `destroy` しない。** 破棄対象は配列に集めてループの外でまとめて破棄する
   （`EnemySystem` / `ProjectileSystem`）
 - **タイムラインは共通化する。** 攻撃・ダッシュ系はすべて `MotionTimeline`（構え／有効／

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -18,6 +18,7 @@
 | [`LocalOffset`](../Ash2/src/Component/LocalOffset.hpp) | 親からの相対座標（Hierarchy 付きエンティティのみ） |
 | [`Hierarchy`](../Ash2/src/Component/Hierarchy.hpp) | 親子関係（双方向連結リスト、static メンバで操作） |
 | [`Drawable`](../Ash2/src/Component/Drawable.hpp) | 描画形状の variant。詳細は下記「描画データ型」参照 |
+| [`DrawColor`](../Ash2/src/Component/DrawColor.hpp) | 描画色（`ColorF`）。図形では塗り色、テクスチャでは乗算色として使う。未所持は白・不透明（`KDefaultDrawColor`）として扱われる |
 | [`SpriteAnimation`](../Ash2/src/Component/SpriteAnimation.hpp) | アニメーション再生状態（per-entity）。共有データは `AnimationDataRegistry` を `dataKey` で参照する |
 | [`Name`](../Ash2/src/Component/Name.hpp) | エンティティ名（`const String`、構築後不変。NameLookup と対応） |
 | [`Player`](../Ash2/src/Component/Player.hpp) | プレイヤータグ（データなし） |
@@ -31,6 +32,7 @@
 | [`Motion`](../Ash2/src/Component/Motion.hpp) | エンティティの排他的な行動状態（`variant`）。状態ごとの詳細は下記「モーション状態型」参照 |
 | [`Hitstop`](../Ash2/src/Component/Hitstop.hpp) | ヒットストップ中であることを示す残り時間タイマー。`HitstopSystem` が減算・除去し、付与中は `MovementSystem`/`GravitySystem`/`AnimationSystem` の対象から除外される。`MotionSystem` は除外せず dt = 0 で呼ぶ |
 | [`Invincible`](../Ash2/src/Component/Invincible.hpp) | 無敵状態であることを示すタグ。`HitSystem` の被弾対象ビューから除外される。`PlayerMotion::Dash`（地上・空中いずれも）が構え・ダッシュ中は毎フレーム付与し、後隙入りで除去する |
+| [`FadeOut`](../Ash2/src/Component/FadeOut.hpp) | 透過しながら消滅する途中であることを示すコンポーネント（`duration`/`remaining`）。`FadeOutSystem` が `DrawColor::color.a` を更新し、満了時にエンティティを破棄する |
 
 ---
 
@@ -38,14 +40,16 @@
 
 [`Component/Drawable.hpp`](../Ash2/src/Component/Drawable.hpp) が定義する。
 `Drawable` は `variant<RectDrawable, CircleDrawable, PieDrawable, TextureDrawable>`。
+色は形状側ではなく [`DrawColor`](../Ash2/src/Component/DrawColor.hpp) が一括で持つ
+（上記「コンポーネント一覧」参照）。
 
 | 名前 | 役割 |
 |---|---|
-| `RectDrawable` | 矩形描画（サイズ・色・枠線・`DrawAnchor`） |
-| `CircleDrawable` | 円描画（半径・色・枠線） |
-| `PieDrawable` | 扇形描画（半径・開始角・角度・色・枠線）。角度は12時方向から時計回りのラジアン |
+| `RectDrawable` | 矩形描画（サイズ・枠線・`DrawAnchor`） |
+| `CircleDrawable` | 円描画（半径・枠線） |
+| `PieDrawable` | 扇形描画（半径・開始角・角度・枠線）。角度は12時方向から時計回りのラジアン |
 | `TextureDrawable` | テクスチャ描画（`TextureRegion`・描画オフセット・`DrawAnchor`） |
-| `BorderStyle` | 枠線スタイル（色・太さ）。各形状の `border` が `none` なら枠線なし |
+| `BorderStyle` | 枠線スタイル（色・太さ）。各形状の `border` が `none` なら枠線なし。`DrawColor` の影響は受けず常に不透明で描画される（構築箇所ゼロの未使用コード、整理は #251） |
 | `DrawAnchor` | `WorldPos` を形状のどこに合わせるか（`Center` / `BottomCenter`）。`RectDrawable` と `TextureDrawable` のみが持ち、既定は `Center` |
 
 ---
@@ -101,7 +105,7 @@
 | `Stagger` | 満了で `Idle`（`Tick()` が `RectDrawable::size` を縦縮みさせ、満了時に原寸へ戻す） |
 | `Repel` | 満了で `Idle`（満了時に `Velocity.w` を 0 に戻す） |
 | `Knockback` | 満了で `Idle`（放物線は `MovementSystem`/`GravitySystem` に委ねる） |
-| `Defeated` | なし（`RectDrawable::color.a` をフェードさせ、満了エンティティは `EnemySystem` が破棄する） |
+| `Defeated` | なし（`DrawColor::color.a` をフェードさせ、満了エンティティは `EnemySystem` が破棄する） |
 
 ### 例外
 
@@ -130,8 +134,9 @@
 | [`HitReactionSystem::Apply`](../Ash2/src/System/HitReactionSystem.hpp) | フェーズ内（PlayerTestPhase、HitSystem の後） | `HitSystem::Update` が返した `HitPair` ごとに、攻撃側本体（ヒットボックスの `Hierarchy` 親）と被弾側へ `Hitstop` を付与し、`Enemy` を持つ被弾側の `Motion` と `Velocity` を下記「リアクションの対応」に従って強制遷移させる |
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（PlayerTestPhase、HitReactionSystem の後） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |
 | [`EnemySystem::Update`](../Ash2/src/System/EnemySystem.hpp) | フェーズ内（PlayerTestPhase、ProjectileSystem の後） | `EnemyMotion::Defeated` の残り時間が尽きたエンティティを収集し、`MotionSystem` のビュー走査外でまとめて破棄する |
+| [`FadeOutSystem::Update`](../Ash2/src/System/FadeOutSystem.hpp) | フェーズ内（PlayerTestPhase、EnemySystem の後） | `FadeOut` の残り時間を減算して `DrawColor::color.a`（`get_or_emplace` で確保）に反映し、満了したエンティティを破棄する。`Hitstop` による除外はしない |
 | [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | `Hitstop` を持たない SpriteAnimation の elapsed を進め、切り出した `TextureRegion` を `TextureDrawable` に反映する（`facingRight` なら反転） |
-| [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（HudSystem の前） | WorldPos+Drawable を奥行き順にソートして描画 |
+| [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（HudSystem の前） | WorldPos+Drawable を奥行き順にソートして描画。`DrawColor`（未所持は白・不透明）を塗り色・テクスチャの乗算色として適用する |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画（プレイヤー 1 体のみ想定）。他のシステムと異なり実装をヘッダに直書きしている |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
@@ -183,10 +188,11 @@
 
 | 名前 | 役割 | 定義 |
 |---|---|---|
-| `HitboxSpec` | 攻撃判定エンティティの生成仕様（半径・ダメージ・リアクション・ヒットストップ時間）をまとめた構造体 | `Helper.hpp` |
+| `HitboxSpec` | 攻撃判定エンティティの生成仕様（半径・ダメージ・リアクション・ヒットストップ時間・フェード時間）をまとめた構造体 | `Helper.hpp` |
 | `SetClip` | クリップが変化していれば差し替え、再生位置をリセットする | `Helper.hpp`/`.cpp` |
 | `StopHorizontalMovement` | 横方向（w・d）の速度を 0 にする | `Helper.hpp`/`.cpp` |
-| `UpdateAttackHitbox` | active 区間に応じて攻撃判定エンティティ（光の珠）を生成・`LocalOffset` 更新・破棄する。オフセットは `offsetFn(progress)` で決まる | `Helper.hpp`/`.cpp` |
+| `ReleaseAttackHitbox` | ヒットボックスを `Hierarchy::Detach` → `Attack` 除去 → `FadeOut` 付与の順で解放する。`fadeSec` が 0 以下なら即座に破棄する | `Helper.hpp`/`.cpp` |
+| `UpdateAttackHitbox` | active 区間に応じて攻撃判定エンティティ（光の珠）を生成・`LocalOffset` 更新し、後隙入りで `ReleaseAttackHitbox` を呼ぶ。オフセットは `offsetFn(progress)` で決まる | `Helper.hpp`/`.cpp` |
 | `MakeMelee` | 指定段の `Melee` を生成（`melee_{stage+1}` クリップを先頭から再生） | `Transition.hpp` / `Melee.cpp` |
 | `MakeRanged` | `Ranged` を生成（スタミナ消費、`timer` はクリップ再生時間から算出） | `Transition.hpp` / `Ranged.cpp` |
 | `MakeDash` | `Dash` を生成（スタミナ消費、`air` フラグ設定） | `Transition.hpp` / `Dash.cpp` |
@@ -264,7 +270,7 @@
 - `Ash2/App/assets/config/player.toml` から読み込むプレイヤー設定
 - 基本値（移動速度 `speed`・ジャンプ初速 `jumpSpeed`・重力 `gravity`）と、`MeleeConfig` /
   `RangedConfig` / `DashConfig` / `DashAttackConfig` / `AirAttackConfig` / `StaminaConfig` /
-  `LandingConfig` の各サブ設定を持つ
+  `LandingConfig` / `AttackEffectConfig` の各サブ設定を持つ
 - 地上・空中を共有する `Dash`/`DashAttack`（`air` フラグで区別）は、それぞれ単一の
   `DashConfig`/`DashAttackConfig` を共通で参照する（専用設定は持たない）
 
@@ -282,6 +288,7 @@
 | `AirAttackConfig` | タイムライン・軌道半径（w-h 平面）・カプセル半径・ダメージ・ヒットストップ時間 |
 | `StaminaConfig` | 回復開始待機秒数 `recoveryDelay`・毎秒の不足分回復割合 `recoveryRate` |
 | `LandingConfig` | 着地硬直時間 `recoverySec` |
+| `AttackEffectConfig` | ヒットボックス解放後のフェードアウト時間 `fadeSec`（全攻撃共通の1値。`HitboxSpec::fadeSec` として渡される） |
 
 - `hitstopSec`（`MeleeStageConfig`/`DashAttackConfig`/`AirAttackConfig` が個別に持つ）はヒット成立時に
   `Attack.hitstopSec` へ渡す停止時間で、段・アクションごとに調整できる（`RangedConfig` は持たない。
@@ -415,6 +422,7 @@
 | `TestHitstopSystem.cpp` | `HitstopSystem` |
 | `TestPlayerMotionSystem.cpp` | プレイヤー各状態の `Tick()` |
 | `TestEnemyMotionSystem.cpp` | 敵各状態の `Tick()`、`EnemySystem` |
+| `TestFadeOutSystem.cpp` | `FadeOutSystem` の `DrawColor::color.a` 減衰・満了時の破棄 |
 | `TestProjectileSystem.cpp` | `ProjectileSystem` の消滅条件 |
 | `TestNameLookup.cpp` | `NameLookupSystem` のシグナル同期 |
 | `TestPlayerConfig.cpp` | `PlayerConfig::FromToml` |
@@ -430,6 +438,7 @@
 
 - `Hierarchy` のメンバは必ず static メンバ関数（Attach/Detach/DestroyWithChildren）経由で操作する。
 - `Drawable` の型変更は `std::visit` を使い、DrawSystem と AnimationSystem の両方への影響を確認する。
+- 図形（`Drawable`）に `DrawColor` を付け忘れると白（`KDefaultDrawColor`）で描かれる。意図した色にしたい場合は忘れず付与すること。
 - 新クラス追加時は `Ash2.vcxproj` と `Ash2.vcxproj.filters` にも追加が必要。
 - `NameLookup` への挿入・削除は `NameLookupSystem::Connect` で自動化されている（`Name` コンポーネントの追加・削除に連動）。手動での `NameLookup[key] = entity` 登録は不要。
 - `Motion` に新しい状態型を追加したときは、その型に `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。`MotionSystem::Update` の `std::visit` が `MotionState` concept（`MotionSystem.hpp`）で制約されているため。


### PR DESCRIPTION
close #250

## 変更概要

攻撃判定エフェクト（光の珠）が `active` 終了と同時に一瞬で消える挙動を、透過度を下げながら消える形に変えた。

`active` 終了時に即破棄せず、`Hierarchy::Detach` で切り離す → `Attack` を外す → `FadeOut` を付与、という流れにした。新設の `FadeOutSystem` が `DrawColor::color.a` を下げ、尽きたら破棄する。

## 実装判断

### 色を `DrawColor` コンポーネント1つへ切り出した

Issue 本文の検討事項1（`Drawable` が variant でテクスチャは色を持たない）に対し、挙げられていた2案（Drawable 全般の仕組みにする／色を持つ形状に限る）のいずれでもなく、`RectDrawable` / `CircleDrawable` / `PieDrawable` から `ColorF color` を削除して `DrawColor` へ移した。

- variant の中に色があると `std::get_if` で取り出して直接書き換える実装を誘発する。`EnemyMotion::Defeated` が実際にそうなっていた
- 色が1箇所に集まり、`FadeOutSystem` は `Drawable` の variant を知らずに済む
- 調査の結果、`Drawable` の構築は本体5・テスト4の計9箇所（うち2箇所はテクスチャで色なし）と小規模だった

検討の過程で以下は却下した。

- **`std::visit` で色を持つ3形状のみ書き換える案** — `TextureDrawable` だけフェードしない歪みが残り、素材色を演出で破壊するため元に戻せない
- **`double` 1つの `Opacity` を持つ案** — `TextureRegion::draw` も `ColorF` を受け取れるため alpha に絞る根拠がない
- **素材色 `BaseColor` と変調色 `Tint` の2層構造** — 色を2箇所で管理することになり、当初の問題を解決しない。2層の根拠だった「元に戻す必要のある演出で素材色を書き潰さない」は現時点で存在しない機能のための備えだった（`Invincible` は判定除外のみで点滅描画を持たず、被弾フラッシュも未実装）。将来そうした演出が必要になった場合は、演出専用のコンポーネントが自前で色を持つほうが素直と判断した

### `DrawColor` 未所持は既定色で描き、assert は置かない

`CircleDrawable{.radius, .color}` という型による保証は失われるが、「図形は必ず `DrawColor` を持つ」という不変条件を assert のために新設することはしなかった。付け忘れは静かに壊れるのではなく白で描かれ、初回の実行で目に見える。意図して既定の白のままにする図形も許される。

既定色は `KDefaultDrawColor`（`ColorF{1.0}`）として `DrawColor.hpp` に `inline constexpr` で置いた。既定値と `DrawSystem` のフォールバックの2箇所で使うため定数化している。`ColorF{}` は値初期化で `(0, 0, 0, 0)` の透明な黒になり、付け忘れが「見えないエンティティ」になるため使っていない。

### 解放処理を `ReleaseAttackHitbox` に集約した

`UpdateAttackHitbox` の破棄に加え、`AirAttack` / `DashAttack` の接地による強制破棄も同じ関数に寄せた。`Hierarchy::DestroyWithChildren` を直接呼ぶ箇所を残さないため。`fadeSec <= 0.0` のときは即破棄にフォールバックする。

### `EnemyMotion::Defeated` の移行

`std::get_if<RectDrawable>` による色書き換えを `get_or_emplace<DrawColor>` に置き換えた。`color` 削除でコンパイルエラーになるため必須の変更だが、副次的に `RectDrawable` 以外の敵でフェードが効かない不具合も解消された。破棄タイミングは `EnemySystem` が握ったままとし、`FadeOut` には統合していない（二重破棄の調停が必要になるため）。

### フェード時間は `player.toml` に置いた

`[attack_effect] fade_sec` として全攻撃共通の1値にした。#229 の調整を F5 リロードで回すため、再ビルドを挟まずに済む場所に置いている。値は `HitboxSpec` 経由で渡しているので、段・アクションごとの個別調整に移す場合は呼び出し側の一行差し替えで済む。

### 破棄漏れへの手当て

`FadeOut` 自体を検索用タグとして使い、`onBeforePop` で `view<FadeOut>` を個別破棄する。`Projectile` の既存の回避策と同じ形にそろえた。F5 のコンフィグリロードも `onBeforePop` を通るため同じ経路で消える。

## 既知の制約

`BorderStyle` は自前の `ColorF` を持つため、`DrawColor` の alpha を下げても枠線だけ不透明のまま残る。ただし `.border` を設定する箇所はコードベースにゼロで枠線は描画されないため実害はない。調査の過程で `PieDrawable` も一度も構築されていないことが判明したため、両者の調査と削除の判断は #251 に分離した。

## 確認

- format / tidy / build / test すべて通過（170 テストケース・425 アサーション）
- 実機で確認済み：珠が透過しながら消えること、消えかけの珠がその場に留まりプレイヤーに追従しないこと、F5 リロードやフェーズ離脱で残らないこと、敵の撃破フェードと各エンティティの色に異常がないこと

## 関連

- #229 / #230 / #231（本Issueの完了待ちで中断していた）
- #251（`BorderStyle` / `PieDrawable` の調査・削除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)