### PR TITLE
未使用の BorderStyle と PieDrawable を削除

### DIFF
--- a/Ash2/src/Component/Drawable.hpp
+++ b/Ash2/src/Component/Drawable.hpp
@@ -3,12 +3,6 @@
 
 #include <variant>
 
-/// @brief 枠線スタイル
-struct BorderStyle {
-  ColorF color;
-  double thickness;
-};
-
 /// @brief WorldPos を描画形状内のどの点に合わせるか
 enum class DrawAnchor : uint8 {
   /// 形状の中心
@@ -21,27 +15,12 @@ enum class DrawAnchor : uint8 {
 struct RectDrawable {
   /// 描画サイズ（幅・高さ）
   SizeF size;
-  /// none = 枠線なし
-  Optional<BorderStyle> border;
   DrawAnchor anchor = DrawAnchor::Center;
 };
 
 /// @brief 円描画データ
 struct CircleDrawable {
   double radius;
-  /// none = 枠線なし
-  Optional<BorderStyle> border;
-};
-
-/// @brief 扇形描画データ
-struct PieDrawable {
-  double radius;
-  /// ラジアン、12時方向から時計回り
-  double startAngle;
-  /// ラジアン
-  double angle;
-  /// none = 枠線なし
-  Optional<BorderStyle> border;
 };
 
 /// @brief テクスチャ描画データ
@@ -53,5 +32,4 @@ struct TextureDrawable {
 };
 
 /// @brief 描画コンポーネント（描画形状の variant）
-using Drawable =
-    std::variant<RectDrawable, CircleDrawable, PieDrawable, TextureDrawable>;
+using Drawable = std::variant<RectDrawable, CircleDrawable, TextureDrawable>;

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -48,34 +48,10 @@ void DrawSystem::Draw(const entt::registry& registry) {
                 }
               }();
               rect.draw(color);
-              if (shape.border) {
-                rect.drawFrame(shape.border->thickness, shape.border->color);
-              }
             },
             [&screenPos, &color](const CircleDrawable& shape) {
               const Circle circle{screenPos, shape.radius};
               circle.draw(color);
-              if (shape.border) {
-                circle.drawFrame(shape.border->thickness, shape.border->color);
-              }
-            },
-            [&screenPos, &color](const PieDrawable& shape) {
-              const Circle circle{screenPos, shape.radius};
-              circle.drawPie(shape.startAngle, shape.angle, color);
-              if (shape.border) {
-                const auto& b = *shape.border;
-                circle.drawArc(
-                    shape.startAngle, shape.angle, 0.0, b.thickness, b.color
-                );
-                const Vec2 p1 =
-                    screenPos + Vec2{Circular{shape.radius, shape.startAngle}};
-                const Vec2 p2 =
-                    screenPos +
-                    Vec2{Circular{shape.radius, shape.startAngle + shape.angle}
-                    };
-                Line{screenPos, p1}.draw(b.thickness, b.color);
-                Line{screenPos, p2}.draw(b.thickness, b.color);
-              }
             },
             [&screenPos, &color](const TextureDrawable& shape) {
               const Vec2 anchorPos = screenPos + shape.drawOffset;

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -39,17 +39,15 @@
 ## 描画データ型
 
 [`Component/Drawable.hpp`](../Ash2/src/Component/Drawable.hpp) が定義する。
-`Drawable` は `variant<RectDrawable, CircleDrawable, PieDrawable, TextureDrawable>`。
+`Drawable` は `variant<RectDrawable, CircleDrawable, TextureDrawable>`。
 色は形状側ではなく [`DrawColor`](../Ash2/src/Component/DrawColor.hpp) が一括で持つ
 （上記「コンポーネント一覧」参照）。
 
 | 名前 | 役割 |
 |---|---|
-| `RectDrawable` | 矩形描画（サイズ・枠線・`DrawAnchor`） |
-| `CircleDrawable` | 円描画（半径・枠線） |
-| `PieDrawable` | 扇形描画（半径・開始角・角度・枠線）。角度は12時方向から時計回りのラジアン |
+| `RectDrawable` | 矩形描画（サイズ・`DrawAnchor`） |
+| `CircleDrawable` | 円描画（半径） |
 | `TextureDrawable` | テクスチャ描画（`TextureRegion`・描画オフセット・`DrawAnchor`） |
-| `BorderStyle` | 枠線スタイル（色・太さ）。各形状の `border` が `none` なら枠線なし。`DrawColor` の影響は受けず常に不透明で描画される（構築箇所ゼロの未使用コード、整理は #251） |
 | `DrawAnchor` | `WorldPos` を形状のどこに合わせるか（`Center` / `BottomCenter`）。`RectDrawable` と `TextureDrawable` のみが持ち、既定は `Center` |
 
 ---


### PR DESCRIPTION
close #251

## 概要

構築箇所がゼロだった `BorderStyle`（枠線）と `PieDrawable`（扇形）を削除した。あわせて `RectDrawable` / `CircleDrawable` の `border` メンバと、`DrawSystem` の枠線描画・扇形描画の分岐も削除している。

## 導入経緯（git log での調査結果）

- `PieDrawable` は #44 でプレイヤーの仮描画用に追加された（胴体を扇形、頭・手・足を円で描画）
- `BorderStyle` は #52 で同じ仮描画に輪郭を足すために追加された
- #54 でプレイヤー描画がスプライトへ置き換わり、`72e8ea2` が `DemoPhase` から `PieDrawable` と `border` の構築を削除した。以降どこからも構築されていない

## 削除と判断した理由

- 攻撃判定の可視化は光の珠として `CircleDrawable` で実現済みで、扇形を使っていない
- ロック（遠距離照準）は「実際の見た目より大きめの円」で判定する設計で、扇形の要件がない
- 当たり判定はカプセルのため、デバッグ表示を足すとしても扇形にはならない

## 副次的な効果

#250 で塗り色は `DrawColor` に移ったが、`BorderStyle::color` だけが variant の中に色を残していた。そのため `FadeOut` の透過が枠線に効かず、消えかけでも枠線だけ不透明になる不整合があった。今回の削除で「色は `DrawColor` が一括で持つ」が例外なく成立する。

## 見送った選択肢

- 枠線を残し、枠線色を `DrawColor` 由来にする案 — 塗りと枠線で別色を指定できなくなり、枠線を持つ意味が薄れる
- ロックカーソル用に `CircleDrawable::border` だけ残す案 — カーソルは半ロックとロック確定の区別や追尾が要り、単なる枠線では足りない。必要になった時点で要件に合う描画型を足す方がよい

## 影響

削除した分岐は `border` が常に `none` で到達不能だったため、描画結果は変わらない。`Drawable` の構築箇所はすべて designated initializer のため、メンバ削除による位置ずれの影響もない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)