### PR TITLE
近接コンボ1段目の当たり判定を調整する

### DIFF
--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -3,7 +3,7 @@ jump_speed = 400.0
 gravity = 980.0
 
 [melee]
-cap_mid_h = 30.0
+cap_mid_h = 24.0
 reach     = 60.0
 damage    = 20
 
@@ -13,7 +13,7 @@ windup_sec        = 0.05
 active_sec        = 0.10
 recovery_a_sec    = 0.00
 recovery_b_sec    = 0.20
-radius            = 25.0
+radius            = 18.0
 slash_rise_height = 0.0
 hitstop_sec       = 0.05
 


### PR DESCRIPTION
近接コンボ1段目（Thrust）の数値をプレイテストで調整した。close #229

## 変更内容

`Ash2/App/assets/config/player.toml` の2値のみ変更。

| キー | 初期値 | 確定値 |
|---|---|---|
| `radius`（1段目） | 25.0 | 18.0 |
| `cap_mid_h`（`[melee]` 3段共通） | 30.0 | 24.0 |

時間4項目（`windup_sec` / `active_sec` / `recovery_a_sec` / `recovery_b_sec`）・`reach`・`trajectory` はいずれも初期値のまま確定した。

## `recovery_a_sec` を 0.00 のまま据え置いた理由

後隙AとBの差はキャンセルを受け付けるかどうかだけで、ポーズの表示には差がない。振り切ったポーズはキャンセルしなければ後隙Bで全て見えるため、余韻のために後隙Aを置く必要がない。

一方で後隙Aを増やすと副作用がある。

- コンボ入力: 先行入力として予約されるので技は出るが、後隙Aが明けるまで遅延する
- ダッシュキャンセル: 予約されず入力が捨てられ、後隙Bに入ってから押し直しになる

つまり見せられる絵が増えないまま、キャンセルの効きだけが鈍る。ダッシュでは忙しない動きを避けるため意図的に後隙Aを置いているが（`motion_design.md` 参照）、1段目はコンボの入り口で繋がりの良さを優先する箇所なので 0.00 が一貫する。

## `cap_mid_h` の波及について

`cap_mid_h` は `[melee]` 直下の3段共通の値のため、2段目（#230）・3段目（#231）にも影響する。1段目基準で決めた値であり、後続の段で不都合が出た時点で段別化を別Issueに切る方針。

## `motion_design.md` を変更していない理由

Issue のスコープに「近接コンボ表の1段目の行を実装値に更新する」を挙げていたが、変更不要だった。表に載っているのは時間4項目のみで、いずれも初期値のまま確定したため。`radius` / `cap_mid_h` は表に数値として載っておらず、当たり判定欄は「前方・近距離」という定性的な記述のみ。実装と記載はすでに一致している。

## 経緯

消え際が未実装のうちは `active_sec` / `reach` / `cap_mid_h` を判断できず本Issueを中断していた。#250（攻撃判定エフェクトの消え際）の完了を受けて再開し、消え際つきで残りを確定した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
