### PR TITLE
clang-format に BlockIndent を導入する

### DIFF
--- a/Ash2/.clang-format
+++ b/Ash2/.clang-format
@@ -1,4 +1,6 @@
 BasedOnStyle: Google
+AlignAfterOpenBracket: BlockIndent
+PenaltyBreakScopeResolution: 1000000
 SortIncludes: CaseSensitive
 IncludeBlocks: Regroup
 IncludeCategories:

--- a/Ash2/src/Component/Hierarchy.cpp
+++ b/Ash2/src/Component/Hierarchy.cpp
@@ -2,8 +2,10 @@
 
 #include "Component/LocalOffset.hpp"
 
-void Hierarchy::Attach(entt::registry& registry, entt::entity parent,
-                       entt::entity child, WorldPos offset) {
+void Hierarchy::Attach(
+    entt::registry& registry, entt::entity parent, entt::entity child,
+    WorldPos offset
+) {
   if (!registry.all_of<Hierarchy>(parent)) {
     registry.emplace<Hierarchy>(parent);
   }
@@ -58,8 +60,9 @@ void Hierarchy::Detach(entt::registry& registry, entt::entity child) {
   registry.remove<LocalOffset>(child);
 }
 
-void Hierarchy::DestroyWithChildren(entt::registry& registry,
-                                    entt::entity entity) {
+void Hierarchy::DestroyWithChildren(
+    entt::registry& registry, entt::entity entity
+) {
   if (!registry.valid(entity)) return;
   if (registry.all_of<Hierarchy>(entity)) {
     auto child = registry.get<const Hierarchy>(entity).m_firstChild;

--- a/Ash2/src/Component/Hierarchy.hpp
+++ b/Ash2/src/Component/Hierarchy.hpp
@@ -22,15 +22,18 @@ class Hierarchy {
   /// 子がすでに別の親を持つ場合は先に Detach してから挿入する。
   /// parent・child が Hierarchy を持たない場合は自動的に追加する。
   /// @param offset 親からの相対座標（省略時はゼロ）
-  static void Attach(entt::registry& registry, entt::entity parent,
-                     entt::entity child, WorldPos offset = {});
+  static void Attach(
+      entt::registry& registry, entt::entity parent, entt::entity child,
+      WorldPos offset = {}
+  );
 
   /// @brief 子を親から切り離す（O(1)）
   static void Detach(entt::registry& registry, entt::entity child);
 
   /// @brief エンティティと全子孫を再帰的に破棄する
-  static void DestroyWithChildren(entt::registry& registry,
-                                  entt::entity entity);
+  static void DestroyWithChildren(
+      entt::registry& registry, entt::entity entity
+  );
 
  private:
   entt::entity m_parent = entt::null;

--- a/Ash2/src/Config/AnimationData.cpp
+++ b/Ash2/src/Config/AnimationData.cpp
@@ -7,7 +7,8 @@ namespace {
 /// @brief TOML から1クリップ分の AnimationClip を生成する
 /// @param name クリップ名（欠落キーのメッセージにテーブル名として前置する）
 [[nodiscard]] std::expected<AnimationClip, String> ParseClip(
-    const TOMLValue& clip, StringView name) {
+    const TOMLValue& clip, StringView name
+) {
   TomlFields f{clip, U"AnimationData::ParseClip", String{name}};
   return f.wrap(AnimationClip{
       .row = f.get<int32>(U"row"),
@@ -17,8 +18,8 @@ namespace {
 }
 
 /// @brief TOML からアニメーション共有データを生成する
-[[nodiscard]] std::expected<AnimationData, String> Parse(
-    const TOMLValue& toml) {
+[[nodiscard]] std::expected<AnimationData, String> Parse(const TOMLValue& toml
+) {
   TomlFields f{toml, U"AnimationData::Parse"};
   const auto textureKey = f.get<String>(U"texture");
   const Size size = {f.get<int32>(U"width"), f.get<int32>(U"height")};
@@ -26,8 +27,9 @@ namespace {
   // draw_offset は別テーブルのため、prefix 付きの別インスタンスで読む。
   // offset.check() が先に欠落を報告し、f 側の欠落チェックは後続の
   // f.wrap() 呼び出しで別途行われる。
-  TomlFields offset{toml[U"draw_offset"], U"AnimationData::Parse",
-                    U"draw_offset"};
+  TomlFields offset{
+      toml[U"draw_offset"], U"AnimationData::Parse", U"draw_offset"
+  };
   const Vec2 drawOffset = {offset.get<double>(U"x"), offset.get<double>(U"y")};
   if (auto result = offset.check(); !result) {
     return std::unexpected{std::move(result).error()};

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -10,7 +10,8 @@ namespace {
 /// の4キーを持つテーブルであればよく、melee の段テーブルのように
 /// 他のキーを併せ持っていても構わない
 [[nodiscard]] std::expected<MotionTimeline, String> ParseTimeline(
-    const TOMLValue& toml, StringView section) {
+    const TOMLValue& toml, StringView section
+) {
   TomlFields f{toml, U"PlayerConfig::ParseTimeline", String{section}};
   return f.wrap(MotionTimeline{
       .windupSec = f.get<double>(U"windup_sec"),
@@ -22,20 +23,23 @@ namespace {
 
 /// @brief TOML の trajectory 文字列を MeleeTrajectory へ変換する
 [[nodiscard]] std::expected<MeleeTrajectory, String> ParseMeleeTrajectory(
-    const String& value) {
+    const String& value
+) {
   if (value == U"thrust") return MeleeTrajectory::Thrust;
   if (value == U"slash") return MeleeTrajectory::Slash;
   return std::unexpected{
       U"PlayerConfig::ParseMeleeTrajectory: 不明な melee "
       U"trajectory \"" +
-      value + U"\""};
+      value + U"\""
+  };
 }
 
 /// @brief TOML から近接コンボ1段分の MeleeStageConfig を生成する
 /// @param index 段のインデックス（欠落キーのメッセージに `melee.stage[index]`
 /// として前置し、 実運用の複数段のうちどの段が不正かを示す）
 [[nodiscard]] std::expected<MeleeStageConfig, String> ParseMeleeStage(
-    const TOMLValue& stageToml, size_t index) {
+    const TOMLValue& stageToml, size_t index
+) {
   const String prefix = U"melee.stage[" + Format(index) + U"]";
   auto timeline = ParseTimeline(stageToml, prefix);
   if (!timeline) {
@@ -69,8 +73,8 @@ namespace {
 }
 
 /// @brief TOML から近接攻撃の設定値を生成する
-[[nodiscard]] std::expected<MeleeConfig, String> ParseMelee(
-    const TOMLValue& m) {
+[[nodiscard]] std::expected<MeleeConfig, String> ParseMelee(const TOMLValue& m
+) {
   Array<MeleeStageConfig> stages;
   // Why not: m[U"stage"] がテーブル配列として存在しない場合に
   // tableArrayView() を呼ぶと不正アクセスになるため、
@@ -89,8 +93,8 @@ namespace {
   // stages が空だと Tick(Melee&, ...) の stages[state.stage] アクセスが
   // 不正になるため許容しない
   if (stages.isEmpty()) {
-    return std::unexpected{
-        U"PlayerConfig::ParseMelee: melee.stage がありません"};
+    return std::unexpected{U"PlayerConfig::ParseMelee: melee.stage がありません"
+    };
   }
 
   TomlFields f{m, U"PlayerConfig::ParseMelee", U"melee"};
@@ -103,8 +107,8 @@ namespace {
 }
 
 /// @brief TOML から遠距離攻撃の設定値を生成する
-[[nodiscard]] std::expected<RangedConfig, String> ParseRanged(
-    const TOMLValue& r) {
+[[nodiscard]] std::expected<RangedConfig, String> ParseRanged(const TOMLValue& r
+) {
   TomlFields f{r, U"PlayerConfig::ParseRanged", U"ranged"};
   return f.wrap(RangedConfig{
       .reach = f.get<double>(U"reach"),
@@ -133,7 +137,8 @@ namespace {
 
 /// @brief TOML からダッシュ攻撃の設定値を生成する
 [[nodiscard]] std::expected<DashAttackConfig, String> ParseDashAttack(
-    const TOMLValue& da) {
+    const TOMLValue& da
+) {
   auto timeline = ParseTimeline(da, U"dash_attack");
   if (!timeline) {
     return std::unexpected{std::move(timeline).error()};
@@ -152,7 +157,8 @@ namespace {
 
 /// @brief TOML から空中攻撃の設定値を生成する
 [[nodiscard]] std::expected<AirAttackConfig, String> ParseAirAttack(
-    const TOMLValue& aa) {
+    const TOMLValue& aa
+) {
   auto timeline = ParseTimeline(aa, U"air_attack");
   if (!timeline) {
     return std::unexpected{std::move(timeline).error()};
@@ -170,7 +176,8 @@ namespace {
 
 /// @brief TOML からスタミナ回復の設定値を生成する
 [[nodiscard]] std::expected<StaminaConfig, String> ParseStamina(
-    const TOMLValue& s) {
+    const TOMLValue& s
+) {
   TomlFields f{s, U"PlayerConfig::ParseStamina", U"stamina"};
   return f.wrap(StaminaConfig{
       .recoveryDelay = f.get<double>(U"recovery_delay"),
@@ -180,7 +187,8 @@ namespace {
 
 /// @brief TOML から着地硬直の設定値を生成する
 [[nodiscard]] std::expected<LandingConfig, String> ParseLanding(
-    const TOMLValue& l) {
+    const TOMLValue& l
+) {
   TomlFields f{l, U"PlayerConfig::ParseLanding", U"landing"};
   return f.wrap(LandingConfig{
       .recoverySec = f.get<double>(U"recovery_sec"),
@@ -189,7 +197,8 @@ namespace {
 
 /// @brief TOML から攻撃演出共通の設定値を生成する
 [[nodiscard]] std::expected<AttackEffectConfig, String> ParseAttackEffect(
-    const TOMLValue& ae) {
+    const TOMLValue& ae
+) {
   TomlFields f{ae, U"PlayerConfig::ParseAttackEffect", U"attack_effect"};
   return f.wrap(AttackEffectConfig{
       .fadeSec = f.get<double>(U"fade_sec"),

--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -5,7 +5,8 @@ namespace {
 /// @brief TOML の 1 ステップ値を ScenarioStep に変換する
 /// @note "make" アクションは別 Issue で対応予定のためエラーとする
 [[nodiscard]] std::expected<ScenarioStep, String> ParseStep(
-    const TOMLValue& step, const PhaseLoaderTable& loaders) {
+    const TOMLValue& step, const PhaseLoaderTable& loaders
+) {
   const auto action = step[U"action"].getOpt<String>();
   if (!action) {
     return std::unexpected{U"ScenarioData::ParseStep: action がありません"};
@@ -18,8 +19,9 @@ namespace {
     }
     const auto it = loaders.find(*phaseName);
     if (it == loaders.end()) {
-      return std::unexpected{U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" +
-                             *phaseName + U"\""};
+      return std::unexpected{
+          U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" + *phaseName + U"\""
+      };
     }
     auto maker = it->second(step);
     if (!maker) {
@@ -34,17 +36,20 @@ namespace {
   if (*action == U"make") {
     return std::unexpected{
         U"ScenarioData::ParseStep: \"make\" アクションは未対応です（Issue "
-        U"#67 スコープ外）"};
+        U"#67 スコープ外）"
+    };
   }
 
-  return std::unexpected{U"ScenarioData::ParseStep: 不明なアクション \"" +
-                         *action + U"\""};
+  return std::unexpected{
+      U"ScenarioData::ParseStep: 不明なアクション \"" + *action + U"\""
+  };
 }
 
 }  // namespace
 
-ScenarioData ScenarioData::FromToml(const TOMLValue& toml,
-                                    const PhaseLoaderTable& loaders) {
+ScenarioData ScenarioData::FromToml(
+    const TOMLValue& toml, const PhaseLoaderTable& loaders
+) {
   ScenarioData data;
 
   for (const auto& member : toml.tableView()) {

--- a/Ash2/src/Config/ScenarioData.hpp
+++ b/Ash2/src/Config/ScenarioData.hpp
@@ -45,6 +45,7 @@ struct ScenarioData {
 
   /// @brief TOML からシナリオデータを生成する
   /// @param loaders フェーズ名 → PhaseLoader のマップ（呼び出し元が用意する）
-  [[nodiscard]] static ScenarioData FromToml(const TOMLValue& toml,
-                                             const PhaseLoaderTable& loaders);
+  [[nodiscard]] static ScenarioData FromToml(
+      const TOMLValue& toml, const PhaseLoaderTable& loaders
+  );
 };

--- a/Ash2/src/Config/TomlFields.hpp
+++ b/Ash2/src/Config/TomlFields.hpp
@@ -23,8 +23,9 @@ class TomlFields {
     if (auto value = m_table[String{key}].getOpt<T>()) {
       return *std::move(value);
     }
-    m_missing.push_back(m_prefix.isEmpty() ? String{key}
-                                           : (m_prefix + U"." + String{key}));
+    m_missing.push_back(
+        m_prefix.isEmpty() ? String{key} : (m_prefix + U"." + String{key})
+    );
     return T{};
   }
 
@@ -34,8 +35,9 @@ class TomlFields {
     if (m_missing.isEmpty()) {
       return {};
     }
-    return std::unexpected{m_context + U": キーがありません: " +
-                           m_missing.join(U", ", U"", U"")};
+    return std::unexpected{
+        m_context + U": キーがありません: " + m_missing.join(U", ", U"", U"")
+    };
   }
 
   /// @brief 記録した欠落を expected に畳む

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -43,7 +43,8 @@ void InitializeRegistry(entt::registry& registry) {
 
   const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
   registry.ctx().emplace<ScenarioData>(
-      ScenarioData::FromToml(scenarioToml, GetPhaseLoaders()));
+      ScenarioData::FromToml(scenarioToml, GetPhaseLoaders())
+  );
 }
 
 void ReloadConfig(entt::registry& registry) {

--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -25,7 +25,8 @@ inline InputState InputDeviceSelector::update() {
   }
   // 最後に入力があったデバイスへ切り替える
   const Vec2 stickAxis = XInputAction::KLeftThumbDeadZone(
-      Vec2{XInput(0).leftThumbX, XInput(0).leftThumbY});
+      Vec2{XInput(0).leftThumbX, XInput(0).leftThumbY}
+  );
   if (XInput(0).isConnected() &&
       (XInput(0).buttonUp.down() || XInput(0).buttonDown.down() ||
        XInput(0).buttonLeft.down() || XInput(0).buttonRight.down() ||

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -10,7 +10,8 @@ struct XInputAction {
   /// 左スティックに適用するデッドゾーン（`InputDeviceSelector`
   /// もスティック傾き判定に同じ定数を参照する）
   static constexpr DeadZone KLeftThumbDeadZone{
-      .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular};
+      .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular
+  };
 
   /// @brief 現在のコントローラー入力状態を InputState に変換して返す
   [[nodiscard]] static InputState ToInputState();

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -41,9 +41,12 @@ void Main() {
 
     InputDeviceSelector inputSelector;
 
-    PhaseStack phaseStack(std::make_unique<ScenarioPhase>(
-                              ScenarioPhase::Param{.sectionName = U"init"}),
-                          registry);
+    PhaseStack phaseStack(
+        std::make_unique<ScenarioPhase>(
+            ScenarioPhase::Param{.sectionName = U"init"}
+        ),
+        registry
+    );
 
     while (System::Update()) {
       const FrameData frameData{

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -37,16 +37,21 @@ void AnimationViewerPhase::onAfterPush(entt::registry& registry) {
   m_entity = registry.create();
   registry.emplace<WorldPos>(m_entity);
   registry.emplace<Drawable>(
-      m_entity, TextureDrawable{.anchor = DrawAnchor::BottomCenter});
+      m_entity, TextureDrawable{.anchor = DrawAnchor::BottomCenter}
+  );
   registry.emplace<SpriteAnimation>(
       m_entity,
-      SpriteAnimation{.dataKey = m_dataKey,
-                      .currentClip = m_clips.empty() ? U"" : m_clips[0]});
+      SpriteAnimation{
+          .dataKey = m_dataKey,
+          .currentClip = m_clips.empty() ? U"" : m_clips[0]
+      }
+  );
   AnimationSystem::Update(registry, 0.0);
 }
 
-IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
-                                                  const FrameData& frameData) {
+IPhase::PhaseCommand AnimationViewerPhase::update(
+    entt::registry& registry, const FrameData& frameData
+) {
   if (KeyEscape.down()) {
     return PhaseCommand::Pop();
   }
@@ -83,8 +88,9 @@ IPhase::PhaseCommand AnimationViewerPhase::update(entt::registry& registry,
   Scene::SetBackground(ColorF{KBgBrightness});
   m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(KTitleX, KTitleY);
   if (!m_clips.empty()) {
-    m_font(U"Clip [{}/{}]: {}"_fmt(m_clipIndex + 1, m_clips.size(),
-                                   m_clips[m_clipIndex]))
+    m_font(U"Clip [{}/{}]: {}"_fmt(
+               m_clipIndex + 1, m_clips.size(), m_clips[m_clipIndex]
+           ))
         .draw(KTitleX, KClipInfoY);
   }
   m_font(U"← → : clip  F : flip  Esc : back")

--- a/Ash2/src/Phase/AnimationViewerPhase.hpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.hpp
@@ -18,8 +18,9 @@ class AnimationViewerPhase : public IPhase {
   /// @brief 一時エンティティを生成する
   void onAfterPush(entt::registry& registry) override;
 
-  [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    const FrameData& frameData) override;
+  [[nodiscard]] PhaseCommand update(
+      entt::registry& registry, const FrameData& frameData
+  ) override;
 
   /// @brief 一時エンティティを破棄する
   void onBeforePop(entt::registry& registry) override;

--- a/Ash2/src/Phase/IPhase.hpp
+++ b/Ash2/src/Phase/IPhase.hpp
@@ -43,8 +43,9 @@ class IPhase {
   /// @brief スタックに積まれた直後に呼ばれる
   virtual void onAfterPush(entt::registry&) {}
 
-  [[nodiscard]] virtual PhaseCommand update(entt::registry& registry,
-                                            const FrameData& frameData) = 0;
+  [[nodiscard]] virtual PhaseCommand update(
+      entt::registry& registry, const FrameData& frameData
+  ) = 0;
 
   /// @brief スタックから取り出される直前に呼ばれる
   virtual void onBeforePop(entt::registry&) {}
@@ -59,13 +60,15 @@ inline IPhase::PhaseCommand IPhase::PhaseCommand::Pop() {
 }
 
 inline IPhase::PhaseCommand IPhase::PhaseCommand::Push(
-    std::unique_ptr<IPhase>&& phase) {
+    std::unique_ptr<IPhase>&& phase
+) {
   assert(phase != nullptr);
   return {.type = Type::Push, .nextPhase = std::move(phase)};
 }
 
 inline IPhase::PhaseCommand IPhase::PhaseCommand::Reset(
-    std::unique_ptr<IPhase>&& phase) {
+    std::unique_ptr<IPhase>&& phase
+) {
   assert(phase != nullptr);
   return {.type = Type::Reset, .nextPhase = std::move(phase)};
 }

--- a/Ash2/src/Phase/PhaseLoaders.cpp
+++ b/Ash2/src/Phase/PhaseLoaders.cpp
@@ -33,8 +33,8 @@ class PhaseMaker : public IPhaseMaker {
 /// unexpected でエラーメッセージを返す）
 template <PhaseWithParam T, typename F>
 PhaseLoader MakeLoader(F&& parse) {
-  return [p = std::forward<F>(parse)](
-             const TOMLValue& step) -> std::expected<IPhaseMaker::Ptr, String> {
+  return [p = std::forward<F>(parse)](const TOMLValue& step
+         ) -> std::expected<IPhaseMaker::Ptr, String> {
     auto param = p(step);
     if (!param) {
       return std::unexpected{std::move(param).error()};
@@ -52,45 +52,54 @@ const PhaseLoaderTable& GetPhaseLoaders() {
            [](const TOMLValue&)
                -> std::expected<PlayerTestPhase::Param, String> {
              return PlayerTestPhase::Param{};
-           })},
+           }
+       )},
       {U"test_menu",
        MakeLoader<TestMenuPhase>(
            [](const TOMLValue&) -> std::expected<TestMenuPhase::Param, String> {
              return TestMenuPhase::Param{};
-           })},
+           }
+       )},
       {U"animation_viewer",
        MakeLoader<AnimationViewerPhase>(
-           [](const TOMLValue& step)
-               -> std::expected<AnimationViewerPhase::Param, String> {
+           [](const TOMLValue& step
+           ) -> std::expected<AnimationViewerPhase::Param, String> {
              const auto dataKey = step[U"param"].getOpt<String>();
              if (!dataKey) {
                return std::unexpected{
                    U"ScenarioData::ParseStep: animation_viewer に param があ"
-                   U"りません"};
+                   U"りません"
+               };
              }
              return AnimationViewerPhase::Param{.dataKey = *dataKey};
-           })},
+           }
+       )},
       {U"scenario",
        MakeLoader<ScenarioPhase>(
-           [](const TOMLValue& step)
-               -> std::expected<ScenarioPhase::Param, String> {
+           [](const TOMLValue& step
+           ) -> std::expected<ScenarioPhase::Param, String> {
              const auto sectionName = step[U"param"].getOpt<String>();
              if (!sectionName) {
                return std::unexpected{
-                   U"ScenarioData::ParseStep: scenario に param がありません"};
+                   U"ScenarioData::ParseStep: scenario に param がありません"
+               };
              }
              return ScenarioPhase::Param{.sectionName = *sectionName};
-           })},
+           }
+       )},
       {U"wait",
-       MakeLoader<WaitPhase>([](const TOMLValue& step)
-                                 -> std::expected<WaitPhase::Param, String> {
-         const auto duration = step[U"duration"].getOpt<double>();
-         if (!duration) {
-           return std::unexpected{
-               U"ScenarioData::ParseStep: wait に duration がありません"};
-         }
-         return WaitPhase::Param{.duration = *duration};
-       })},
+       MakeLoader<WaitPhase>(
+           [](const TOMLValue& step
+           ) -> std::expected<WaitPhase::Param, String> {
+             const auto duration = step[U"duration"].getOpt<double>();
+             if (!duration) {
+               return std::unexpected{
+                   U"ScenarioData::ParseStep: wait に duration がありません"
+               };
+             }
+             return WaitPhase::Param{.duration = *duration};
+           }
+       )},
   };
   return loaders;
 }

--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -1,7 +1,8 @@
 #include "Phase/PhaseStack.hpp"
 
-PhaseStack::PhaseStack(std::unique_ptr<IPhase>&& initialPhase,
-                       entt::registry& registry) {
+PhaseStack::PhaseStack(
+    std::unique_ptr<IPhase>&& initialPhase, entt::registry& registry
+) {
   push(registry, std::move(initialPhase));
 }
 
@@ -40,8 +41,9 @@ void PhaseStack::pop(entt::registry& registry) {
   m_stack.pop_back();
 }
 
-void PhaseStack::push(entt::registry& registry,
-                      std::unique_ptr<IPhase>&& phase) {
+void PhaseStack::push(
+    entt::registry& registry, std::unique_ptr<IPhase>&& phase
+) {
   assert(phase != nullptr);
   m_stack.push_back(std::move(phase));
   m_stack.back()->onAfterPush(registry);

--- a/Ash2/src/Phase/PhaseStack.hpp
+++ b/Ash2/src/Phase/PhaseStack.hpp
@@ -6,8 +6,9 @@
 /// @brief フェーズをスタックで管理するクラス
 class PhaseStack {
  public:
-  explicit PhaseStack(std::unique_ptr<IPhase>&& initialPhase,
-                      entt::registry& registry);
+  explicit PhaseStack(
+      std::unique_ptr<IPhase>&& initialPhase, entt::registry& registry
+  );
 
   void update(entt::registry& registry, const FrameData& frameData);
 

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -48,15 +48,19 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   registry.emplace<Gravity>(m_playerRoot, Gravity{.accel = cfg.gravity});
   registry.emplace<Name>(m_playerRoot, Name{U"player"});
   registry.emplace<Drawable>(
-      m_playerRoot, TextureDrawable{.anchor = DrawAnchor::BottomCenter});
+      m_playerRoot, TextureDrawable{.anchor = DrawAnchor::BottomCenter}
+  );
   registry.emplace<SpriteAnimation>(
       m_playerRoot,
-      SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
-  registry.emplace<Hp>(m_playerRoot,
-                       Hp{.max = KPlayerMaxHp, .current = KPlayerMaxHp});
+      SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"}
+  );
+  registry.emplace<Hp>(
+      m_playerRoot, Hp{.max = KPlayerMaxHp, .current = KPlayerMaxHp}
+  );
   registry.emplace<Stamina>(
       m_playerRoot,
-      Stamina{.max = KPlayerMaxStamina, .current = KPlayerMaxStamina});
+      Stamina{.max = KPlayerMaxStamina, .current = KPlayerMaxStamina}
+  );
   registry.emplace<Motion>(m_playerRoot, PlayerMotion::Neutral{});
   AnimationSystem::Update(registry, 0.0);
 
@@ -77,19 +81,26 @@ entt::entity PlayerTestPhase::spawnEnemy(entt::registry& registry) {
   registry.emplace<Motion>(enemy, EnemyMotion::Idle{});
   registry.emplace<Drawable>(
       enemy,
-      RectDrawable{.size = enemyCfg.size, .anchor = DrawAnchor::BottomCenter});
+      RectDrawable{.size = enemyCfg.size, .anchor = DrawAnchor::BottomCenter}
+  );
   registry.emplace<DrawColor>(enemy, DrawColor{.color = KDummyColor});
   registry.emplace<Collider>(
-      enemy, Collider{.segmentStart = Vec3{0.0, 0.0, 0.0},
-                      .segmentEnd = Vec3{0.0, enemyCfg.capsuleHeight, 0.0},
-                      .radius = enemyCfg.capsuleRadius});
-  registry.emplace<Hp>(enemy,
-                       Hp{.max = enemyCfg.maxHp, .current = enemyCfg.maxHp});
+      enemy,
+      Collider{
+          .segmentStart = Vec3{0.0, 0.0, 0.0},
+          .segmentEnd = Vec3{0.0, enemyCfg.capsuleHeight, 0.0},
+          .radius = enemyCfg.capsuleRadius
+      }
+  );
+  registry.emplace<Hp>(
+      enemy, Hp{.max = enemyCfg.maxHp, .current = enemyCfg.maxHp}
+  );
   return enemy;
 }
 
-IPhase::PhaseCommand PlayerTestPhase::update(entt::registry& registry,
-                                             const FrameData& frameData) {
+IPhase::PhaseCommand PlayerTestPhase::update(
+    entt::registry& registry, const FrameData& frameData
+) {
   const double dt = frameData.dt;
 
   HitstopSystem::Update(registry, dt);

--- a/Ash2/src/Phase/PlayerTestPhase.hpp
+++ b/Ash2/src/Phase/PlayerTestPhase.hpp
@@ -18,8 +18,9 @@ class PlayerTestPhase : public IPhase {
   /// @brief プレイヤーエンティティ（ルート）と敵エンティティを生成する
   void onAfterPush(entt::registry& registry) override;
 
-  [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    const FrameData& frameData) override;
+  [[nodiscard]] PhaseCommand update(
+      entt::registry& registry, const FrameData& frameData
+  ) override;
 
   /// @brief プレイヤーエンティティ（ルート＋子孫）と敵エンティティを破棄する
   void onBeforePop(entt::registry& registry) override;

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -8,8 +8,9 @@ ScenarioPhase::ScenarioPhase(const Param& param)
 
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 
-IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
-                                           const FrameData& /*frameData*/) {
+IPhase::PhaseCommand ScenarioPhase::update(
+    entt::registry& registry, const FrameData& /*frameData*/
+) {
   const auto& steps =
       registry.ctx().get<ScenarioData>().sections.at(m_sectionName);
   if (m_currentStep >= steps.size()) {
@@ -19,13 +20,15 @@ IPhase::PhaseCommand ScenarioPhase::update(entt::registry& registry,
   const auto& step = steps[m_currentStep];
   ++m_currentStep;
 
-  return std::visit(Overloaded{
-                        [&](const StepPush& s) {
-                          return PhaseCommand::Push(s.maker->make());
-                        },
-                        [&](const StepReset& s) {
-                          return PhaseCommand::Reset(s.maker->make());
-                        },
-                    },
-                    step);
+  return std::visit(
+      Overloaded{
+          [&](const StepPush& s) {
+            return PhaseCommand::Push(s.maker->make());
+          },
+          [&](const StepReset& s) {
+            return PhaseCommand::Reset(s.maker->make());
+          },
+      },
+      step
+  );
 }

--- a/Ash2/src/Phase/ScenarioPhase.hpp
+++ b/Ash2/src/Phase/ScenarioPhase.hpp
@@ -18,8 +18,9 @@ class ScenarioPhase : public IPhase {
   void onAfterPush(entt::registry& registry) override;
 
   /// @brief 毎フレーム 1 ステップを処理する
-  [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    const FrameData& frameData) override;
+  [[nodiscard]] PhaseCommand update(
+      entt::registry& registry, const FrameData& frameData
+  ) override;
 
  private:
   String m_sectionName;

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -24,15 +24,17 @@ void TestMenuPhase::onAfterPush(entt::registry& /*registry*/) {
           .label = U"AnimationViewer (player)",
           .create = [](entt::registry&) -> std::unique_ptr<IPhase> {
             return std::make_unique<AnimationViewerPhase>(
-                AnimationViewerPhase::Param{.dataKey = U"player"});
+                AnimationViewerPhase::Param{.dataKey = U"player"}
+            );
           },
       },
   };
   m_selectedIndex = 0;
 }
 
-IPhase::PhaseCommand TestMenuPhase::update(entt::registry& registry,
-                                           const FrameData& /*frameData*/) {
+IPhase::PhaseCommand TestMenuPhase::update(
+    entt::registry& registry, const FrameData& /*frameData*/
+) {
   if (KeyUp.down()) {
     m_selectedIndex = (m_selectedIndex - 1 + m_items.size()) % m_items.size();
   }
@@ -52,8 +54,9 @@ IPhase::PhaseCommand TestMenuPhase::update(entt::registry& registry,
     const ColorF color =
         (i == m_selectedIndex) ? Palette::Yellow : Palette::White;
     m_font(m_items[i].label)
-        .draw(KItemX, KItemBaseY + static_cast<double>(i) * KItemSpacing,
-              color);
+        .draw(
+            KItemX, KItemBaseY + static_cast<double>(i) * KItemSpacing, color
+        );
   }
 
   return PhaseCommand::None();

--- a/Ash2/src/Phase/TestMenuPhase.hpp
+++ b/Ash2/src/Phase/TestMenuPhase.hpp
@@ -17,8 +17,9 @@ class TestMenuPhase : public IPhase {
   /// @brief メニュー項目を初期化する
   void onAfterPush(entt::registry& registry) override;
 
-  [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    const FrameData& frameData) override;
+  [[nodiscard]] PhaseCommand update(
+      entt::registry& registry, const FrameData& frameData
+  ) override;
 
  private:
   /// メニュー項目（表示名 + 生成ラムダ）

--- a/Ash2/src/Phase/WaitPhase.cpp
+++ b/Ash2/src/Phase/WaitPhase.cpp
@@ -2,8 +2,9 @@
 
 WaitPhase::WaitPhase(const Param& param) : m_duration(param.duration) {}
 
-IPhase::PhaseCommand WaitPhase::update(entt::registry&,
-                                       const FrameData& frameData) {
+IPhase::PhaseCommand WaitPhase::update(
+    entt::registry&, const FrameData& frameData
+) {
   m_elapsed += frameData.dt;
   return m_elapsed >= m_duration ? PhaseCommand::Pop() : PhaseCommand::None();
 }

--- a/Ash2/src/Phase/WaitPhase.hpp
+++ b/Ash2/src/Phase/WaitPhase.hpp
@@ -15,8 +15,9 @@ class WaitPhase : public IPhase {
 
   /// @brief 経過時間を積算し、duration を超えたら Pop を返す
   /// @return duration 経過後に Pop、それまでは None
-  [[nodiscard]] PhaseCommand update(entt::registry& registry,
-                                    const FrameData& frameData) override;
+  [[nodiscard]] PhaseCommand update(
+      entt::registry& registry, const FrameData& frameData
+  ) override;
 
  private:
   /// 待機時間（秒）

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -12,11 +12,14 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
 
   auto view = registry.view<SpriteAnimation, Drawable>(entt::exclude<Hitstop>);
   for (auto [entity, anim, drawable] : view.each()) {
-    assert(dataRegistry.contains(anim.dataKey) &&
-           "AnimationDataRegistry にキーが存在しない");
+    assert(
+        dataRegistry.contains(anim.dataKey) &&
+        "AnimationDataRegistry にキーが存在しない"
+    );
     const auto& data = dataRegistry.at(anim.dataKey);
-    assert(data.clips.contains(anim.currentClip) &&
-           "clips にクリップが存在しない");
+    assert(
+        data.clips.contains(anim.currentClip) && "clips にクリップが存在しない"
+    );
     const auto& clip = data.clips.at(anim.currentClip);
 
     anim.elapsed += dt;
@@ -27,8 +30,8 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
     anim.elapsed = Math::Fmod(anim.elapsed, cycleDuration);
     const int32 col =
         static_cast<int32>(anim.elapsed * clip.speed) % clip.count;
-    auto region = TextureAsset{data.textureKey}(
-        col * data.size.x, clip.row * data.size.y, data.size.x, data.size.y);
+    const Point cell{col, clip.row};
+    auto region = TextureAsset{data.textureKey}(cell * data.size, data.size);
 
     if (anim.facingRight) {
       region = region.mirrored();

--- a/Ash2/src/System/AttachmentSystem.cpp
+++ b/Ash2/src/System/AttachmentSystem.cpp
@@ -5,17 +5,20 @@
 #include "Component/WorldPos.hpp"
 
 namespace {
-void Propagate(entt::registry& registry, const WorldPos& parentPos,
-               entt::entity child) {
+void Propagate(
+    entt::registry& registry, const WorldPos& parentPos, entt::entity child
+) {
   while (child != entt::null) {
     const auto& node = registry.get<const Hierarchy>(child);
     if (registry.all_of<WorldPos>(child)) {
       auto& pos = registry.get<WorldPos>(child);
       if (registry.all_of<LocalOffset>(child)) {
         const auto& off = registry.get<const LocalOffset>(child).value;
-        pos = {.w = parentPos.w + off.w,
-               .h = parentPos.h + off.h,
-               .d = parentPos.d + off.d};
+        pos = {
+            .w = parentPos.w + off.w,
+            .h = parentPos.h + off.h,
+            .d = parentPos.d + off.d
+        };
       } else {
         pos = parentPos;
       }

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -20,7 +20,8 @@ void DrawSystem::Draw(const entt::registry& registry) {
     const auto* drawColor = registry.try_get<DrawColor>(entity);
     entries.push_back(
         {std::cref(pos), std::cref(drawable),
-         (drawColor != nullptr) ? drawColor->color : KDefaultDrawColor});
+         (drawColor != nullptr) ? drawColor->color : KDefaultDrawColor}
+    );
   }
 
   std::ranges::sort(entries, [](const DrawEntry& a, const DrawEntry& b) {
@@ -36,12 +37,14 @@ void DrawSystem::Draw(const entt::registry& registry) {
               const RectF rect = [&] {
                 switch (shape.anchor) {
                   case DrawAnchor::BottomCenter:
-                    return RectF{Arg::bottomCenter(screenPos), shape.size.x,
-                                 shape.size.y};
+                    return RectF{
+                        Arg::bottomCenter(screenPos), shape.size.x, shape.size.y
+                    };
                   case DrawAnchor::Center:
                   default:
-                    return RectF{Arg::center(screenPos), shape.size.x,
-                                 shape.size.y};
+                    return RectF{
+                        Arg::center(screenPos), shape.size.x, shape.size.y
+                    };
                 }
               }();
               rect.draw(color);
@@ -61,13 +64,15 @@ void DrawSystem::Draw(const entt::registry& registry) {
               circle.drawPie(shape.startAngle, shape.angle, color);
               if (shape.border) {
                 const auto& b = *shape.border;
-                circle.drawArc(shape.startAngle, shape.angle, 0.0, b.thickness,
-                               b.color);
+                circle.drawArc(
+                    shape.startAngle, shape.angle, 0.0, b.thickness, b.color
+                );
                 const Vec2 p1 =
                     screenPos + Vec2{Circular{shape.radius, shape.startAngle}};
                 const Vec2 p2 =
-                    screenPos + Vec2{Circular{shape.radius,
-                                              shape.startAngle + shape.angle}};
+                    screenPos +
+                    Vec2{Circular{shape.radius, shape.startAngle + shape.angle}
+                    };
                 Line{screenPos, p1}.draw(b.thickness, b.color);
                 Line{screenPos, p2}.draw(b.thickness, b.color);
               }
@@ -85,6 +90,7 @@ void DrawSystem::Draw(const entt::registry& registry) {
               }
             },
         },
-        entry.drawable.get());
+        entry.drawable.get()
+    );
   }
 }

--- a/Ash2/src/System/EnemyMotionSystem.cpp
+++ b/Ash2/src/System/EnemyMotionSystem.cpp
@@ -18,13 +18,17 @@ constexpr double KMaxShrinkRatio = 0.2;
 
 }  // namespace
 
-Optional<Motion> Tick(Idle& /*state*/, entt::registry& /*registry*/,
-                      entt::entity /*entity*/, const FrameData& /*frameData*/) {
+Optional<Motion> Tick(
+    Idle& /*state*/, entt::registry& /*registry*/, entt::entity /*entity*/,
+    const FrameData& /*frameData*/
+) {
   return none;
 }
 
-Optional<Motion> Tick(Stagger& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Stagger& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   const auto& cfg = registry.ctx().get<EnemyConfig>();
   state.remaining -= frameData.dt;
 
@@ -49,8 +53,10 @@ Optional<Motion> Tick(Stagger& state, entt::registry& registry,
   return none;
 }
 
-Optional<Motion> Tick(Repel& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Repel& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   state.remaining -= frameData.dt;
 
   if (state.remaining <= 0.0) {
@@ -60,8 +66,10 @@ Optional<Motion> Tick(Repel& state, entt::registry& registry,
   return none;
 }
 
-Optional<Motion> Tick(Knockback& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Knockback& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   state.remaining -= frameData.dt;
 
   // 打ち上げ直後は接地したままこの Tick に入るため、上昇中は止めない。
@@ -77,8 +85,10 @@ Optional<Motion> Tick(Knockback& state, entt::registry& registry,
   return none;
 }
 
-Optional<Motion> Tick(Defeated& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Defeated& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   const auto& cfg = registry.ctx().get<EnemyConfig>();
   state.remaining -= frameData.dt;
 

--- a/Ash2/src/System/EnemyMotionSystem.hpp
+++ b/Ash2/src/System/EnemyMotionSystem.hpp
@@ -12,39 +12,44 @@ namespace EnemyMotion {
 
 /// @brief Idle 状態の更新（無反応、何もしない）
 /// @return 常に none
-[[nodiscard]] Optional<Motion> Tick(Idle& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Idle& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Stagger 状態の更新（RectDrawable
 /// を縦縮みさせながら残り時間を減算する。満了時は EnemyConfig::size
 /// で原寸に戻し Idle へ遷移する）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Stagger& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Stagger& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Repel 状態の更新（残り時間減算。満了時は Velocity.w を 0
 /// に戻し Idle へ遷移する）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Repel& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Repel& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Knockback 状態の更新（残り時間減算・接地中は Velocity.w を 0
 /// に固定。放物線自体は MovementSystem/GravitySystem に委ねる。満了時は
 /// Idle へ遷移する）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Knockback& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Knockback& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Defeated 状態の更新（DrawColor::color.a
 /// を残り時間比でフェードアウトさせながら残り時間を減算する。満了後の破棄は
 /// EnemySystem が行う）
 /// @return 常に none
-[[nodiscard]] Optional<Motion> Tick(Defeated& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Defeated& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 }  // namespace EnemyMotion

--- a/Ash2/src/System/HitReactionSystem.cpp
+++ b/Ash2/src/System/HitReactionSystem.cpp
@@ -15,8 +15,9 @@
 #include "Component/WorldPos.hpp"
 #include "Config/EnemyConfig.hpp"
 
-void HitReactionSystem::Apply(entt::registry& registry,
-                              const Array<HitPair>& hits) {
+void HitReactionSystem::Apply(
+    entt::registry& registry, const Array<HitPair>& hits
+) {
   const auto& cfg = registry.ctx().get<EnemyConfig>();
 
   for (const auto& hit : hits) {
@@ -79,7 +80,8 @@ void HitReactionSystem::Apply(entt::registry& registry,
       registry.remove<Collider>(hit.target);
       registry.remove<Hp>(hit.target);
       registry.replace<Motion>(
-          hit.target, EnemyMotion::Defeated{.remaining = cfg.defeatedSec});
+          hit.target, EnemyMotion::Defeated{.remaining = cfg.defeatedSec}
+      );
       continue;
     }
 
@@ -88,18 +90,21 @@ void HitReactionSystem::Apply(entt::registry& registry,
         break;
       case ReactionLevel::Stagger:
         registry.replace<Motion>(
-            hit.target, EnemyMotion::Stagger{.remaining = cfg.staggerSec});
+            hit.target, EnemyMotion::Stagger{.remaining = cfg.staggerSec}
+        );
         break;
       case ReactionLevel::Repel:
         registry.get<Velocity>(hit.target).w = sign * cfg.repelSpeed;
-        registry.replace<Motion>(hit.target,
-                                 EnemyMotion::Repel{.remaining = cfg.repelSec});
+        registry.replace<Motion>(
+            hit.target, EnemyMotion::Repel{.remaining = cfg.repelSec}
+        );
         break;
       case ReactionLevel::Blow:
         registry.get<Velocity>(hit.target).w = sign * cfg.blowSpeedW;
         registry.get<Velocity>(hit.target).h = cfg.blowSpeedH;
         registry.replace<Motion>(
-            hit.target, EnemyMotion::Knockback{.remaining = cfg.knockbackSec});
+            hit.target, EnemyMotion::Knockback{.remaining = cfg.knockbackSec}
+        );
         break;
     }
   }

--- a/Ash2/src/System/HitSystem.cpp
+++ b/Ash2/src/System/HitSystem.cpp
@@ -91,8 +91,10 @@ Array<HitPair> HitSystem::Update(entt::registry& registry) {
       const Vec3 tp2 = worldT + tCol.segmentEnd;
 
       const double sumR = aCol.radius + tCol.radius;
-      if (SegmentDistSq(Segment{.start = ap1, .end = ap2},
-                        Segment{.start = tp1, .end = tp2}) >= sumR * sumR)
+      if (SegmentDistSq(
+              Segment{.start = ap1, .end = ap2},
+              Segment{.start = tp1, .end = tp2}
+          ) >= sumR * sumR)
         continue;
 
       rootAtk.hitTargets.emplace(target);

--- a/Ash2/src/System/HudSystem.hpp
+++ b/Ash2/src/System/HudSystem.hpp
@@ -36,7 +36,8 @@ class HudSystem {
         const double staminaRatio =
             Clamp(static_cast<double>(stamina.current) / stamina.max, 0.0, 1.0);
         RectF{KBarX, KStaminaBarY, KBarWidth * staminaRatio, KBarHeight}.draw(
-            KStaminaColor);
+            KStaminaColor
+        );
       }
 
       // Player タグを持つエンティティは 1

--- a/Ash2/src/System/MotionSystem.cpp
+++ b/Ash2/src/System/MotionSystem.cpp
@@ -7,8 +7,9 @@
 #include "System/EnemyMotionSystem.hpp"
 #include "System/PlayerMotionSystem.hpp"
 
-void MotionSystem::Update(entt::registry& registry,
-                          const FrameData& frameData) {
+void MotionSystem::Update(
+    entt::registry& registry, const FrameData& frameData
+) {
   // ヒットストップ中も Tick は呼ぶ（dt = 0 で時間だけ凍結する）。
   // 除外すると停止中の入力が Tick に届かず、コンボ予約を取りこぼす
   FrameData frozen = frameData;
@@ -22,7 +23,8 @@ void MotionSystem::Update(entt::registry& registry,
         [&](MotionState auto& state) {
           return Tick(state, registry, entity, fd);
         },
-        motion);
+        motion
+    );
     if (next.has_value()) {
       registry.replace<Motion>(entity, *next);
     }

--- a/Ash2/src/System/PlayerMotion/AirAttack.cpp
+++ b/Ash2/src/System/PlayerMotion/AirAttack.cpp
@@ -20,8 +20,9 @@ namespace {
 // progress / orbitRadius は隣接する double 引数として渡すと取り違えやすいため
 // （bugprone-easily-swappable-parameters 対策）、orbitRadius は
 // AirAttackConfig への const 参照経由で受け取る。
-Vec3 AirAttackOrbOffset(double progress, const AirAttackConfig& aa,
-                        double capMidH, bool facingRight) {
+Vec3 AirAttackOrbOffset(
+    double progress, const AirAttackConfig& aa, double capMidH, bool facingRight
+) {
   const double angle = Math::TwoPi * progress;
   const double w = facingRight ? aa.orbitRadius * Math::Cos(angle)
                                : -aa.orbitRadius * Math::Cos(angle);
@@ -35,8 +36,10 @@ AirAttack MakeAirAttack(SpriteAnimation& anim) {
   return AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null};
 }
 
-Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    AirAttack& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -49,8 +52,9 @@ Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
   // 接地検出は後隙中も含め毎フレーム優先して評価する（タイマー満了判定より先）
   if (pos.isOnGround()) {
     if (state.hitboxEntity != entt::null) {
-      state.hitboxEntity = ReleaseAttackHitbox(registry, state.hitboxEntity,
-                                               cfg.attackEffect.fadeSec);
+      state.hitboxEntity = ReleaseAttackHitbox(
+          registry, state.hitboxEntity, cfg.attackEffect.fadeSec
+      );
     }
     return Landing{.timer = cfg.landing.recoverySec};
   }
@@ -60,13 +64,17 @@ Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
   const auto offsetFn = [&aa, &cfg, facingRight](double progress) {
     return AirAttackOrbOffset(progress, aa, cfg.melee.capMidH, facingRight);
   };
-  UpdateAttackHitbox(registry, entity, state.elapsed, timeline,
-                     HitboxSpec{.radius = aa.radius,
-                                .damage = aa.damage,
-                                .reaction = ReactionLevel::Repel,
-                                .hitstopSec = aa.hitstopSec,
-                                .fadeSec = cfg.attackEffect.fadeSec},
-                     state.hitboxEntity, offsetFn);
+  UpdateAttackHitbox(
+      registry, entity, state.elapsed, timeline,
+      HitboxSpec{
+          .radius = aa.radius,
+          .damage = aa.damage,
+          .reaction = ReactionLevel::Repel,
+          .hitstopSec = aa.hitstopSec,
+          .fadeSec = cfg.attackEffect.fadeSec
+      },
+      state.hitboxEntity, offsetFn
+  );
 
   // 接地せずに終わった場合はタイマー満了で Neutral へ戻る
   if (timeline.isFinished(state.elapsed)) {

--- a/Ash2/src/System/PlayerMotion/Dash.cpp
+++ b/Ash2/src/System/PlayerMotion/Dash.cpp
@@ -11,16 +11,20 @@
 
 namespace PlayerMotion {
 
-Dash MakeDash(entt::registry& registry, entt::entity entity,
-              const PlayerConfig& cfg, SpriteAnimation& anim, bool air) {
+Dash MakeDash(
+    entt::registry& registry, entt::entity entity, const PlayerConfig& cfg,
+    SpriteAnimation& anim, bool air
+) {
   auto& stamina = registry.get<Stamina>(entity);
   stamina.current = Max(0, stamina.current - cfg.dash.staminaCost);
   SetClip(anim, U"dash");
   return Dash{.air = air};
 }
 
-Optional<Motion> Tick(Dash& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Dash& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& dash = cfg.dash;
   const auto& timeline = dash.timeline;

--- a/Ash2/src/System/PlayerMotion/DashAttack.cpp
+++ b/Ash2/src/System/PlayerMotion/DashAttack.cpp
@@ -20,25 +20,29 @@ namespace {
 // progress / orbitRadius は隣接する double 引数として渡すと取り違えやすいため
 // （bugprone-easily-swappable-parameters 対策）、orbitRadius は
 // DashAttackConfig への const 参照経由で受け取る。
-Vec3 DashAttackOrbOffset(double progress, const DashAttackConfig& da,
-                         double capMidH) {
+Vec3 DashAttackOrbOffset(
+    double progress, const DashAttackConfig& da, double capMidH
+) {
   const double angle = Math::TwoPi * progress;
-  return Vec3{da.orbitRadius * Math::Cos(angle), capMidH,
-              da.orbitRadius * Math::Sin(angle)};
+  return Vec3{
+      da.orbitRadius * Math::Cos(angle), capMidH,
+      da.orbitRadius * Math::Sin(angle)
+  };
 }
 
 }  // namespace
 
 DashAttack MakeDashAttack(SpriteAnimation& anim, bool air, Vec2 dashDir) {
   SetClip(anim, U"dash_attack");
-  return DashAttack{.elapsed = 0.0,
-                    .air = air,
-                    .hitboxEntity = entt::null,
-                    .dashDir = dashDir};
+  return DashAttack{
+      .elapsed = 0.0, .air = air, .hitboxEntity = entt::null, .dashDir = dashDir
+  };
 }
 
-Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    DashAttack& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -54,8 +58,9 @@ Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
   // 空中発動時のみ。地上 DashAttack は接地遷移を持たない）
   if (state.air && pos.isOnGround()) {
     if (state.hitboxEntity != entt::null) {
-      state.hitboxEntity = ReleaseAttackHitbox(registry, state.hitboxEntity,
-                                               cfg.attackEffect.fadeSec);
+      state.hitboxEntity = ReleaseAttackHitbox(
+          registry, state.hitboxEntity, cfg.attackEffect.fadeSec
+      );
     }
     return Landing{.timer = cfg.landing.recoverySec};
   }
@@ -65,13 +70,17 @@ Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
   const auto offsetFn = [&da, capMidH](double progress) {
     return DashAttackOrbOffset(progress, da, capMidH);
   };
-  UpdateAttackHitbox(registry, entity, state.elapsed, timeline,
-                     HitboxSpec{.radius = da.radius,
-                                .damage = da.damage,
-                                .reaction = ReactionLevel::Repel,
-                                .hitstopSec = da.hitstopSec,
-                                .fadeSec = cfg.attackEffect.fadeSec},
-                     state.hitboxEntity, offsetFn);
+  UpdateAttackHitbox(
+      registry, entity, state.elapsed, timeline,
+      HitboxSpec{
+          .radius = da.radius,
+          .damage = da.damage,
+          .reaction = ReactionLevel::Repel,
+          .hitstopSec = da.hitstopSec,
+          .fadeSec = cfg.attackEffect.fadeSec
+      },
+      state.hitboxEntity, offsetFn
+  );
 
   // 突進フェーズ（構え）：ダッシュ方向へ移動
   // 空中発動時は AirDash の暫定仕様に合わせ垂直速度を 0 に固定する

--- a/Ash2/src/System/PlayerMotion/Helper.cpp
+++ b/Ash2/src/System/PlayerMotion/Helper.cpp
@@ -25,18 +25,30 @@ constexpr ColorF KMeleeOrbColor = {1.0, 0.9, 0.5};
 /// 珠は体の近くに静止した位置に置く。Collider は珠エンティティ自身の原点からの
 /// オフセット 0 で固定し、珠の現在位置は UpdateAttackHitbox が更新する
 /// LocalOffset のみが担う。
-entt::entity SpawnAttackHitbox(entt::registry& registry, entt::entity owner,
-                               const WorldPos& pos, const HitboxSpec& spec) {
+entt::entity SpawnAttackHitbox(
+    entt::registry& registry, entt::entity owner, const WorldPos& pos,
+    const HitboxSpec& spec
+) {
   const auto hitbox = registry.create();
   registry.emplace<WorldPos>(hitbox, pos);
   registry.emplace<LocalOffset>(hitbox, LocalOffset{});
   Hierarchy::Attach(registry, owner, hitbox);
-  registry.emplace<Collider>(hitbox, Collider{.segmentStart = Vec3::Zero(),
-                                              .segmentEnd = Vec3::Zero(),
-                                              .radius = spec.radius});
-  registry.emplace<Attack>(hitbox, Attack{.damage = spec.damage,
-                                          .hitstopSec = spec.hitstopSec,
-                                          .reaction = spec.reaction});
+  registry.emplace<Collider>(
+      hitbox,
+      Collider{
+          .segmentStart = Vec3::Zero(),
+          .segmentEnd = Vec3::Zero(),
+          .radius = spec.radius
+      }
+  );
+  registry.emplace<Attack>(
+      hitbox,
+      Attack{
+          .damage = spec.damage,
+          .hitstopSec = spec.hitstopSec,
+          .reaction = spec.reaction
+      }
+  );
   registry.emplace<Drawable>(hitbox, CircleDrawable{.radius = spec.radius});
   registry.emplace<DrawColor>(hitbox, DrawColor{.color = KMeleeOrbColor});
   return hitbox;
@@ -57,23 +69,26 @@ void StopHorizontalMovement(entt::registry& registry, entt::entity entity) {
   vel.d = 0.0;
 }
 
-entt::entity ReleaseAttackHitbox(entt::registry& registry,
-                                 entt::entity hitboxEntity, double fadeSec) {
+entt::entity ReleaseAttackHitbox(
+    entt::registry& registry, entt::entity hitboxEntity, double fadeSec
+) {
   Hierarchy::Detach(registry, hitboxEntity);
   registry.remove<Attack>(hitboxEntity);
   if (fadeSec <= 0.0) {
     registry.destroy(hitboxEntity);
   } else {
     registry.emplace_or_replace<FadeOut>(
-        hitboxEntity, FadeOut{.duration = fadeSec, .remaining = fadeSec});
+        hitboxEntity, FadeOut{.duration = fadeSec, .remaining = fadeSec}
+    );
   }
   return entt::null;
 }
 
-void UpdateAttackHitbox(entt::registry& registry, entt::entity owner,
-                        double elapsed, const MotionTimeline& timeline,
-                        const HitboxSpec& spec, entt::entity& hitboxEntity,
-                        const std::function<Vec3(double)>& offsetFn) {
+void UpdateAttackHitbox(
+    entt::registry& registry, entt::entity owner, double elapsed,
+    const MotionTimeline& timeline, const HitboxSpec& spec,
+    entt::entity& hitboxEntity, const std::function<Vec3(double)>& offsetFn
+) {
   // 攻撃フレーム中（未生成ならここで生成する）：珠を前方へ EaseOut
   // 補間で移動させる
   if (timeline.isActive(elapsed)) {

--- a/Ash2/src/System/PlayerMotion/Helper.hpp
+++ b/Ash2/src/System/PlayerMotion/Helper.hpp
@@ -39,17 +39,19 @@ void StopHorizontalMovement(entt::registry& registry, entt::entity entity);
 /// したうえで `FadeOut` を付与する。`fadeSec` が 0 以下の場合はフェードを
 /// 挟まず即座に破棄する。
 /// @return entt::null（呼び出し側の hitboxEntity 変数への代入に使う）
-entt::entity ReleaseAttackHitbox(entt::registry& registry,
-                                 entt::entity hitboxEntity, double fadeSec);
+entt::entity ReleaseAttackHitbox(
+    entt::registry& registry, entt::entity hitboxEntity, double fadeSec
+);
 
 /// @brief 攻撃判定の発生区間に応じてヒットボックスを生成・更新・破棄する
 /// @param timeline 攻撃のタイムライン（active 区間の判定に使用）
 /// @param spec
 /// 生成時に確定させる半径・ダメージ・リアクション・ヒットストップ時間
 /// @param offsetFn 攻撃フレーム内の進行度から珠のオフセットを算出する関数
-void UpdateAttackHitbox(entt::registry& registry, entt::entity owner,
-                        double elapsed, const MotionTimeline& timeline,
-                        const HitboxSpec& spec, entt::entity& hitboxEntity,
-                        const std::function<Vec3(double)>& offsetFn);
+void UpdateAttackHitbox(
+    entt::registry& registry, entt::entity owner, double elapsed,
+    const MotionTimeline& timeline, const HitboxSpec& spec,
+    entt::entity& hitboxEntity, const std::function<Vec3(double)>& offsetFn
+);
 
 }  // namespace PlayerMotion

--- a/Ash2/src/System/PlayerMotion/Landing.cpp
+++ b/Ash2/src/System/PlayerMotion/Landing.cpp
@@ -6,8 +6,10 @@
 
 namespace PlayerMotion {
 
-Optional<Motion> Tick(Landing& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Landing& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   StopHorizontalMovement(registry, entity);
 
   auto& anim = registry.get<SpriteAnimation>(entity);

--- a/Ash2/src/System/PlayerMotion/Melee.cpp
+++ b/Ash2/src/System/PlayerMotion/Melee.cpp
@@ -15,8 +15,9 @@ namespace {
 
 /// @brief 突き出し軌道（近接1・3段目）の珠オフセット（プレイヤー相対）を返す
 /// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
-Vec3 MeleeThrustOffset(double progress, bool facingRight, double reach,
-                       double capMidH) {
+Vec3 MeleeThrustOffset(
+    double progress, bool facingRight, double reach, double capMidH
+) {
   const double sign = facingRight ? 1.0 : -1.0;
   const double eased = EaseOutQuad(Clamp(progress, 0.0, 1.0));
   return Vec3{sign * reach * eased, capMidH, 0.0};
@@ -27,8 +28,10 @@ Vec3 MeleeThrustOffset(double progress, bool facingRight, double reach,
 // reach / capMidH は隣接する double 引数として渡すと取り違えやすいため
 // （bugprone-easily-swappable-parameters 対策）、両者を保持する MeleeConfig
 // への const 参照で受け取る。
-Vec3 MeleeSlashOffset(double progress, bool facingRight,
-                      const MeleeConfig& melee, double slashRiseHeight) {
+Vec3 MeleeSlashOffset(
+    double progress, bool facingRight, const MeleeConfig& melee,
+    double slashRiseHeight
+) {
   const double sign = facingRight ? 1.0 : -1.0;
   const double eased = EaseOutQuad(Clamp(progress, 0.0, 1.0));
   const double horizontal = sign * melee.reach * eased;
@@ -37,20 +40,22 @@ Vec3 MeleeSlashOffset(double progress, bool facingRight,
 }
 
 /// @brief 段の軌道設定から、進行度→珠オフセットのラムダを作る
-std::function<Vec3(double)> MakeMeleeOffsetFn(const MeleeStageConfig& stage,
-                                              bool facingRight,
-                                              const MeleeConfig& melee) {
+std::function<Vec3(double)> MakeMeleeOffsetFn(
+    const MeleeStageConfig& stage, bool facingRight, const MeleeConfig& melee
+) {
   switch (stage.trajectory) {
     case MeleeTrajectory::Slash:
       return [=, &melee](double progress) {
-        return MeleeSlashOffset(progress, facingRight, melee,
-                                stage.slashRiseHeight);
+        return MeleeSlashOffset(
+            progress, facingRight, melee, stage.slashRiseHeight
+        );
       };
     case MeleeTrajectory::Thrust:
     default:
       return [=, &melee](double progress) {
-        return MeleeThrustOffset(progress, facingRight, melee.reach,
-                                 melee.capMidH);
+        return MeleeThrustOffset(
+            progress, facingRight, melee.reach, melee.capMidH
+        );
       };
   }
 }
@@ -63,8 +68,9 @@ void RestartClip(SpriteAnimation& anim, const String& clip) {
 
 }  // namespace
 
-Melee MakeMelee(SpriteAnimation& anim, size_t stage,
-                entt::entity hitboxEntity) {
+Melee MakeMelee(
+    SpriteAnimation& anim, size_t stage, entt::entity hitboxEntity
+) {
   // 段ごとに専用クリップ（melee_1/melee_2/melee_3）へ切り替わるため、
   // 呼び出し元（初回入場・コンボ継続いずれも）で必ずクリップ名が変わり、
   // RestartClip と SetClip の挙動差は生じない。
@@ -72,14 +78,18 @@ Melee MakeMelee(SpriteAnimation& anim, size_t stage,
   return Melee{.stage = stage, .elapsed = 0.0, .hitboxEntity = hitboxEntity};
 }
 
-Optional<Motion> Tick(Melee& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Melee& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   StopHorizontalMovement(registry, entity);
 
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& melee = cfg.melee;
-  assert(state.stage < melee.stages.size() &&
-         "state.stage は melee.stages の範囲内でなければならない");
+  assert(
+      state.stage < melee.stages.size() &&
+      "state.stage は melee.stages の範囲内でなければならない"
+  );
   const auto& stageCfg = melee.stages[state.stage];
   const auto& timeline = stageCfg.timeline;
   const auto& input = frameData.input;
@@ -93,13 +103,17 @@ Optional<Motion> Tick(Melee& state, entt::registry& registry,
       hasNextStage ? ReactionLevel::Stagger : ReactionLevel::Blow;
 
   const auto offsetFn = MakeMeleeOffsetFn(stageCfg, anim.facingRight, melee);
-  UpdateAttackHitbox(registry, entity, state.elapsed, timeline,
-                     HitboxSpec{.radius = stageCfg.radius,
-                                .damage = melee.damage,
-                                .reaction = reaction,
-                                .hitstopSec = stageCfg.hitstopSec,
-                                .fadeSec = cfg.attackEffect.fadeSec},
-                     state.hitboxEntity, offsetFn);
+  UpdateAttackHitbox(
+      registry, entity, state.elapsed, timeline,
+      HitboxSpec{
+          .radius = stageCfg.radius,
+          .damage = melee.damage,
+          .reaction = reaction,
+          .hitstopSec = stageCfg.hitstopSec,
+          .fadeSec = cfg.attackEffect.fadeSec
+      },
+      state.hitboxEntity, offsetFn
+  );
 
   if (hasNextStage) {
     // 構え〜後隙A中の攻撃入力は次段への遷移を予約するのみ

--- a/Ash2/src/System/PlayerMotion/Neutral.cpp
+++ b/Ash2/src/System/PlayerMotion/Neutral.cpp
@@ -9,8 +9,10 @@
 
 namespace PlayerMotion {
 
-Optional<Motion> Tick(Neutral& /*state*/, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Neutral& /*state*/, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   const auto& input = frameData.input;
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& pos = registry.get<WorldPos>(entity);

--- a/Ash2/src/System/PlayerMotion/Ranged.cpp
+++ b/Ash2/src/System/PlayerMotion/Ranged.cpp
@@ -31,45 +31,61 @@ double GetClipDuration(const AnimationData& data, const String& clip) {
 
 }  // namespace
 
-void SpawnProjectile(entt::registry& registry, const WorldPos& pos,
-                     bool facingRight, const PlayerConfig& cfg) {
+void SpawnProjectile(
+    entt::registry& registry, const WorldPos& pos, bool facingRight,
+    const PlayerConfig& cfg
+) {
   const double sign = facingRight ? 1.0 : -1.0;
   const auto bullet = registry.create();
   registry.emplace<WorldPos>(
       bullet,
-      WorldPos{.w = pos.w, .h = pos.h + cfg.ranged.spawnHeight, .d = pos.d});
-  registry.emplace<Velocity>(bullet,
-                             Velocity{.w = sign * cfg.ranged.bulletSpeed});
-  registry.emplace<Collider>(bullet, Collider{
-                                         .segmentStart = Vec3{0.0, 0.0, 0.0},
-                                         .segmentEnd = Vec3{0.0, 0.0, 0.0},
-                                         .radius = cfg.ranged.radius,
-                                     });
+      WorldPos{.w = pos.w, .h = pos.h + cfg.ranged.spawnHeight, .d = pos.d}
+  );
+  registry.emplace<Velocity>(
+      bullet, Velocity{.w = sign * cfg.ranged.bulletSpeed}
+  );
+  registry.emplace<Collider>(
+      bullet,
+      Collider{
+          .segmentStart = Vec3{0.0, 0.0, 0.0},
+          .segmentEnd = Vec3{0.0, 0.0, 0.0},
+          .radius = cfg.ranged.radius,
+      }
+  );
   registry.emplace<Attack>(bullet, Attack{.damage = cfg.ranged.damage});
-  registry.emplace<Drawable>(bullet,
-                             CircleDrawable{.radius = cfg.ranged.radius});
+  registry.emplace<Drawable>(
+      bullet, CircleDrawable{.radius = cfg.ranged.radius}
+  );
   registry.emplace<DrawColor>(bullet, DrawColor{.color = KBulletColor});
   registry.emplace<Projectile>(bullet);
 }
 
-Ranged MakeRanged(entt::registry& registry, entt::entity entity,
-                  const PlayerConfig& cfg, SpriteAnimation& anim) {
+Ranged MakeRanged(
+    entt::registry& registry, entt::entity entity, const PlayerConfig& cfg,
+    SpriteAnimation& anim
+) {
   auto& stamina = registry.get<Stamina>(entity);
   stamina.current = Max(0, stamina.current - cfg.ranged.staminaCost);
 
   const auto& dataRegistry = registry.ctx().get<AnimationDataRegistry>();
-  assert(dataRegistry.contains(anim.dataKey) &&
-         "AnimationDataRegistry にキーが存在しない");
+  assert(
+      dataRegistry.contains(anim.dataKey) &&
+      "AnimationDataRegistry にキーが存在しない"
+  );
   const auto& data = dataRegistry.at(anim.dataKey);
-  assert(data.clips.contains(U"ranged_attack") &&
-         "clips に ranged_attack が存在しない");
+  assert(
+      data.clips.contains(U"ranged_attack") &&
+      "clips に ranged_attack が存在しない"
+  );
 
   SetClip(anim, U"ranged_attack");
   return Ranged{.timer = GetClipDuration(data, U"ranged_attack")};
 }
 
-Optional<Motion> Tick(Ranged& state, entt::registry& registry,
-                      entt::entity entity, const FrameData& frameData) {
+Optional<Motion> Tick(
+    Ranged& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
   StopHorizontalMovement(registry, entity);
 
   state.timer -= frameData.dt;

--- a/Ash2/src/System/PlayerMotion/Transition.hpp
+++ b/Ash2/src/System/PlayerMotion/Transition.hpp
@@ -13,18 +13,23 @@ namespace PlayerMotion {
 /// @brief 指定段の Melee へ移行する（攻撃クリップを先頭から再生）
 /// @param stage 移行先のコンボ段インデックス
 /// @param hitboxEntity 引き継ぐ攻撃判定エンティティ（通常は entt::null）
-Melee MakeMelee(SpriteAnimation& anim, size_t stage,
-                entt::entity hitboxEntity = entt::null);
+Melee MakeMelee(
+    SpriteAnimation& anim, size_t stage, entt::entity hitboxEntity = entt::null
+);
 
 /// @brief Ranged へ移行する（スタミナ消費、遠距離攻撃クリップの設定と timer
 /// の算出）
-Ranged MakeRanged(entt::registry& registry, entt::entity entity,
-                  const PlayerConfig& cfg, SpriteAnimation& anim);
+Ranged MakeRanged(
+    entt::registry& registry, entt::entity entity, const PlayerConfig& cfg,
+    SpriteAnimation& anim
+);
 
 /// @brief Dash へ移行する（スタミナ消費、クリップの設定）
 /// @param air 空中発動か（true: 空中ダッシュ相当）
-Dash MakeDash(entt::registry& registry, entt::entity entity,
-              const PlayerConfig& cfg, SpriteAnimation& anim, bool air);
+Dash MakeDash(
+    entt::registry& registry, entt::entity entity, const PlayerConfig& cfg,
+    SpriteAnimation& anim, bool air
+);
 
 /// @brief DashAttack へ移行する
 /// @param air 空中発動か（true: 空中ダッシュ攻撃相当）
@@ -35,7 +40,9 @@ DashAttack MakeDashAttack(SpriteAnimation& anim, bool air, Vec2 dashDir);
 AirAttack MakeAirAttack(SpriteAnimation& anim);
 
 /// @brief 遠距離攻撃の弾エンティティを生成する
-void SpawnProjectile(entt::registry& registry, const WorldPos& pos,
-                     bool facingRight, const PlayerConfig& cfg);
+void SpawnProjectile(
+    entt::registry& registry, const WorldPos& pos, bool facingRight,
+    const PlayerConfig& cfg
+);
 
 }  // namespace PlayerMotion

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -11,50 +11,57 @@ namespace PlayerMotion {
 /// @brief Neutral 状態の更新（移動・ジャンプ・向き・クリップ決定、Melee/Ranged/
 /// Dash への入場判定）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Neutral& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Neutral& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Melee 状態の更新（横移動停止・タイマー減算・ヒットボックス管理・
 /// コンボ予約判定。段の設定は cfg.melee.stages[state.stage] を参照する）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Melee& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Melee& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Ranged 状態の更新（横移動停止・タイマー減算）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Ranged& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Ranged& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Dash 状態の更新（移動・タイマー減算・無敵の付与/除去・
 /// 後隙Aからのダッシュ攻撃/再ダッシュキャンセル予約・後隙B開始時の遷移。
 /// state.air が true の場合は空中発動として接地で Landing へ強制遷移する）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Dash& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Dash& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief DashAttack 状態の更新（突進・軌道上のヒットボックス管理・後隙満了で
 /// Neutral へ戻る。state.air が true の場合は空中発動として接地で Landing
 /// へ強制遷移する）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(DashAttack& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    DashAttack& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief AirAttack 状態の更新（垂直面の軌道上のヒットボックス管理・
 /// 接地で Landing へ遷移・後隙満了で Neutral へ戻る）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(AirAttack& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    AirAttack& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 /// @brief Landing 状態の更新（横移動停止・タイマー減算・満了で Neutral へ戻る）
 /// @return 遷移先がある場合はその Motion、なければ none
-[[nodiscard]] Optional<Motion> Tick(Landing& state, entt::registry& registry,
-                                    entt::entity entity,
-                                    const FrameData& frameData);
+[[nodiscard]] Optional<Motion> Tick(
+    Landing& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
 
 }  // namespace PlayerMotion

--- a/Ash2/tests/TestAttachmentSystem.cpp
+++ b/Ash2/tests/TestAttachmentSystem.cpp
@@ -15,8 +15,9 @@ TEST_CASE("AttachmentSystem - child follows parent with offset") {
 
   auto child = registry.create();
   registry.emplace<WorldPos>(child);
-  Hierarchy::Attach(registry, parent, child,
-                    WorldPos{.w = 1.0, .h = 0.5, .d = 2.0});
+  Hierarchy::Attach(
+      registry, parent, child, WorldPos{.w = 1.0, .h = 0.5, .d = 2.0}
+  );
 
   AttachmentSystem::UpdateTransform(registry);
 
@@ -118,10 +119,13 @@ TEST_CASE("AttachmentSystem - Detach removes child from linked list") {
 
   Hierarchy::Detach(registry, child);
 
-  REQUIRE(registry.get<const Hierarchy>(parent).firstChild() ==
-          entt::entity{entt::null});
-  REQUIRE(registry.get<const Hierarchy>(child).parent() ==
-          entt::entity{entt::null});
+  REQUIRE(
+      registry.get<const Hierarchy>(parent).firstChild() ==
+      entt::entity{entt::null}
+  );
+  REQUIRE(
+      registry.get<const Hierarchy>(child).parent() == entt::entity{entt::null}
+  );
   REQUIRE_FALSE(registry.all_of<LocalOffset>(child));
 }
 
@@ -138,18 +142,24 @@ TEST_CASE("AttachmentSystem - re-attaching child to different parent") {
   Hierarchy::Attach(registry, parent1, child);
   Hierarchy::Attach(registry, parent2, child);
 
-  REQUIRE(registry.get<const Hierarchy>(parent1).firstChild() ==
-          entt::entity{entt::null});
+  REQUIRE(
+      registry.get<const Hierarchy>(parent1).firstChild() ==
+      entt::entity{entt::null}
+  );
   REQUIRE(registry.get<const Hierarchy>(parent2).firstChild() == child);
   REQUIRE(registry.get<const Hierarchy>(child).parent() == parent2);
-  REQUIRE(registry.get<const Hierarchy>(child).prevSibling() ==
-          entt::entity{entt::null});
-  REQUIRE(registry.get<const Hierarchy>(child).nextSibling() ==
-          entt::entity{entt::null});
+  REQUIRE(
+      registry.get<const Hierarchy>(child).prevSibling() ==
+      entt::entity{entt::null}
+  );
+  REQUIRE(
+      registry.get<const Hierarchy>(child).nextSibling() ==
+      entt::entity{entt::null}
+  );
 }
 
-TEST_CASE(
-    "Hierarchy - DestroyWithChildren on already-destroyed entity is safe") {
+TEST_CASE("Hierarchy - DestroyWithChildren on already-destroyed entity is safe"
+) {
   entt::registry registry;
   auto parent = registry.create();
   auto child = registry.create();

--- a/Ash2/tests/TestEnemyMotionSystem.cpp
+++ b/Ash2/tests/TestEnemyMotionSystem.cpp
@@ -59,13 +59,15 @@ TEST_CASE("EnemyMotionSystem - Stagger shrinks RectDrawable vertically") {
 
   const auto& rect = std::get<RectDrawable>(registry.get<Drawable>(enemy));
   REQUIRE(rect.size.y < 80.0);
-  REQUIRE(std::holds_alternative<EnemyMotion::Stagger>(
-      registry.get<Motion>(enemy)));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Stagger>(registry.get<Motion>(enemy))
+  );
 }
 
 TEST_CASE(
     "EnemyMotionSystem - Stagger restores original size and transitions to "
-    "Idle on expiry") {
+    "Idle on expiry"
+) {
   // 満了時（remaining <= 0）は EnemyConfig::size を代入して原寸に戻し、
   // Idle へ遷移する
   entt::registry registry;
@@ -80,13 +82,14 @@ TEST_CASE(
   const auto& rect = std::get<RectDrawable>(registry.get<Drawable>(enemy));
   REQUIRE(rect.size.x == Approx(60.0));
   REQUIRE(rect.size.y == Approx(80.0));
-  REQUIRE(
-      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy)));
+  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
+  );
 }
 
 TEST_CASE(
     "EnemyMotionSystem - Repel zeroes velocity and transitions to Idle on "
-    "expiry") {
+    "expiry"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto enemy = MakeEnemy(registry, EnemyMotion::Repel{.remaining = 0.01});
@@ -96,8 +99,8 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(0.0));
-  REQUIRE(
-      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy)));
+  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
+  );
 }
 
 TEST_CASE("EnemyMotionSystem - Repel keeps velocity while remaining") {
@@ -110,13 +113,14 @@ TEST_CASE("EnemyMotionSystem - Repel keeps velocity while remaining") {
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(-250.0));
-  REQUIRE(
-      std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(enemy)));
+  REQUIRE(std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(enemy)
+  ));
 }
 
 TEST_CASE(
     "EnemyMotionSystem - Knockback keeps horizontal velocity on the launch "
-    "frame") {
+    "frame"
+) {
   // 打ち上げ直後は接地したまま Tick に入るので、上昇中は止めてはならない
   entt::registry registry;
   SetupContext(registry);
@@ -132,8 +136,8 @@ TEST_CASE(
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(300.0));
 }
 
-TEST_CASE(
-    "EnemyMotionSystem - Knockback zeroes horizontal velocity on landing") {
+TEST_CASE("EnemyMotionSystem - Knockback zeroes horizontal velocity on landing"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto enemy =
@@ -147,12 +151,14 @@ TEST_CASE(
 
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(0.0));
   REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(enemy)));
+      registry.get<Motion>(enemy)
+  ));
 }
 
 TEST_CASE(
     "EnemyMotionSystem - Knockback keeps horizontal velocity while "
-    "airborne") {
+    "airborne"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto enemy =
@@ -175,8 +181,8 @@ TEST_CASE("EnemyMotionSystem - Knockback transitions to Idle on expiry") {
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
 
-  REQUIRE(
-      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy)));
+  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
+  );
 }
 
 TEST_CASE("EnemyMotionSystem - Defeated fades DrawColor::color.a") {
@@ -196,7 +202,8 @@ TEST_CASE("EnemyMotionSystem - Defeated fades DrawColor::color.a") {
 
 TEST_CASE(
     "EnemyMotionSystem - Defeated emplaces DrawColor even without "
-    "Drawable") {
+    "Drawable"
+) {
   // Drawable を持たない敵でも DrawColor が付与される
   entt::registry registry;
   SetupContext(registry);
@@ -221,8 +228,8 @@ TEST_CASE("EnemySystem - destroys entity when Defeated has expired") {
   REQUIRE_FALSE(registry.valid(enemy));
 }
 
-TEST_CASE(
-    "EnemySystem - keeps entity while Defeated still has remaining time") {
+TEST_CASE("EnemySystem - keeps entity while Defeated still has remaining time"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto enemy =
@@ -255,17 +262,20 @@ TEST_CASE("EnemyMotionSystem - Hitstop freezes Stagger remaining and size") {
   const FrameData frameData{.dt = 0.075};
   MotionSystem::Update(registry, frameData);
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Stagger>(
-      registry.get<Motion>(enemy)));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Stagger>(registry.get<Motion>(enemy))
+  );
   REQUIRE(
       std::get<EnemyMotion::Stagger>(registry.get<Motion>(enemy)).remaining ==
-      Approx(0.15));
+      Approx(0.15)
+  );
   const auto& rect = std::get<RectDrawable>(registry.get<Drawable>(enemy));
   REQUIRE(rect.size.y == Approx(80.0));
 }
 
 TEST_CASE(
-    "EnemyMotionSystem - Hitstop keeps Knockback vel.w on the launch frame") {
+    "EnemyMotionSystem - Hitstop keeps Knockback vel.w on the launch frame"
+) {
   // blowSpeedH（テスト設定値 300.0）が正である限り、着地判定と組み合わさる
   // vel.h <= 0 ガードには入らないため vel.w は消えない。blowSpeedH
   // を 0 にする将来の調整で、このテストが失敗して気付けるようにする
@@ -286,7 +296,8 @@ TEST_CASE(
 
 TEST_CASE(
     "EnemyMotionSystem - Hitstop prevents Defeated from being destroyed by "
-    "EnemySystem") {
+    "EnemySystem"
+) {
   // dt = 0 で remaining が凍結されるため、停止中は EnemySystem
   // に破棄されない
   entt::registry registry;

--- a/Ash2/tests/TestFadeOutSystem.cpp
+++ b/Ash2/tests/TestFadeOutSystem.cpp
@@ -56,8 +56,9 @@ TEST_CASE("FadeOutSystem - preserves existing RGB while updating alpha") {
   // は白へ戻らない
   entt::registry registry;
   const auto entity = registry.create();
-  registry.emplace<DrawColor>(entity,
-                              DrawColor{.color = ColorF{0.2, 0.5, 0.9}});
+  registry.emplace<DrawColor>(
+      entity, DrawColor{.color = ColorF{0.2, 0.5, 0.9}}
+  );
   registry.emplace<FadeOut>(entity, FadeOut{.duration = 1.0, .remaining = 1.0});
 
   FadeOutSystem::Update(registry, 0.5);

--- a/Ash2/tests/TestHitReactionSystem.cpp
+++ b/Ash2/tests/TestHitReactionSystem.cpp
@@ -41,8 +41,10 @@ void SetupContext(entt::registry& registry) {
 
 /// @brief 攻撃側本体（親）とヒットボックス（子、Attack 保持）を生成し、
 /// ヒットボックスエンティティを返す
-entt::entity MakeAttacker(entt::registry& registry, double ownerW,
-                          ReactionLevel reaction, double hitstopSec = 0.05) {
+entt::entity MakeAttacker(
+    entt::registry& registry, double ownerW, ReactionLevel reaction,
+    double hitstopSec = 0.05
+) {
   const auto owner = registry.create();
   registry.emplace<WorldPos>(owner, WorldPos{.w = ownerW});
 
@@ -50,7 +52,8 @@ entt::entity MakeAttacker(entt::registry& registry, double ownerW,
   Hierarchy::Attach(registry, owner, hitbox);
   registry.emplace<Attack>(
       hitbox,
-      Attack{.damage = 10, .hitstopSec = hitstopSec, .reaction = reaction});
+      Attack{.damage = 10, .hitstopSec = hitstopSec, .reaction = reaction}
+  );
   return hitbox;
 }
 
@@ -74,42 +77,49 @@ TEST_CASE("HitReactionSystem - Stagger reaction transitions Enemy to Stagger") {
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Stagger);
   const auto target = MakeTarget(registry, 50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Stagger>(
-      registry.get<Motion>(target)));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Stagger>(registry.get<Motion>(target))
+  );
 }
 
 TEST_CASE(
     "HitReactionSystem - Repel reaction transitions Enemy to Repel and sets "
-    "velocity") {
+    "velocity"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Repel);
   const auto target = MakeTarget(registry, 50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
-  REQUIRE(
-      std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(target)));
+  REQUIRE(std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(target
+  )));
   REQUIRE(registry.get<Velocity>(target).w == Approx(250.0));
 }
 
 TEST_CASE(
     "HitReactionSystem - Blow reaction transitions Enemy to Knockback and "
-    "sets velocity") {
+    "sets velocity"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Blow);
   const auto target = MakeTarget(registry, 50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)));
+      registry.get<Motion>(target)
+  ));
   REQUIRE(registry.get<Velocity>(target).w == Approx(300.0));
   REQUIRE(registry.get<Velocity>(target).h == Approx(300.0));
 }
@@ -120,64 +130,73 @@ TEST_CASE("HitReactionSystem - None reaction leaves Enemy in Idle") {
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::None);
   const auto target = MakeTarget(registry, 50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
-  REQUIRE(
-      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(target)));
+  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(target)
+  ));
 }
 
 TEST_CASE(
     "HitReactionSystem - Hp depletion forces Defeated regardless of "
-    "reaction") {
+    "reaction"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Stagger);
   const auto target = MakeTarget(registry, 50.0);
   registry.get<Hp>(target).current = 0;
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(std::holds_alternative<EnemyMotion::Defeated>(
-      registry.get<Motion>(target)));
+      registry.get<Motion>(target)
+  ));
   REQUIRE_FALSE(registry.all_of<Collider>(target));
   REQUIRE_FALSE(registry.all_of<Hp>(target));
 }
 
 TEST_CASE(
     "HitReactionSystem - hit from an owner to the left pushes target to the "
-    "right (positive vel.w)") {
+    "right (positive vel.w)"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto attacker =
       MakeAttacker(registry, /*ownerW=*/0.0, ReactionLevel::Repel);
   const auto target = MakeTarget(registry, /*targetW=*/50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(registry.get<Velocity>(target).w > 0.0);
 }
 
 TEST_CASE(
     "HitReactionSystem - hit from an owner to the right pushes target to "
-    "the left (negative vel.w)") {
+    "the left (negative vel.w)"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto attacker =
       MakeAttacker(registry, /*ownerW=*/100.0, ReactionLevel::Repel);
   const auto target = MakeTarget(registry, /*targetW=*/50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(registry.get<Velocity>(target).w < 0.0);
 }
 
 TEST_CASE(
     "HitReactionSystem - hitstopSec <= 0 skips hitstop but still applies "
-    "reaction") {
+    "reaction"
+) {
   // 弾（Ranged）は hitstopSec 0 で作られるが、ひるみ・撃破自体は起きる
   entt::registry registry;
   SetupContext(registry);
@@ -185,17 +204,20 @@ TEST_CASE(
       MakeAttacker(registry, 0.0, ReactionLevel::Blow, /*hitstopSec=*/0.0);
   const auto target = MakeTarget(registry, 50.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)));
+      registry.get<Motion>(target)
+  ));
   REQUIRE_FALSE(registry.all_of<Hitstop>(target));
 }
 
 TEST_CASE(
     "HitReactionSystem - hitstopSec <= 0 still forces Defeated on Hp "
-    "depletion") {
+    "depletion"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto attacker =
@@ -203,17 +225,20 @@ TEST_CASE(
   const auto target = MakeTarget(registry, 50.0);
   registry.get<Hp>(target).current = 0;
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(std::holds_alternative<EnemyMotion::Defeated>(
-      registry.get<Motion>(target)));
+      registry.get<Motion>(target)
+  ));
   REQUIRE_FALSE(registry.all_of<Hitstop>(target));
 }
 
 TEST_CASE(
     "HitReactionSystem - Stagger hit while Repel resets Velocity.w to "
-    "zero") {
+    "zero"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto target = MakeTarget(registry, 50.0);
@@ -221,17 +246,20 @@ TEST_CASE(
   registry.get<Velocity>(target).w = 250.0;
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Stagger);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Stagger>(
-      registry.get<Motion>(target)));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Stagger>(registry.get<Motion>(target))
+  );
   REQUIRE(registry.get<Velocity>(target).w == Approx(0.0));
 }
 
 TEST_CASE(
     "HitReactionSystem - Blow hit while Stagger restores RectDrawable "
-    "size") {
+    "size"
+) {
   entt::registry registry;
   SetupContext(registry);
   const auto target = MakeTarget(registry, 50.0);
@@ -239,18 +267,21 @@ TEST_CASE(
   registry.emplace<Drawable>(target, RectDrawable{.size = {60.0, 40.0}});
   const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Blow);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)));
+      registry.get<Motion>(target)
+  ));
   const auto& rect = std::get<RectDrawable>(registry.get<Drawable>(target));
   REQUIRE(rect.size.y == Approx(80.0));
 }
 
 TEST_CASE(
     "HitReactionSystem - None reaction while Knockback keeps Velocity "
-    "untouched") {
+    "untouched"
+) {
   // 弾（reaction 既定の None）が当たっても、進行中の Knockback は乱さない
   entt::registry registry;
   SetupContext(registry);
@@ -261,27 +292,33 @@ TEST_CASE(
   const auto attacker =
       MakeAttacker(registry, 0.0, ReactionLevel::None, /*hitstopSec=*/0.0);
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)));
+      registry.get<Motion>(target)
+  ));
   REQUIRE(registry.get<Velocity>(target).w == Approx(300.0));
   REQUIRE(registry.get<Velocity>(target).h == Approx(300.0));
 }
 
 TEST_CASE(
     "HitReactionSystem - grants Hitstop to the attacker's owner and the "
-    "target") {
+    "target"
+) {
   entt::registry registry;
   SetupContext(registry);
-  const auto attacker = MakeAttacker(registry, 0.0, ReactionLevel::Stagger,
-                                     /*hitstopSec=*/0.1);
+  const auto attacker = MakeAttacker(
+      registry, 0.0, ReactionLevel::Stagger,
+      /*hitstopSec=*/0.1
+  );
   const auto target = MakeTarget(registry, 50.0);
   const auto owner = registry.get<Hierarchy>(attacker).parent();
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(registry.all_of<Hitstop>(owner));
   REQUIRE(registry.all_of<Hitstop>(target));
@@ -289,7 +326,8 @@ TEST_CASE(
 
 TEST_CASE(
     "HitReactionSystem - overlapping Hitstop keeps the longer remaining "
-    "time") {
+    "time"
+) {
   // 停止中に短いヒットが重なっても、長い方の残り時間を維持する
   entt::registry registry;
   SetupContext(registry);
@@ -300,17 +338,20 @@ TEST_CASE(
   const auto target = MakeTarget(registry, 50.0);
 
   HitReactionSystem::Apply(
-      registry, {HitPair{.attacker = longAttacker, .target = target}});
+      registry, {HitPair{.attacker = longAttacker, .target = target}}
+  );
   REQUIRE(registry.get<Hitstop>(target).remaining == Approx(0.2));
 
   HitReactionSystem::Apply(
-      registry, {HitPair{.attacker = shortAttacker, .target = target}});
+      registry, {HitPair{.attacker = shortAttacker, .target = target}}
+  );
   REQUIRE(registry.get<Hitstop>(target).remaining == Approx(0.2));
 }
 
 TEST_CASE(
     "HitReactionSystem - overlapping Hitstop extends to a longer new "
-    "remaining time") {
+    "remaining time"
+) {
   // 停止中により長いヒットが重なったら、その長い方へ更新する
   entt::registry registry;
   SetupContext(registry);
@@ -321,17 +362,20 @@ TEST_CASE(
   const auto target = MakeTarget(registry, 50.0);
 
   HitReactionSystem::Apply(
-      registry, {HitPair{.attacker = shortAttacker, .target = target}});
+      registry, {HitPair{.attacker = shortAttacker, .target = target}}
+  );
   REQUIRE(registry.get<Hitstop>(target).remaining == Approx(0.05));
 
   HitReactionSystem::Apply(
-      registry, {HitPair{.attacker = longAttacker, .target = target}});
+      registry, {HitPair{.attacker = longAttacker, .target = target}}
+  );
   REQUIRE(registry.get<Hitstop>(target).remaining == Approx(0.2));
 }
 
 TEST_CASE(
     "HitReactionSystem - non-Enemy target only receives Hitstop, no "
-    "reaction applied") {
+    "reaction applied"
+) {
   // Enemy を持たない被弾側（プレイヤー想定）はリアクション適用の対象外
   entt::registry registry;
   SetupContext(registry);
@@ -341,8 +385,9 @@ TEST_CASE(
   const auto target = registry.create();
   registry.emplace<WorldPos>(target, WorldPos{.w = 50.0});
 
-  HitReactionSystem::Apply(registry,
-                           {HitPair{.attacker = attacker, .target = target}});
+  HitReactionSystem::Apply(
+      registry, {HitPair{.attacker = attacker, .target = target}}
+  );
 
   REQUIRE(registry.all_of<Hitstop>(target));
   REQUIRE_FALSE(registry.all_of<Motion>(target));

--- a/Ash2/tests/TestHitSystem.cpp
+++ b/Ash2/tests/TestHitSystem.cpp
@@ -15,17 +15,27 @@ TEST_CASE("HitSystem - no repeated damage from multi-frame attack") {
   // 攻撃エンティティ（WorldPos 原点、半径10の球コライダー）
   auto attacker = registry.create();
   registry.emplace<WorldPos>(attacker, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(attacker, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                                .segmentEnd = {0.0, 0.0, 0.0},
-                                                .radius = 10.0});
+  registry.emplace<Collider>(
+      attacker,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Attack>(attacker, Attack{.damage = 5});
 
   // 被弾エンティティ（隣接、重なる位置）
   auto target = registry.create();
   registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 10.0});
+  registry.emplace<Collider>(
+      target,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
 
   // 1フレーム目：ヒットしてダメージが入り、HitPair が1件返る
@@ -59,25 +69,40 @@ TEST_CASE("HitSystem - multi-collider attack hits target only once") {
   // 子コライダー1（root を参照）
   auto child1 = registry.create();
   registry.emplace<WorldPos>(child1, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(child1, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 10.0});
+  registry.emplace<Collider>(
+      child1,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Attack>(child1, Attack{.damage = 10, .root = root});
 
   // 子コライダー2（同じ root を参照）
   auto child2 = registry.create();
   registry.emplace<WorldPos>(child2, WorldPos{.w = 3.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(child2, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 10.0});
+  registry.emplace<Collider>(
+      child2,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Attack>(child2, Attack{.damage = 10, .root = root});
 
   // 被弾エンティティ（両コライダーと重なる位置）
   auto target = registry.create();
   registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 10.0});
+  registry.emplace<Collider>(
+      target,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
 
   // 1回の Update で child1 と child2 が両方ヒットしても、ダメージは1回分のみ
@@ -98,17 +123,27 @@ TEST_CASE("HitSystem - collider with destroyed root is skipped") {
   // 攻撃コライダー（無効な root を参照）
   auto attacker = registry.create();
   registry.emplace<WorldPos>(attacker, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(attacker, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                                .segmentEnd = {0.0, 0.0, 0.0},
-                                                .radius = 10.0});
+  registry.emplace<Collider>(
+      attacker,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Attack>(attacker, Attack{.damage = 5, .root = root});
 
   // 被弾エンティティ（重なる位置）
   auto target = registry.create();
   registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 10.0});
+  registry.emplace<Collider>(
+      target,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
 
   const auto hits = HitSystem::Update(registry);
@@ -126,17 +161,27 @@ TEST_CASE("HitSystem - collider with root lacking Attack is skipped") {
   // 攻撃コライダー（Attack 非保持の root を参照）
   auto attacker = registry.create();
   registry.emplace<WorldPos>(attacker, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(attacker, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                                .segmentEnd = {0.0, 0.0, 0.0},
-                                                .radius = 10.0});
+  registry.emplace<Collider>(
+      attacker,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Attack>(attacker, Attack{.damage = 5, .root = root});
 
   // 被弾エンティティ（重なる位置）
   auto target = registry.create();
   registry.emplace<WorldPos>(target, WorldPos{.w = 5.0, .h = 0.0, .d = 0.0});
-  registry.emplace<Collider>(target, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 10.0});
+  registry.emplace<Collider>(
+      target,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 10.0
+      }
+  );
   registry.emplace<Hp>(target, Hp{.max = 100, .current = 100});
 
   const auto hits = HitSystem::Update(registry);

--- a/Ash2/tests/TestPhaseStack.cpp
+++ b/Ash2/tests/TestPhaseStack.cpp
@@ -15,9 +15,11 @@ struct PhaseSpy {
 
 class MockPhase : public IPhase {
  public:
-  explicit MockPhase(std::shared_ptr<PhaseSpy> spy,
-                     PhaseCommand::Type cmd = PhaseCommand::Type::None,
-                     std::unique_ptr<IPhase> next = nullptr)
+  explicit MockPhase(
+      std::shared_ptr<PhaseSpy> spy,
+      PhaseCommand::Type cmd = PhaseCommand::Type::None,
+      std::unique_ptr<IPhase> next = nullptr
+  )
       : m_spy(std::move(spy)), m_cmd(cmd), m_next(std::move(next)) {}
 
   void onAfterPush(entt::registry&) override { m_spy->afterPushCount++; }
@@ -63,7 +65,8 @@ TEST_CASE("PhaseStack - Pop command calls onBeforePop and removes phase") {
   auto spy = std::make_shared<PhaseSpy>();
   PhaseStack stack{
       std::make_unique<MockPhase>(spy, IPhase::PhaseCommand::Type::Pop),
-      registry};
+      registry
+  };
 
   REQUIRE(spy->beforePopCount == 0);
   stack.update(registry, FrameData{});
@@ -78,9 +81,12 @@ TEST_CASE("PhaseStack - Push command calls onAfterPush on new phase") {
   auto spy1 = std::make_shared<PhaseSpy>();
   auto spy2 = std::make_shared<PhaseSpy>();
   PhaseStack stack{
-      std::make_unique<MockPhase>(spy1, IPhase::PhaseCommand::Type::Push,
-                                  std::make_unique<MockPhase>(spy2)),
-      registry};
+      std::make_unique<MockPhase>(
+          spy1, IPhase::PhaseCommand::Type::Push,
+          std::make_unique<MockPhase>(spy2)
+      ),
+      registry
+  };
 
   REQUIRE(spy1->afterPushCount == 1);
   REQUIRE(spy2->afterPushCount == 0);
@@ -94,9 +100,12 @@ TEST_CASE("PhaseStack - Reset command pops all phases then pushes new phase") {
   auto spy1 = std::make_shared<PhaseSpy>();
   auto spy2 = std::make_shared<PhaseSpy>();
   PhaseStack stack{
-      std::make_unique<MockPhase>(spy1, IPhase::PhaseCommand::Type::Reset,
-                                  std::make_unique<MockPhase>(spy2)),
-      registry};
+      std::make_unique<MockPhase>(
+          spy1, IPhase::PhaseCommand::Type::Reset,
+          std::make_unique<MockPhase>(spy2)
+      ),
+      registry
+  };
 
   stack.update(registry, FrameData{});
   REQUIRE(spy1->beforePopCount == 1);
@@ -108,7 +117,8 @@ TEST_CASE("PhaseStack - update on empty stack does nothing") {
   auto spy = std::make_shared<PhaseSpy>();
   PhaseStack stack{
       std::make_unique<MockPhase>(spy, IPhase::PhaseCommand::Type::Pop),
-      registry};
+      registry
+  };
 
   stack.update(registry, FrameData{});
   REQUIRE(spy->updateCount == 1);

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -109,7 +109,8 @@ TEST_CASE("PlayerConfig::FromToml - missing speed throws Error") {
 
 TEST_CASE(
     "PlayerConfig::FromToml - missing melee.stage trajectory throws Error "
-    "(not \"unknown value\")") {
+    "(not \"unknown value\")"
+) {
   std::string toml{KFullToml};
   const auto pos = toml.find("trajectory = \"thrust\"\n");
   REQUIRE(pos != std::string::npos);
@@ -127,12 +128,15 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerConfig::FromToml - unknown melee.stage trajectory value throws "
-    "Error") {
+    "Error"
+) {
   std::string toml{KFullToml};
   const auto pos = toml.find("trajectory = \"thrust\"\n");
   REQUIRE(pos != std::string::npos);
-  toml.replace(pos, std::string_view{"trajectory = \"thrust\"\n"}.size(),
-               "trajectory = \"spin\"\n");
+  toml.replace(
+      pos, std::string_view{"trajectory = \"thrust\"\n"}.size(),
+      "trajectory = \"spin\"\n"
+  );
   const TOMLReader reader{MemoryViewReader{toml.data(), toml.size()}};
   REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
 }

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -41,20 +41,22 @@ void SetupContext(entt::registry& registry) {
                   {
                       // 1段目相当（突き出し）
                       MeleeStageConfig{
-                          .timeline = {.windupSec = 0.05,
-                                       .activeSec = 0.10,
-                                       .recoveryASec = 0.0,
-                                       .recoveryBSec = 0.20},
+                          .timeline =
+                              {.windupSec = 0.05,
+                               .activeSec = 0.10,
+                               .recoveryASec = 0.0,
+                               .recoveryBSec = 0.20},
                           .radius = 20.0,
                           .trajectory = MeleeTrajectory::Thrust,
                           .hitstopSec = 0.05,
                       },
                       // 2段目相当（斬り上げ）
                       MeleeStageConfig{
-                          .timeline = {.windupSec = 0.05,
-                                       .activeSec = 0.15,
-                                       .recoveryASec = 0.0,
-                                       .recoveryBSec = 0.20},
+                          .timeline =
+                              {.windupSec = 0.05,
+                               .activeSec = 0.15,
+                               .recoveryASec = 0.0,
+                               .recoveryBSec = 0.20},
                           .radius = 20.0,
                           .trajectory = MeleeTrajectory::Slash,
                           .slashRiseHeight = 40.0,
@@ -62,44 +64,52 @@ void SetupContext(entt::registry& registry) {
                       },
                       // 3段目相当（締め技、突き出し）
                       MeleeStageConfig{
-                          .timeline = {.windupSec = 0.10,
-                                       .activeSec = 0.20,
-                                       .recoveryASec = 0.0,
-                                       .recoveryBSec = 0.20},
+                          .timeline =
+                              {.windupSec = 0.10,
+                               .activeSec = 0.20,
+                               .recoveryASec = 0.0,
+                               .recoveryBSec = 0.20},
                           .radius = 25.0,
                           .trajectory = MeleeTrajectory::Thrust,
                           .hitstopSec = 0.13,
                       },
                   },
           },
-      .ranged = {.reach = 100.0,
-                 .radius = 5.0,
-                 .damage = 5,
-                 .bulletSpeed = 300.0,
-                 .spawnHeight = 40.0},
-      .dash = {.speed = 500.0,
-               .timeline = {.windupSec = 0.0,
-                            .activeSec = 0.15,
-                            .recoveryASec = 0.15,
-                            .recoveryBSec = 0.15},
-               .staminaCost = 20},
-      .dashAttack = {.timeline = {.windupSec = 0.05,
-                                  .activeSec = 0.20,
-                                  .recoveryASec = 0.20,
-                                  .recoveryBSec = 0.0},
-                     .speed = 600.0,
-                     .orbitRadius = 30.0,
-                     .radius = 20.0,
-                     .damage = 20,
-                     .hitstopSec = 0.08},
-      .airAttack = {.timeline = {.windupSec = 0.05,
-                                 .activeSec = 0.25,
-                                 .recoveryASec = 0.20,
-                                 .recoveryBSec = 0.0},
-                    .orbitRadius = 50.0,
-                    .radius = 20.0,
-                    .damage = 15,
-                    .hitstopSec = 0.08},
+      .ranged =
+          {.reach = 100.0,
+           .radius = 5.0,
+           .damage = 5,
+           .bulletSpeed = 300.0,
+           .spawnHeight = 40.0},
+      .dash =
+          {.speed = 500.0,
+           .timeline =
+               {.windupSec = 0.0,
+                .activeSec = 0.15,
+                .recoveryASec = 0.15,
+                .recoveryBSec = 0.15},
+           .staminaCost = 20},
+      .dashAttack =
+          {.timeline =
+               {.windupSec = 0.05,
+                .activeSec = 0.20,
+                .recoveryASec = 0.20,
+                .recoveryBSec = 0.0},
+           .speed = 600.0,
+           .orbitRadius = 30.0,
+           .radius = 20.0,
+           .damage = 20,
+           .hitstopSec = 0.08},
+      .airAttack =
+          {.timeline =
+               {.windupSec = 0.05,
+                .activeSec = 0.25,
+                .recoveryASec = 0.20,
+                .recoveryBSec = 0.0},
+           .orbitRadius = 50.0,
+           .radius = 20.0,
+           .damage = 15,
+           .hitstopSec = 0.08},
       .landing = {.recoverySec = 0.20},
       .attackEffect = {.fadeSec = 0.30},
   });
@@ -131,7 +141,8 @@ entt::entity MakePlayer(entt::registry& registry) {
   registry.emplace<WorldPos>(player, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0});
   registry.emplace<Velocity>(player);
   registry.emplace<SpriteAnimation>(
-      player, SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"});
+      player, SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"}
+  );
   registry.emplace<Motion>(player, PlayerMotion::Neutral{});
   registry.emplace<Stamina>(player, Stamina{.max = 100, .current = 100});
   return player;
@@ -141,7 +152,8 @@ entt::entity MakePlayer(entt::registry& registry) {
 
 TEST_CASE(
     "PlayerMotionSystem - melee attack input transitions Neutral to Melee "
-    "stage 0") {
+    "stage 0"
+) {
   // 近接攻撃入力で Neutral から Melee（1段目）へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -167,7 +179,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - ranged attack input transitions Neutral to "
-    "Ranged") {
+    "Ranged"
+) {
   // 遠距離攻撃入力で Neutral から Ranged へ遷移し、弾エンティティが生成される
   entt::registry registry;
   SetupContext(registry);
@@ -184,8 +197,9 @@ TEST_CASE(
   const auto& ranged = std::get<PlayerMotion::Ranged>(motion);
   REQUIRE(ranged.timer == Approx(4.0 / 8.0));
 
-  REQUIRE(registry.get<SpriteAnimation>(player).currentClip ==
-          U"ranged_attack");
+  REQUIRE(
+      registry.get<SpriteAnimation>(player).currentClip == U"ranged_attack"
+  );
 
   // 弾エンティティが生成されている
   const auto bulletView = registry.view<Projectile>();
@@ -207,7 +221,8 @@ TEST_CASE("PlayerMotionSystem - no attack input keeps Neutral") {
 
 TEST_CASE(
     "PlayerMotionSystem - airborne player attack input transitions Neutral "
-    "to AirAttack") {
+    "to AirAttack"
+) {
   // 空中にいる場合は攻撃入力で AirAttack へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -232,7 +247,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - airborne player ranged attack input transitions "
-    "Neutral to Ranged") {
+    "Neutral to Ranged"
+) {
   // 空中にいる場合も遠距離攻撃入力で Ranged
   // へ遷移し、弾エンティティが生成される
   entt::registry registry;
@@ -251,8 +267,9 @@ TEST_CASE(
   const auto& ranged = std::get<PlayerMotion::Ranged>(motion);
   REQUIRE(ranged.timer == Approx(4.0 / 8.0));
 
-  REQUIRE(registry.get<SpriteAnimation>(player).currentClip ==
-          U"ranged_attack");
+  REQUIRE(
+      registry.get<SpriteAnimation>(player).currentClip == U"ranged_attack"
+  );
 
   // 弾エンティティが生成されている
   const auto bulletView = registry.view<Projectile>();
@@ -261,7 +278,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - AirAttack spawns hitbox and moves along vertical "
-    "orbit during active frame") {
+    "orbit during active frame"
+) {
   // 攻撃判定区間でヒットボックスが生成され、w-h 平面上の円軌道で移動する
   entt::registry registry;
   SetupContext(registry);
@@ -270,7 +288,8 @@ TEST_CASE(
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null});
+      PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null}
+  );
 
   // windupSec(0.05) を跨ぎ、activeSec(0.25) 中の進行度 0.25 地点まで進める
   const FrameData frameData{.dt = 0.1125};
@@ -294,7 +313,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - AirAttack orbit mirrors horizontally when facing "
-    "left") {
+    "left"
+) {
   // 左向きのとき w 成分の符号が反転する（progress 0.25 は cos=0 で符号の
   // 影響を受けないため、progress 0.0 で検証する）
   entt::registry registry;
@@ -305,7 +325,8 @@ TEST_CASE(
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null});
+      PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null}
+  );
 
   // windupSec(0.05) ちょうどまで進め、progress 0.0（w = -orbitRadius）にする
   const FrameData frameData{.dt = 0.05};
@@ -324,7 +345,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - AirAttack transitions to Landing when player "
-    "lands, destroying leftover hitbox") {
+    "lands, destroying leftover hitbox"
+) {
   // 後隙中でも接地したら Landing へ強制遷移し、ヒットボックスは破棄される
   entt::registry registry;
   SetupContext(registry);
@@ -335,7 +357,8 @@ TEST_CASE(
   registry.emplace<LocalOffset>(hitbox);
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
-      player, PlayerMotion::AirAttack{.elapsed = 0.1, .hitboxEntity = hitbox});
+      player, PlayerMotion::AirAttack{.elapsed = 0.1, .hitboxEntity = hitbox}
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -355,7 +378,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - AirAttack transitions to Neutral on recovery "
-    "timeout while still airborne") {
+    "timeout while still airborne"
+) {
   // 接地せずに後隙が満了した場合はタイマー満了で Neutral へ戻る
   entt::registry registry;
   SetupContext(registry);
@@ -366,7 +390,8 @@ TEST_CASE(
   // = 0.05+0.25+0.20 = 0.50
   registry.replace<Motion>(
       player,
-      PlayerMotion::AirAttack{.elapsed = 0.49, .hitboxEntity = entt::null});
+      PlayerMotion::AirAttack{.elapsed = 0.49, .hitboxEntity = entt::null}
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -377,7 +402,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - jump input immediately switches to jump_rise "
-    "clip") {
+    "clip"
+) {
   // ジャンプ入力と同フレームで jump_rise
   // クリップに切り替わる（1フレーム遅延の修正）
   entt::registry registry;
@@ -395,7 +421,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - simultaneous jump and melee attack input "
-    "transitions to Melee without vertical velocity") {
+    "transitions to Melee without vertical velocity"
+) {
   // 同一フレームのジャンプ＋近接攻撃入力は Melee へ遷移し、上昇しない
   entt::registry registry;
   SetupContext(registry);
@@ -414,7 +441,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - simultaneous jump and ranged attack input "
-    "transitions to Ranged without vertical velocity") {
+    "transitions to Ranged without vertical velocity"
+) {
   // 同一フレームのジャンプ＋遠距離攻撃入力は Ranged へ遷移し、上昇しない
   entt::registry registry;
   SetupContext(registry);
@@ -433,7 +461,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - simultaneous jump and dash input transitions to "
-    "Dash without vertical velocity") {
+    "Dash without vertical velocity"
+) {
   // 同一フレームのジャンプ＋ダッシュ入力は Dash へ遷移し、上昇しない
   entt::registry registry;
   SetupContext(registry);
@@ -462,7 +491,8 @@ TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee to Neutral") {
   const auto hitbox = registry.create();
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.34, .hitboxEntity = hitbox});
+      PlayerMotion::Melee{.stage = 0, .elapsed = 0.34, .hitboxEntity = hitbox}
+  );
 
   const FrameData frameData{.dt = 0.5};
   MotionSystem::Update(registry, frameData);
@@ -494,15 +524,19 @@ TEST_CASE("PlayerMotionSystem - timer expiry transitions Ranged to Neutral") {
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 elapsed increases but stays in "
-    "Melee") {
+    "Melee"
+) {
   // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
@@ -514,15 +548,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 spawns hitbox when entering active "
-    "frame") {
+    "frame"
+) {
   // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   // windupSec(0.05) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
@@ -540,7 +578,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 destroys hitbox when entering "
-    "recovery") {
+    "recovery"
+) {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
   entt::registry registry;
   SetupContext(registry);
@@ -551,7 +590,8 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.10, .hitboxEntity = hitbox});
+      PlayerMotion::Melee{.stage = 0, .elapsed = 0.10, .hitboxEntity = hitbox}
+  );
 
   // windupSec+activeSec(0.15) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
@@ -575,8 +615,11 @@ TEST_CASE("PlayerMotionSystem - Melee stage 0 stops horizontal movement") {
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.1};
   frameData.input.moveAxis = Vec2{1.0, 0.0};
@@ -589,7 +632,8 @@ TEST_CASE("PlayerMotionSystem - Melee stage 0 stops horizontal movement") {
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 attack input during windup only "
-    "sets comboQueued") {
+    "sets comboQueued"
+) {
   // windup中（elapsed < activeStart）の攻撃入力では即時遷移せず、
   // comboQueued が立つのみ
   entt::registry registry;
@@ -597,8 +641,11 @@ TEST_CASE(
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
@@ -611,7 +658,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 attack input during active only "
-    "sets comboQueued") {
+    "sets comboQueued"
+) {
   // active中（activeStart <= elapsed < activeEnd）の攻撃入力でも
   // 即時遷移せず、comboQueued が立つのみ
   entt::registry registry;
@@ -620,8 +668,11 @@ TEST_CASE(
 
   // windupSec(0.05) を超え activeEnd(0.15) 未満
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.10, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.10, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
@@ -634,18 +685,23 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 transitions to stage 1 immediately "
-    "when comboQueued at activeEnd") {
+    "when comboQueued at activeEnd"
+) {
   // activeEnd 到達時に comboQueued が立っていれば即座に次段へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   // activeEnd は windupSec+activeSec = 0.15
-  registry.replace<Motion>(player,
-                           PlayerMotion::Melee{.stage = 0,
-                                               .elapsed = 0.14,
-                                               .hitboxEntity = entt::null,
-                                               .comboQueued = true});
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee{
+          .stage = 0,
+          .elapsed = 0.14,
+          .hitboxEntity = entt::null,
+          .comboQueued = true
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -657,7 +713,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 transitions to stage 1 immediately "
-    "on new attack input during recovery") {
+    "on new attack input during recovery"
+) {
   // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に次段へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -665,8 +722,11 @@ TEST_CASE(
 
   // activeEnd(0.15) を既に過ぎている状態（comboQueued は未予約）
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
@@ -679,7 +739,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 attack input during recoveryA only "
-    "sets comboQueued and fires after entering recoveryB") {
+    "sets comboQueued and fires after entering recoveryB"
+) {
   // 後隙A中（activeEnd <= elapsed < recoveryAEnd）の攻撃入力では即時遷移せず
   // 予約のみ行い、後隙Bに入ってから次段へ遷移する
   entt::registry registry;
@@ -691,8 +752,11 @@ TEST_CASE(
       0.10;
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null
+      }
+  );
 
   // 後隙A中の攻撃入力：予約のみで遷移しない
   FrameData frameData{.dt = 0.01};
@@ -719,7 +783,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 transitions to Neutral when "
-    "recoveryEnd exceeded without comboQueued") {
+    "recoveryEnd exceeded without comboQueued"
+) {
   // comboQueued が立っていない状態で recoveryEnd を超えたら Neutral へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -727,8 +792,11 @@ TEST_CASE(
 
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.35
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.34, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.34, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -739,15 +807,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 comboQueued accumulates across "
-    "frames") {
+    "frames"
+) {
   // comboQueued は一度立ったら立ったまま（OR的に蓄積）
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   // 1フレーム目：攻撃入力あり、comboQueued が立つ
   FrameData frameData1{.dt = 0.01};
@@ -755,7 +827,8 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData1);
 
   REQUIRE(
-      std::get<PlayerMotion::Melee>(registry.get<Motion>(player)).comboQueued);
+      std::get<PlayerMotion::Melee>(registry.get<Motion>(player)).comboQueued
+  );
 
   // 2フレーム目：攻撃入力なし、comboQueued は立ったまま
   const FrameData frameData2{.dt = 0.01};
@@ -768,15 +841,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 elapsed increases but stays in "
-    "Melee") {
+    "Melee"
+) {
   // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
@@ -788,15 +865,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 spawns hitbox when entering active "
-    "frame") {
+    "frame"
+) {
   // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   // windupSec(0.05) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
@@ -811,7 +892,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 destroys hitbox when entering "
-    "recovery") {
+    "recovery"
+) {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
   entt::registry registry;
   SetupContext(registry);
@@ -822,7 +904,8 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 1, .elapsed = 0.15, .hitboxEntity = hitbox});
+      PlayerMotion::Melee{.stage = 1, .elapsed = 0.15, .hitboxEntity = hitbox}
+  );
 
   // windupSec+activeSec(0.20) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
@@ -841,7 +924,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 transitions to Neutral when "
-    "recoveryEnd exceeded") {
+    "recoveryEnd exceeded"
+) {
   // recoveryEnd を超えたら Neutral へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -849,8 +933,11 @@ TEST_CASE(
 
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.40
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.39, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.39, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -861,7 +948,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 attack input during windup only "
-    "sets comboQueued") {
+    "sets comboQueued"
+) {
   // windup中（elapsed < activeStart）の攻撃入力では即時遷移せず、
   // comboQueued が立つのみ
   entt::registry registry;
@@ -869,8 +957,11 @@ TEST_CASE(
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
@@ -883,18 +974,23 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 transitions to stage 2 immediately "
-    "when comboQueued at activeEnd") {
+    "when comboQueued at activeEnd"
+) {
   // activeEnd 到達時に comboQueued が立っていれば即座に次段へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   // activeEnd は windupSec+activeSec = 0.20
-  registry.replace<Motion>(player,
-                           PlayerMotion::Melee{.stage = 1,
-                                               .elapsed = 0.19,
-                                               .hitboxEntity = entt::null,
-                                               .comboQueued = true});
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee{
+          .stage = 1,
+          .elapsed = 0.19,
+          .hitboxEntity = entt::null,
+          .comboQueued = true
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -906,7 +1002,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 transitions to stage 2 immediately "
-    "on new attack input during recovery") {
+    "on new attack input during recovery"
+) {
   // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に次段へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -914,8 +1011,11 @@ TEST_CASE(
 
   // activeEnd(0.20) を既に過ぎている状態（comboQueued は未予約）
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.21, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.21, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
@@ -928,7 +1028,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 transitions to Neutral when "
-    "recoveryEnd exceeded without comboQueued") {
+    "recoveryEnd exceeded without comboQueued"
+) {
   // comboQueued が立っていない状態で recoveryEnd を超えたら Neutral へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -936,8 +1037,11 @@ TEST_CASE(
 
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.40
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.39, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.39, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -948,15 +1052,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 2 elapsed increases but stays in "
-    "Melee") {
+    "Melee"
+) {
   // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
@@ -968,15 +1076,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 2 spawns hitbox when entering active "
-    "frame") {
+    "frame"
+) {
   // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   // windupSec(0.10) を跨ぐ dt
   const FrameData frameData{.dt = 0.11};
@@ -994,15 +1106,19 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee hitstopSec differs per stage, following "
-    "config") {
+    "config"
+) {
   // 締め技（3段目）は1段目より長いヒットストップ時間を持つ（コンボ段との連動）
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
   // windupSec(0.05) を跨ぐ dt
   MotionSystem::Update(registry, FrameData{.dt = 0.06});
   const auto stage0Hitbox =
@@ -1010,8 +1126,11 @@ TEST_CASE(
   const double stage0HitstopSec = registry.get<Attack>(stage0Hitbox).hitstopSec;
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
   // windupSec(0.10) を跨ぐ dt
   MotionSystem::Update(registry, FrameData{.dt = 0.11});
   const auto stage2Hitbox =
@@ -1025,7 +1144,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 2 destroys hitbox when entering "
-    "recovery") {
+    "recovery"
+) {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
   entt::registry registry;
   SetupContext(registry);
@@ -1036,7 +1156,8 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 2, .elapsed = 0.29, .hitboxEntity = hitbox});
+      PlayerMotion::Melee{.stage = 2, .elapsed = 0.29, .hitboxEntity = hitbox}
+  );
 
   // windupSec+activeSec(0.30) を跨ぐ dt
   const FrameData frameData{.dt = 0.06};
@@ -1055,7 +1176,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 2 transitions to Neutral when "
-    "recoveryEnd exceeded") {
+    "recoveryEnd exceeded"
+) {
   // recoveryEnd を超えたら Neutral へ遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -1063,8 +1185,11 @@ TEST_CASE(
 
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.50
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.49, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.49, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -1073,8 +1198,8 @@ TEST_CASE(
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
 }
 
-TEST_CASE(
-    "PlayerMotionSystem - Melee stage 2 (finisher) ignores attack input") {
+TEST_CASE("PlayerMotionSystem - Melee stage 2 (finisher) ignores attack input"
+) {
   // 最終段（次段を持たない）は締め技のため攻撃入力を無視し、
   // recoveryEnd 未満では Melee のまま
   entt::registry registry;
@@ -1082,8 +1207,11 @@ TEST_CASE(
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
@@ -1096,7 +1224,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 2 (finisher) ignores dash input "
-    "during recovery") {
+    "during recovery"
+) {
   // 最終段はキャンセル不可のため、後隙中のダッシュ入力を無視する
   entt::registry registry;
   SetupContext(registry);
@@ -1104,8 +1233,11 @@ TEST_CASE(
 
   // activeEnd(0.30) を既に過ぎている状態
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.31, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.31, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.dashDown = true;
@@ -1123,8 +1255,11 @@ TEST_CASE("PlayerMotionSystem - Melee stage 2 stops horizontal movement") {
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.1};
   frameData.input.moveAxis = Vec2{1.0, 0.0};
@@ -1158,7 +1293,8 @@ TEST_CASE("PlayerMotionSystem - dash input transitions Neutral to Dash") {
 
 TEST_CASE(
     "PlayerMotionSystem - dash input is ignored when stamina is "
-    "insufficient") {
+    "insufficient"
+) {
   // ST不足の場合はダッシュ入力を無視し Neutral のまま、ST も減らない
   entt::registry registry;
   SetupContext(registry);
@@ -1175,8 +1311,8 @@ TEST_CASE(
   REQUIRE(registry.get<Stamina>(player).current == 10);
 }
 
-TEST_CASE(
-    "PlayerMotionSystem - Dash grants Invincible during windup and dash") {
+TEST_CASE("PlayerMotionSystem - Dash grants Invincible during windup and dash"
+) {
   // 構え・ダッシュ中（elapsed < activeEnd）は Invincible が付与される
   entt::registry registry;
   SetupContext(registry);
@@ -1189,12 +1325,12 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.all_of<Invincible>(player));
-  REQUIRE(
-      std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player)));
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player
+  )));
 }
 
-TEST_CASE(
-    "PlayerMotionSystem - Dash removes Invincible when entering recovery") {
+TEST_CASE("PlayerMotionSystem - Dash removes Invincible when entering recovery"
+) {
   // activeEnd(0.15) を超えた時点で Invincible が除去される
   entt::registry registry;
   SetupContext(registry);
@@ -1211,7 +1347,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Dash moves in facing direction when no move "
-    "input") {
+    "input"
+) {
   // ダッシュ中に移動入力がない場合は facingRight 方向へ移動する
   entt::registry registry;
   SetupContext(registry);
@@ -1229,8 +1366,8 @@ TEST_CASE(
   REQUIRE(vel.d == Approx(0.0));
 }
 
-TEST_CASE(
-    "PlayerMotionSystem - Dash moves in free direction when input given") {
+TEST_CASE("PlayerMotionSystem - Dash moves in free direction when input given"
+) {
   // ダッシュ中にフリー方向の移動入力があればその方向へ移動する
   entt::registry registry;
   SetupContext(registry);
@@ -1249,7 +1386,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Dash queues dash attack on attack input during "
-    "recovery B") {
+    "recovery B"
+) {
   // 後隙B中（recoveryAEnd 以降）の近接攻撃入力で dashAttackQueued が立つ
   entt::registry registry;
   SetupContext(registry);
@@ -1269,7 +1407,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Dash cancels into Dash on dash input during "
-    "recovery B") {
+    "recovery B"
+) {
   // 後隙B中（recoveryAEnd 以降）のダッシュ入力で Dash へキャンセルする
   entt::registry registry;
   SetupContext(registry);
@@ -1283,13 +1422,15 @@ TEST_CASE(
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
-  REQUIRE(std::get<PlayerMotion::Dash>(motion).elapsed ==
-          Approx(0.0).margin(0.001));
+  REQUIRE(
+      std::get<PlayerMotion::Dash>(motion).elapsed == Approx(0.0).margin(0.001)
+  );
 }
 
 TEST_CASE(
     "PlayerMotionSystem - Dash re-dashes when dashQueued upon entering "
-    "recovery B") {
+    "recovery B"
+) {
   // ダッシュ中に予約された再ダッシュが後隙B入りで発動する
   entt::registry registry;
   SetupContext(registry);
@@ -1297,20 +1438,23 @@ TEST_CASE(
 
   // dashQueued = true（ダッシュ中の入力で予約済み）、後隙Aの末端
   registry.replace<Motion>(
-      player, PlayerMotion::Dash{.elapsed = 0.29, .dashQueued = true});
+      player, PlayerMotion::Dash{.elapsed = 0.29, .dashQueued = true}
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
   REQUIRE(std::holds_alternative<PlayerMotion::Dash>(motion));
-  REQUIRE(std::get<PlayerMotion::Dash>(motion).elapsed ==
-          Approx(0.0).margin(0.001));
+  REQUIRE(
+      std::get<PlayerMotion::Dash>(motion).elapsed == Approx(0.0).margin(0.001)
+  );
 }
 
 TEST_CASE(
     "PlayerMotionSystem - Dash transitions to Neutral at recovery B end "
-    "even when dashAttackQueued") {
+    "even when dashAttackQueued"
+) {
   // recoveryBEnd を超えたら dashAttackQueued の有無に関わらず Neutral へ戻る
   entt::registry registry;
   SetupContext(registry);
@@ -1318,7 +1462,8 @@ TEST_CASE(
 
   // recoveryBEnd は windupSec+activeSec+recoveryASec+recoveryBSec = 0.45
   registry.replace<Motion>(
-      player, PlayerMotion::Dash{.elapsed = 0.44, .dashAttackQueued = true});
+      player, PlayerMotion::Dash{.elapsed = 0.44, .dashAttackQueued = true}
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -1329,7 +1474,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 recovery dash input cancels into "
-    "Dash") {
+    "Dash"
+) {
   // Melee（1段目）の後隙中にダッシュ入力があるとダッシュへキャンセルする
   entt::registry registry;
   SetupContext(registry);
@@ -1337,8 +1483,11 @@ TEST_CASE(
 
   // activeEnd(0.15) を既に過ぎている状態
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.dashDown = true;
@@ -1352,7 +1501,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 1 recovery dash input cancels into "
-    "Dash") {
+    "Dash"
+) {
   // Melee（2段目）の後隙中にダッシュ入力があるとダッシュへキャンセルする
   entt::registry registry;
   SetupContext(registry);
@@ -1360,8 +1510,11 @@ TEST_CASE(
 
   // activeEnd(0.20) を既に過ぎている状態
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 1, .elapsed = 0.21, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 1, .elapsed = 0.21, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.01};
   frameData.input.dashDown = true;
@@ -1374,7 +1527,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee stage 0 recovery dash input is ignored "
-    "without leftover hitbox") {
+    "without leftover hitbox"
+) {
   // Melee 後隙からダッシュへキャンセルする際、ヒットボックスは既に解放済み
   entt::registry registry;
   SetupContext(registry);
@@ -1386,7 +1540,8 @@ TEST_CASE(
   // activeEnd(0.15) を跨ぐ dt でヒットボックスが解放される
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.14, .hitboxEntity = hitbox});
+      PlayerMotion::Melee{.stage = 0, .elapsed = 0.14, .hitboxEntity = hitbox}
+  );
 
   FrameData frameData{.dt = 0.02};
   frameData.input.dashDown = true;
@@ -1404,7 +1559,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - airborne player dash input transitions Neutral to "
-    "air Dash") {
+    "air Dash"
+) {
   // 空中でのダッシュ入力で Neutral から Dash（air=true）へ遷移し、
   // ST が1回分消費される
   entt::registry registry;
@@ -1429,7 +1585,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - airborne dash input is ignored when stamina is "
-    "insufficient") {
+    "insufficient"
+) {
   // ST不足の場合は空中ダッシュ入力を無視し Neutral のまま、ST も減らない
   entt::registry registry;
   SetupContext(registry);
@@ -1449,7 +1606,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash grants Invincible during windup and "
-    "dash") {
+    "dash"
+) {
   // 構え・ダッシュ中（elapsed < activeEnd）は Invincible が付与される
   entt::registry registry;
   SetupContext(registry);
@@ -1457,20 +1615,22 @@ TEST_CASE(
   registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
 
   // dash.timeline.windupSec(0.0) + activeSec(0.15) = 0.15 未満
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.0, .air = true});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.0, .air = true}
+  );
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.all_of<Invincible>(player));
-  REQUIRE(
-      std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player)));
+  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player
+  )));
 }
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash removes Invincible when entering "
-    "recovery") {
+    "recovery"
+) {
   // activeEnd(0.15) を超えた時点で Invincible が除去される
   entt::registry registry;
   SetupContext(registry);
@@ -1478,8 +1638,9 @@ TEST_CASE(
   registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
 
   registry.emplace<Invincible>(player);
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.14, .air = true});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.14, .air = true}
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -1489,7 +1650,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash fixes vertical velocity to zero during "
-    "dash movement") {
+    "dash movement"
+) {
   // ダッシュ移動区間中は垂直速度が 0 に固定される（暫定仕様）
   entt::registry registry;
   SetupContext(registry);
@@ -1498,8 +1660,9 @@ TEST_CASE(
   registry.get<Velocity>(player).h = -200.0;  // 落下中を模した垂直速度
   registry.get<SpriteAnimation>(player).facingRight = true;
 
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.0, .air = true});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.0, .air = true}
+  );
 
   const FrameData frameData{.dt = 0.05};
   MotionSystem::Update(registry, frameData);
@@ -1512,7 +1675,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash transitions to Landing when player "
-    "lands") {
+    "lands"
+) {
   // 移動・後隙中いずれでも接地したら Landing へ強制遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -1520,8 +1684,9 @@ TEST_CASE(
   registry.get<WorldPos>(player).h = 0.0;  // 接地
   registry.emplace<Invincible>(player);
 
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.1, .air = true});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.1, .air = true}
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -1537,7 +1702,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - ground Dash does not transition to Landing even "
-    "when airborne") {
+    "when airborne"
+) {
   // 地上 Dash（air=false）は接地遷移を持たないため、空中にいても Landing
   // へは遷移しない
   entt::registry registry;
@@ -1545,8 +1711,9 @@ TEST_CASE(
   const auto player = MakePlayer(registry);
   registry.get<WorldPos>(player).h = 50.0;  // 空中
 
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.1, .air = false});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.1, .air = false}
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -1557,7 +1724,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash transitions to Neutral on recovery "
-    "timeout while still airborne") {
+    "timeout while still airborne"
+) {
   // 接地せずに後隙が満了した場合はタイマー満了で Neutral へ戻る
   entt::registry registry;
   SetupContext(registry);
@@ -1565,8 +1733,9 @@ TEST_CASE(
   registry.get<WorldPos>(player).h = 500.0;  // 十分な高さで着地しない
 
   // recoveryBEnd は windupSec+activeSec+recoveryASec+recoveryBSec = 0.45
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.44, .air = true});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.44, .air = true}
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -1577,7 +1746,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash queues air dash attack on attack input "
-    "during recovery B") {
+    "during recovery B"
+) {
   // 後隙B中（recoveryAEnd 以降）の近接攻撃入力で dashAttackQueued が立つ
   entt::registry registry;
   SetupContext(registry);
@@ -1585,8 +1755,9 @@ TEST_CASE(
   registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
 
   // activeEnd(0.15) + recoveryASec(0.15) = 0.30 が recoveryAEnd
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.29, .air = true});
+  registry.replace<Motion>(
+      player, PlayerMotion::Dash{.elapsed = 0.29, .air = true}
+  );
 
   FrameData frameData{.dt = 0.02};
   frameData.input.attackDown = true;
@@ -1599,7 +1770,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash re-dashes when dashQueued upon entering "
-    "recovery B") {
+    "recovery B"
+) {
   // 空中ダッシュにも再ダッシュ予約（dashQueued）が働く（地上と仕様を揃える）
   entt::registry registry;
   SetupContext(registry);
@@ -1608,7 +1780,8 @@ TEST_CASE(
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Dash{.elapsed = 0.29, .air = true, .dashQueued = true});
+      PlayerMotion::Dash{.elapsed = 0.29, .air = true, .dashQueued = true}
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -1622,7 +1795,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air Dash transitions to air DashAttack when "
-    "dashAttackQueued at recovery A end") {
+    "dashAttackQueued at recovery A end"
+) {
   // 後隙A終了時に予約済みなら空中ダッシュ攻撃（DashAttack、air=true）へ
   // 遷移し、方向を引き継ぐ
   entt::registry registry;
@@ -1631,11 +1805,15 @@ TEST_CASE(
   registry.get<WorldPos>(player).h = 50.0;  // 空中（接地遷移を避ける）
 
   // recoveryAEnd(0.30) を跨ぐ dt
-  registry.replace<Motion>(player,
-                           PlayerMotion::Dash{.elapsed = 0.29,
-                                              .air = true,
-                                              .dashAttackQueued = true,
-                                              .lastDashDir = Vec2{0.0, 1.0}});
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Dash{
+          .elapsed = 0.29,
+          .air = true,
+          .dashAttackQueued = true,
+          .lastDashDir = Vec2{0.0, 1.0}
+      }
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -1655,18 +1833,23 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air DashAttack spawns hitbox and moves along w-d "
-    "orbit during active frame") {
+    "orbit during active frame"
+) {
   // 攻撃判定区間でヒットボックスが生成され、w-d 平面上の円軌道で移動する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
   registry.get<WorldPos>(player).h = 100.0;  // 空中（接地遷移を避ける）
 
-  registry.replace<Motion>(player,
-                           PlayerMotion::DashAttack{.elapsed = 0.0,
-                                                    .air = true,
-                                                    .hitboxEntity = entt::null,
-                                                    .dashDir = Vec2{1.0, 0.0}});
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::DashAttack{
+          .elapsed = 0.0,
+          .air = true,
+          .hitboxEntity = entt::null,
+          .dashDir = Vec2{1.0, 0.0}
+      }
+  );
 
   // windupSec(0.05) を跨ぎ、activeSec(0.20) 中の進行度 0.25 地点まで進める
   const FrameData frameData{.dt = 0.10};
@@ -1676,8 +1859,8 @@ TEST_CASE(
   const auto& dashAttack = std::get<PlayerMotion::DashAttack>(motion);
   REQUIRE(dashAttack.hitboxEntity != entt::entity{entt::null});
   REQUIRE(registry.valid(dashAttack.hitboxEntity));
-  REQUIRE(
-      registry.all_of<Collider, Attack, LocalOffset>(dashAttack.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(dashAttack.hitboxEntity
+  ));
 
   // 進行度0.25 → 円上の点（w=0、h=capMidH(40.0)、d=orbitRadius(30.0)）
   const auto& localOffset = registry.get<LocalOffset>(dashAttack.hitboxEntity);
@@ -1691,7 +1874,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air DashAttack transitions to Landing when "
-    "player lands, destroying leftover hitbox") {
+    "player lands, destroying leftover hitbox"
+) {
   // 後隙中でも接地したら Landing へ強制遷移し、ヒットボックスは破棄される
   entt::registry registry;
   SetupContext(registry);
@@ -1702,8 +1886,11 @@ TEST_CASE(
   registry.emplace<LocalOffset>(hitbox);
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
-      player, PlayerMotion::DashAttack{
-                  .elapsed = 0.1, .air = true, .hitboxEntity = hitbox});
+      player,
+      PlayerMotion::DashAttack{
+          .elapsed = 0.1, .air = true, .hitboxEntity = hitbox
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -1723,7 +1910,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - ground DashAttack does not transition to Landing "
-    "even when airborne") {
+    "even when airborne"
+) {
   // 地上 DashAttack（air=false）は接地遷移を持たない
   entt::registry registry;
   SetupContext(registry);
@@ -1735,8 +1923,11 @@ TEST_CASE(
   registry.emplace<LocalOffset>(hitbox);
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
-      player, PlayerMotion::DashAttack{
-                  .elapsed = 0.1, .air = false, .hitboxEntity = hitbox});
+      player,
+      PlayerMotion::DashAttack{
+          .elapsed = 0.1, .air = false, .hitboxEntity = hitbox
+      }
+  );
 
   const FrameData frameData{.dt = 0.01};
   MotionSystem::Update(registry, frameData);
@@ -1747,7 +1938,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - air DashAttack transitions to Neutral on "
-    "recovery timeout while still airborne") {
+    "recovery timeout while still airborne"
+) {
   // 接地せずに後隙が満了した場合はタイマー満了で Neutral へ戻る
   entt::registry registry;
   SetupContext(registry);
@@ -1757,8 +1949,11 @@ TEST_CASE(
   // recoveryEnd は windupSec+activeSec+recoveryASec+recoveryBSec(0)
   // = 0.05+0.20+0.20 = 0.45
   registry.replace<Motion>(
-      player, PlayerMotion::DashAttack{
-                  .elapsed = 0.44, .air = true, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::DashAttack{
+          .elapsed = 0.44, .air = true, .hitboxEntity = entt::null
+      }
+  );
 
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
@@ -1769,7 +1964,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Hitstop freezes Melee elapsed and keeps the same "
-    "hitboxEntity") {
+    "hitboxEntity"
+) {
   // Hitstop 中は dt = 0 で Tick されるため、elapsed もヒットボックスの再生成も
   // 起きない
   entt::registry registry;
@@ -1782,7 +1978,8 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.06, .hitboxEntity = hitbox});
+      PlayerMotion::Melee{.stage = 0, .elapsed = 0.06, .hitboxEntity = hitbox}
+  );
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
@@ -1796,7 +1993,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Hitstop still lets attackDown set comboQueued "
-    "during active frame") {
+    "during active frame"
+) {
   // dt = 0 でも input は読まれるため、停止中の攻撃入力は予約として拾える
   entt::registry registry;
   SetupContext(registry);
@@ -1805,8 +2003,11 @@ TEST_CASE(
 
   // windupSec(0.05) を超え activeEnd(0.15) 未満（active区間）
   registry.replace<Motion>(
-      player, PlayerMotion::Melee{
-                  .stage = 0, .elapsed = 0.10, .hitboxEntity = entt::null});
+      player,
+      PlayerMotion::Melee{
+          .stage = 0, .elapsed = 0.10, .hitboxEntity = entt::null
+      }
+  );
 
   FrameData frameData{.dt = 0.1};
   frameData.input.attackDown = true;
@@ -1821,7 +2022,8 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - Melee resumes and transitions to next stage once "
-    "Hitstop clears") {
+    "Hitstop clears"
+) {
   // 停止中は次段への遷移が起きず、Hitstop 除去後の後隙Bで初めて遷移する
   entt::registry registry;
   SetupContext(registry);
@@ -1829,11 +2031,15 @@ TEST_CASE(
   registry.emplace<Hitstop>(player, Hitstop{.remaining = 0.05});
 
   // activeEnd(0.15) 手前、次段への予約は既に立っている
-  registry.replace<Motion>(player,
-                           PlayerMotion::Melee{.stage = 0,
-                                               .elapsed = 0.14,
-                                               .hitboxEntity = entt::null,
-                                               .comboQueued = true});
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::Melee{
+          .stage = 0,
+          .elapsed = 0.14,
+          .hitboxEntity = entt::null,
+          .comboQueued = true
+      }
+  );
 
   // 停止中：dt を与えても elapsed は凍結されたまま、まだ Melee stage 0
   MotionSystem::Update(registry, FrameData{.dt = 0.1});

--- a/Ash2/tests/TestProjectileSystem.cpp
+++ b/Ash2/tests/TestProjectileSystem.cpp
@@ -16,30 +16,37 @@ namespace {
 /// @param pos 初期ワールド座標
 /// @param vel 速度
 /// @return 生成した弾エンティティ
-entt::entity MakeBullet(entt::registry& registry, const WorldPos& pos,
-                        const Velocity& vel) {
+entt::entity MakeBullet(
+    entt::registry& registry, const WorldPos& pos, const Velocity& vel
+) {
   const auto bullet = registry.create();
   registry.emplace<Projectile>(bullet);
   registry.emplace<WorldPos>(bullet, pos);
   registry.emplace<Velocity>(bullet, vel);
-  registry.emplace<Collider>(bullet, Collider{.segmentStart = {0.0, 0.0, 0.0},
-                                              .segmentEnd = {0.0, 0.0, 0.0},
-                                              .radius = 5.0});
+  registry.emplace<Collider>(
+      bullet,
+      Collider{
+          .segmentStart = {0.0, 0.0, 0.0},
+          .segmentEnd = {0.0, 0.0, 0.0},
+          .radius = 5.0
+      }
+  );
   registry.emplace<Attack>(bullet, Attack{.damage = 10});
   return bullet;
 }
 
 }  // namespace
 
-TEST_CASE(
-    "ProjectileSystem - destroys bullet on impact (hitTargets non-empty)") {
+TEST_CASE("ProjectileSystem - destroys bullet on impact (hitTargets non-empty)"
+) {
   // Attack.hitTargets が空でなくなった（HitSystem
   // がヒットを記録した）場合は破棄される
   entt::registry registry;
 
-  const auto bullet =
-      MakeBullet(registry, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0},
-                 Velocity{.w = 100.0, .h = 0.0, .d = 0.0});
+  const auto bullet = MakeBullet(
+      registry, WorldPos{.w = 0.0, .h = 0.0, .d = 0.0},
+      Velocity{.w = 100.0, .h = 0.0, .d = 0.0}
+  );
 
   // HitSystem が記録したことを模してダミーのターゲットを hitTargets に追加
   const auto dummyTarget = registry.create();
@@ -57,9 +64,10 @@ TEST_CASE("ProjectileSystem - destroys bullet when off-screen") {
 
   // 実行環境の画面サイズに依存しないよう、十分に遠い座標を使う
   constexpr double KFarAway = 1.0e9;
-  const auto bullet =
-      MakeBullet(registry, WorldPos{.w = KFarAway, .h = 0.0, .d = 0.0},
-                 Velocity{.w = 0.0, .h = 0.0, .d = 0.0});
+  const auto bullet = MakeBullet(
+      registry, WorldPos{.w = KFarAway, .h = 0.0, .d = 0.0},
+      Velocity{.w = 0.0, .h = 0.0, .d = 0.0}
+  );
 
   ProjectileSystem::Update(registry);
 


### PR DESCRIPTION
## 概要

`.clang-format` の `AlignAfterOpenBracket` を Google スタイル既定の `Align` から `BlockIndent` に変更し、`src` / `tests` の全ソースへ再適用する。

## 背景

`Align`（開き括弧の位置に継続行を桁揃えする方式）では、行の桁位置が「その行がどの括弧に属するか」を表さない。同じ桁に見えて別階層、という状態が起こるため、入れ子の呼び出しで括弧の対応を読み違えやすい。

```cpp
// 変更前: ScenarioPhase::Param が make_unique の引数か PhaseStack の引数か読み取りづらい
PhaseStack phaseStack(std::make_unique<ScenarioPhase>(
                          ScenarioPhase::Param{.sectionName = U"init"}),
                      registry);

// 変更後: 閉じ括弧が階層を確定させる
PhaseStack phaseStack(
    std::make_unique<ScenarioPhase>(
        ScenarioPhase::Param{.sectionName = U"init"}
    ),
    registry
);
```

## 技術選択の理由

### なぜ `DontAlign` ではなく `BlockIndent` か

代替案として `AlignAfterOpenBracket: DontAlign` + `ContinuationIndentWidth: 4` を全ソースに適用して比較した。この案は採用しない。継続行が一定量インデントされるだけで階層が表現されず、入れ子では内側と外側で異なる規則が混在するため。

```cpp
// DontAlign + 4: 内側は桁揃えのまま、外側だけ +4 になり規則が割れる
PhaseStack phaseStack(std::make_unique<ScenarioPhase>(
                          ScenarioPhase::Param{.sectionName = U"init"}),
    registry);
```

`ContinuationIndentWidth: 2` はさらに不可。本プロジェクトの `IndentWidth` が 2 のため、関数の仮引数継続行と関数本体が同じ桁に並び、区別がつかなくなる。

### なぜ `PenaltyBreakScopeResolution` が必要か

`BlockIndent` の導入により、`ScenarioPhase.cpp` / `TestMenuPhase.cpp` で修飾名が `::` の直後で分断された。

```cpp
IPhase::PhaseCommand ScenarioPhase::
    update(entt::registry& registry, const FrameData& /*frameData*/) {
```

clang-format は改行位置をペナルティ最小化で決める。`BlockIndent` は「開き括弧の後で折ったら閉じ括弧も独立行に置く」ため、仮引数リストで折る配置に改行が 1 つ増える。二分探索で確認したところ、この配置の相対コストは `Align` 時の 21 から `BlockIndent` 時の 1160 に上昇しており、既定の `PenaltyBreakScopeResolution: 500` では届かなくなっていた。

1000000 は「事実上選ばせない」ことを表す慣用値で、`PenaltyExcessCharacter` と同値。全ソースに適用して影響範囲を確認したところ、変化するのは上記 2 ファイルのみ。

### `AnimationSystem.cpp` の変更理由

`BlockIndent` 下では、波括弧初期化した一時オブジェクトを直接呼び出す形が破綻する。`}` が独立行に置かれる規則と、その直後に貼り付いた呼び出しの `(` が衝突するため。

```cpp
auto region = TextureAsset{data.textureKey
}(col * data.size.x, clip.row * data.size.y, data.size.x, data.size.y);
```

この形はペナルティ設定では解決できない（`PenaltyBreakOpenParenthesis` 等を両極端に振っても出力が変わらないことを確認済み）。`Cpp11BracedListStyle: false` なら解消するが、波括弧の内側に空白が入る指定でもあり、指定初期化子を多用する本コードベースでは 51 ファイル・1589 行に波及するため採らない。

代わりに `Texture::operator()` の `(const Vec2& xy, const Vec2& size)` オーバーロードを使い、式自体を短くした。`Size` は `Point` であり成分ごとの `operator*` を持つため、マス目の指定がそのまま書ける。

```cpp
const Point cell{col, clip.row};
auto region = TextureAsset{data.textureKey}(cell * data.size, data.size);
```

77 桁に収まり折り返しが発生しない。`data.size.x` / `data.size.y` の重複も解消している。

## 検証

- clang-format: 再適用後に差分なし
- clang-tidy: 問題なし
- ビルド: 成功
- テスト: 170 ケース / 425 アサーション 全通過
- 目視確認: ゲームを起動しスプライト表示に異常がないことを確認（`AnimationSystem` を対象とするテストは存在しないため）

意味的変更の混入がないことは、変更のあった全ファイルについて空白を除いたトークン列を比較して確認した。`AnimationSystem.cpp` 以外に意味の変わった箇所はない。

## 残った観察（今回は対処しない）

`BlockIndent` の仕様上避けにくく、コードベース全体で一貫しているため許容範囲と判断した。しばらく運用して問題を感じた場合に再検討する。

- 引数が 1 個のとき、閉じ括弧だけが独立行に残る（`TEST_CASE("…"` の次行が `) {` になるなど）
- ラムダの仮引数リスト閉じ括弧が独立行になり `) -> std::expected<…>` と続く
- 要素数の多い初期化子リストは `BlockIndent` の対象外で、従来どおり桁揃えされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
