### PR TITLE
constexpr 定数の接頭辞を K から k に変更する

### DIFF
--- a/Ash2/.clang-tidy
+++ b/Ash2/.clang-tidy
@@ -46,13 +46,11 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.EnumConstantCase
     value: CamelCase
-  # constexpr 定数: K + PascalCase
-  # 接頭辞 K を除いた残りが PascalCase か検査されるため、
-  # K の次が小文字になる語は K を重ねる（例: Knockback → KKnockbackForce）
+  # constexpr 定数: k + PascalCase
   - key: readability-identifier-naming.ConstexprVariableCase
     value: CamelCase
   - key: readability-identifier-naming.ConstexprVariablePrefix
-    value: K
+    value: k
   # マジックナンバー: 0, 1, -1, 2 は例外
   - key: readability-magic-numbers.IgnoredIntegerValues
     value: '0;1;-1;2'

--- a/Ash2/src/Component/DrawColor.hpp
+++ b/Ash2/src/Component/DrawColor.hpp
@@ -2,11 +2,11 @@
 #include <Siv3D.hpp>
 
 /// @brief DrawColor を持たないエンティティに使う既定色（白・不透明）
-inline constexpr ColorF KDefaultDrawColor{1.0};
+inline constexpr ColorF kDefaultDrawColor{1.0};
 
 /// @brief このエンティティを描画するときの色
 ///
 /// 図形では塗り色、テクスチャでは乗算色として使う。
 struct DrawColor {
-  ColorF color = KDefaultDrawColor;
+  ColorF color = kDefaultDrawColor;
 };

--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -24,7 +24,7 @@ inline InputState InputDeviceSelector::update() {
     m_activeDevice = Device::Keyboard;
   }
   // 最後に入力があったデバイスへ切り替える
-  const Vec2 stickAxis = XInputAction::KLeftThumbDeadZone(
+  const Vec2 stickAxis = XInputAction::kLeftThumbDeadZone(
       Vec2{XInput(0).leftThumbX, XInput(0).leftThumbY}
   );
   if (XInput(0).isConnected() &&

--- a/Ash2/src/Input/XInputAction.hpp
+++ b/Ash2/src/Input/XInputAction.hpp
@@ -9,7 +9,7 @@
 struct XInputAction {
   /// 左スティックに適用するデッドゾーン（`InputDeviceSelector`
   /// もスティック傾き判定に同じ定数を参照する）
-  static constexpr DeadZone KLeftThumbDeadZone{
+  static constexpr DeadZone kLeftThumbDeadZone{
       .size = 0.24, .maxValue = 1.0, .type = DeadZoneType::Circular
   };
 
@@ -23,7 +23,7 @@ inline InputState XInputAction::ToInputState() {
   // `XInput(0)` は const 参照のため `setLeftThumbDeadZone()` を直接呼べず、
   // ここで明示的にデッドゾーンを適用する
   const Vec2 stickAxis =
-      KLeftThumbDeadZone(Vec2{pad.leftThumbX, pad.leftThumbY});
+      kLeftThumbDeadZone(Vec2{pad.leftThumbX, pad.leftThumbY});
 
   const Vec2 dpadAxis{
       (pad.buttonRight.pressed() ? 1.0 : 0.0) -

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -9,11 +9,11 @@
 #include "System/AnimationSystem.hpp"
 
 namespace {
-constexpr double KBgBrightness = 0.15;
-constexpr int32 KTitleX = 20;
-constexpr int32 KTitleY = 20;
-constexpr int32 KClipInfoY = 50;
-constexpr int32 KHintY = 80;
+constexpr double kBgBrightness = 0.15;
+constexpr int32 kTitleX = 20;
+constexpr int32 kTitleY = 20;
+constexpr int32 kClipInfoY = 50;
+constexpr int32 kHintY = 80;
 }  // namespace
 
 AnimationViewerPhase::AnimationViewerPhase(const Param& param)
@@ -85,16 +85,16 @@ IPhase::PhaseCommand AnimationViewerPhase::update(
 
   AnimationSystem::Update(registry, frameData.dt);
 
-  Scene::SetBackground(ColorF{KBgBrightness});
-  m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(KTitleX, KTitleY);
+  Scene::SetBackground(ColorF{kBgBrightness});
+  m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(kTitleX, kTitleY);
   if (!m_clips.empty()) {
     m_font(U"Clip [{}/{}]: {}"_fmt(
                m_clipIndex + 1, m_clips.size(), m_clips[m_clipIndex]
            ))
-        .draw(KTitleX, KClipInfoY);
+        .draw(kTitleX, kClipInfoY);
   }
   m_font(U"← → : clip  F : flip  Esc : back")
-      .draw(KTitleX, KHintY, Palette::Gray);
+      .draw(kTitleX, kHintY, Palette::Gray);
 
   return PhaseCommand::None();
 }

--- a/Ash2/src/Phase/AnimationViewerPhase.hpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.hpp
@@ -26,7 +26,7 @@ class AnimationViewerPhase : public IPhase {
   void onBeforePop(entt::registry& registry) override;
 
  private:
-  static constexpr int32 KFontSize = 20;
+  static constexpr int32 kFontSize = 20;
 
   /// AnimationDataRegistry のキー
   String m_dataKey;
@@ -35,5 +35,5 @@ class AnimationViewerPhase : public IPhase {
   /// クリップ名の配列（ソート済み）
   Array<String> m_clips;
   size_t m_clipIndex = 0;
-  Font m_font{KFontSize};
+  Font m_font{kFontSize};
 };

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -34,9 +34,9 @@
 #include "System/ProjectileSystem.hpp"
 #include "System/StaminaSystem.hpp"
 
-constexpr ColorF KDummyColor = {0.8, 0.2, 0.2};
-constexpr int32 KPlayerMaxHp = 100;
-constexpr int32 KPlayerMaxStamina = 100;
+constexpr ColorF kDummyColor = {0.8, 0.2, 0.2};
+constexpr int32 kPlayerMaxHp = 100;
+constexpr int32 kPlayerMaxStamina = 100;
 
 void PlayerTestPhase::onAfterPush(entt::registry& registry) {
   const auto& cfg = registry.ctx().get<PlayerConfig>();
@@ -55,11 +55,11 @@ void PlayerTestPhase::onAfterPush(entt::registry& registry) {
       SpriteAnimation{.dataKey = U"player", .currentClip = U"idle"}
   );
   registry.emplace<Hp>(
-      m_playerRoot, Hp{.max = KPlayerMaxHp, .current = KPlayerMaxHp}
+      m_playerRoot, Hp{.max = kPlayerMaxHp, .current = kPlayerMaxHp}
   );
   registry.emplace<Stamina>(
       m_playerRoot,
-      Stamina{.max = KPlayerMaxStamina, .current = KPlayerMaxStamina}
+      Stamina{.max = kPlayerMaxStamina, .current = kPlayerMaxStamina}
   );
   registry.emplace<Motion>(m_playerRoot, PlayerMotion::Neutral{});
   AnimationSystem::Update(registry, 0.0);
@@ -83,7 +83,7 @@ entt::entity PlayerTestPhase::spawnEnemy(entt::registry& registry) {
       enemy,
       RectDrawable{.size = enemyCfg.size, .anchor = DrawAnchor::BottomCenter}
   );
-  registry.emplace<DrawColor>(enemy, DrawColor{.color = KDummyColor});
+  registry.emplace<DrawColor>(enemy, DrawColor{.color = kDummyColor});
   registry.emplace<Collider>(
       enemy,
       Collider{

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -4,12 +4,12 @@
 #include "Phase/PlayerTestPhase.hpp"
 
 namespace {
-constexpr double KBgBrightness = 0.1;
-constexpr int32 KTitleX = 40;
-constexpr int32 KTitleY = 40;
-constexpr int32 KItemX = 60;
-constexpr int32 KItemBaseY = 100;
-constexpr int32 KItemSpacing = 40;
+constexpr double kBgBrightness = 0.1;
+constexpr int32 kTitleX = 40;
+constexpr int32 kTitleY = 40;
+constexpr int32 kItemX = 60;
+constexpr int32 kItemBaseY = 100;
+constexpr int32 kItemSpacing = 40;
 }  // namespace
 
 void TestMenuPhase::onAfterPush(entt::registry& /*registry*/) {
@@ -47,15 +47,15 @@ IPhase::PhaseCommand TestMenuPhase::update(
     return PhaseCommand::Push(std::move(phase));
   }
 
-  Scene::SetBackground(ColorF{KBgBrightness});
-  m_font(U"Test Menu").draw(KTitleX, KTitleY);
+  Scene::SetBackground(ColorF{kBgBrightness});
+  m_font(U"Test Menu").draw(kTitleX, kTitleY);
 
   for (size_t i = 0; i < m_items.size(); ++i) {
     const ColorF color =
         (i == m_selectedIndex) ? Palette::Yellow : Palette::White;
     m_font(m_items[i].label)
         .draw(
-            KItemX, KItemBaseY + static_cast<double>(i) * KItemSpacing, color
+            kItemX, kItemBaseY + static_cast<double>(i) * kItemSpacing, color
         );
   }
 

--- a/Ash2/src/Phase/TestMenuPhase.hpp
+++ b/Ash2/src/Phase/TestMenuPhase.hpp
@@ -30,9 +30,9 @@ class TestMenuPhase : public IPhase {
     std::function<std::unique_ptr<IPhase>(entt::registry&)> create;
   };
 
-  static constexpr int32 KFontSize = 24;
+  static constexpr int32 kFontSize = 24;
 
   Array<MenuItem> m_items;
   size_t m_selectedIndex = 0;
-  Font m_font{KFontSize};
+  Font m_font{kFontSize};
 };

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -20,7 +20,7 @@ void DrawSystem::Draw(const entt::registry& registry) {
     const auto* drawColor = registry.try_get<DrawColor>(entity);
     entries.push_back(
         {std::cref(pos), std::cref(drawable),
-         (drawColor != nullptr) ? drawColor->color : KDefaultDrawColor}
+         (drawColor != nullptr) ? drawColor->color : kDefaultDrawColor}
     );
   }
 

--- a/Ash2/src/System/EnemyMotionSystem.cpp
+++ b/Ash2/src/System/EnemyMotionSystem.cpp
@@ -14,7 +14,7 @@ namespace EnemyMotion {
 namespace {
 
 /// @brief ひるみ表現の最大縮小率（縦方向）
-constexpr double KMaxShrinkRatio = 0.2;
+constexpr double kMaxShrinkRatio = 0.2;
 
 }  // namespace
 
@@ -41,7 +41,7 @@ Optional<Motion> Tick(
         // duration の中間で最も縮み、両端（開始・終了）で原寸に近づく
         const double progress = state.remaining / cfg.staggerSec;
         const double shrink =
-            (1.0 - Abs(progress * 2.0 - 1.0)) * KMaxShrinkRatio;
+            (1.0 - Abs(progress * 2.0 - 1.0)) * kMaxShrinkRatio;
         rect->size.y = cfg.size.y * (1.0 - shrink);
       }
     }

--- a/Ash2/src/System/HitSystem.cpp
+++ b/Ash2/src/System/HitSystem.cpp
@@ -16,7 +16,7 @@ struct Segment {
 /// @brief 2線分間の最近接距離の二乗を返す
 [[nodiscard]] double SegmentDistSq(Segment segA, Segment segB) {
   // 線分の長さの二乗がこの値以下のとき点とみなす
-  constexpr double KDegenerateThreshold = 1e-10;
+  constexpr double kDegenerateThreshold = 1e-10;
 
   const Vec3 d1 = segA.end - segA.start;
   const Vec3 d2 = segB.end - segB.start;
@@ -28,14 +28,14 @@ struct Segment {
   double s = 0.0;
   double t = 0.0;
 
-  if (a <= KDegenerateThreshold && e <= KDegenerateThreshold) {
+  if (a <= kDegenerateThreshold && e <= kDegenerateThreshold) {
     return r.dot(r);
   }
-  if (a <= KDegenerateThreshold) {
+  if (a <= kDegenerateThreshold) {
     t = Clamp(f / e, 0.0, 1.0);
   } else {
     const double c = d1.dot(r);
-    if (e <= KDegenerateThreshold) {
+    if (e <= kDegenerateThreshold) {
       s = Clamp(-c / a, 0.0, 1.0);
     } else {
       const double b = d1.dot(d2);

--- a/Ash2/src/System/HudSystem.hpp
+++ b/Ash2/src/System/HudSystem.hpp
@@ -13,30 +13,30 @@ class HudSystem {
   /// @brief Player + Hp + Stamina を持つエンティティの HP /
   /// スタミナゲージを画面左上に描画する
   static void Draw(const entt::registry& registry) {
-    constexpr double KBarX = 16.0;
-    constexpr double KHpBarY = 16.0;
-    constexpr double KStaminaBarY = 40.0;
-    constexpr double KBarWidth = 200.0;
-    constexpr double KBarHeight = 18.0;
-    constexpr ColorF KBgColor{0.2, 0.2, 0.2, 0.7};
-    constexpr ColorF KHpColor{0.2, 0.8, 0.2};
-    constexpr ColorF KStaminaColor{0.9, 0.8, 0.1};
+    constexpr double kBarX = 16.0;
+    constexpr double kHpBarY = 16.0;
+    constexpr double kStaminaBarY = 40.0;
+    constexpr double kBarWidth = 200.0;
+    constexpr double kBarHeight = 18.0;
+    constexpr ColorF kBgColor{0.2, 0.2, 0.2, 0.7};
+    constexpr ColorF kHpColor{0.2, 0.8, 0.2};
+    constexpr ColorF kStaminaColor{0.9, 0.8, 0.1};
 
     auto view = registry.view<const Player, const Hp, const Stamina>();
     for (const auto& [entity, hp, stamina] : view.each()) {
-      RectF{KBarX, KHpBarY, KBarWidth, KBarHeight}.draw(KBgColor);
+      RectF{kBarX, kHpBarY, kBarWidth, kBarHeight}.draw(kBgColor);
       if (hp.max > 0) {
         const double hpRatio =
             Clamp(static_cast<double>(hp.current) / hp.max, 0.0, 1.0);
-        RectF{KBarX, KHpBarY, KBarWidth * hpRatio, KBarHeight}.draw(KHpColor);
+        RectF{kBarX, kHpBarY, kBarWidth * hpRatio, kBarHeight}.draw(kHpColor);
       }
 
-      RectF{KBarX, KStaminaBarY, KBarWidth, KBarHeight}.draw(KBgColor);
+      RectF{kBarX, kStaminaBarY, kBarWidth, kBarHeight}.draw(kBgColor);
       if (stamina.max > 0) {
         const double staminaRatio =
             Clamp(static_cast<double>(stamina.current) / stamina.max, 0.0, 1.0);
-        RectF{KBarX, KStaminaBarY, KBarWidth * staminaRatio, KBarHeight}.draw(
-            KStaminaColor
+        RectF{kBarX, kStaminaBarY, kBarWidth * staminaRatio, kBarHeight}.draw(
+            kStaminaColor
         );
       }
 

--- a/Ash2/src/System/PlayerMotion/Helper.cpp
+++ b/Ash2/src/System/PlayerMotion/Helper.cpp
@@ -16,7 +16,7 @@ namespace PlayerMotion {
 
 namespace {
 
-constexpr ColorF KMeleeOrbColor = {1.0, 0.9, 0.5};
+constexpr ColorF kMeleeOrbColor = {1.0, 0.9, 0.5};
 
 /// @brief 攻撃判定エンティティ（光の珠）を生成する
 ///
@@ -50,7 +50,7 @@ entt::entity SpawnAttackHitbox(
       }
   );
   registry.emplace<Drawable>(hitbox, CircleDrawable{.radius = spec.radius});
-  registry.emplace<DrawColor>(hitbox, DrawColor{.color = KMeleeOrbColor});
+  registry.emplace<DrawColor>(hitbox, DrawColor{.color = kMeleeOrbColor});
   return hitbox;
 }
 

--- a/Ash2/src/System/PlayerMotion/Ranged.cpp
+++ b/Ash2/src/System/PlayerMotion/Ranged.cpp
@@ -19,7 +19,7 @@ namespace PlayerMotion {
 
 namespace {
 
-constexpr ColorF KBulletColor = {0.9, 0.9, 0.3};
+constexpr ColorF kBulletColor = {0.9, 0.9, 0.3};
 
 /// @brief 指定クリップの再生時間（秒）を返す
 /// @return クリップが見つからない場合は 0.0
@@ -56,7 +56,7 @@ void SpawnProjectile(
   registry.emplace<Drawable>(
       bullet, CircleDrawable{.radius = cfg.ranged.radius}
   );
-  registry.emplace<DrawColor>(bullet, DrawColor{.color = KBulletColor});
+  registry.emplace<DrawColor>(bullet, DrawColor{.color = kBulletColor});
   registry.emplace<Projectile>(bullet);
 }
 

--- a/Ash2/src/System/StaminaSystem.cpp
+++ b/Ash2/src/System/StaminaSystem.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 // 99% 以上を満タンとみなして丸める閾値（浮動小数点誤差が残り続けるのを防ぐ）
-constexpr double KFullThreshold = 0.99;
+constexpr double kFullThreshold = 0.99;
 }  // namespace
 
 void StaminaSystem::Update(entt::registry& registry, double dt) {
@@ -42,7 +42,7 @@ void StaminaSystem::Update(entt::registry& registry, double dt) {
     }
 
     // 満タンに近い残量を丸めて微小な誤差が残り続けるのを防ぐ
-    if (stamina.current >= static_cast<int32>(stamina.max * KFullThreshold)) {
+    if (stamina.current >= static_cast<int32>(stamina.max * kFullThreshold)) {
       stamina.current = stamina.max;
     }
   }

--- a/Ash2/tests/TestAnimationData.cpp
+++ b/Ash2/tests/TestAnimationData.cpp
@@ -4,7 +4,7 @@
 #include "Config/AnimationData.hpp"
 
 TEST_CASE("AnimationData::FromToml - parses top-level fields correctly") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "texture = \"assets/images/player.png\"\n"
       "width = 32\n"
       "height = 64\n"
@@ -12,7 +12,7 @@ TEST_CASE("AnimationData::FromToml - parses top-level fields correctly") {
       "[draw_offset]\n"
       "x = -8.0\n"
       "y = -32.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   const AnimationData data = AnimationData::FromToml(reader);
   REQUIRE(data.textureKey == U"assets/images/player.png");
   REQUIRE(data.size.x == 32);
@@ -22,7 +22,7 @@ TEST_CASE("AnimationData::FromToml - parses top-level fields correctly") {
 }
 
 TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "texture = \"assets/images/enemy.png\"\n"
       "width = 48\n"
       "height = 48\n"
@@ -40,7 +40,7 @@ TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
       "row = 1\n"
       "count = 6\n"
       "speed = 12.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   const AnimationData data = AnimationData::FromToml(reader);
   REQUIRE(data.clips.contains(U"idle"));
   REQUIRE(data.clips.at(U"idle").row == 0);
@@ -53,19 +53,19 @@ TEST_CASE("AnimationData::FromToml - parses clip entries correctly") {
 }
 
 TEST_CASE("AnimationData::FromToml - missing width throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "texture = \"assets/images/player.png\"\n"
       "height = 64\n"
       "\n"
       "[draw_offset]\n"
       "x = -8.0\n"
       "y = -32.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(AnimationData::FromToml(reader), Error);
 }
 
 TEST_CASE("AnimationData::FromToml - missing clip row throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "texture = \"assets/images/player.png\"\n"
       "width = 32\n"
       "height = 64\n"
@@ -77,13 +77,13 @@ TEST_CASE("AnimationData::FromToml - missing clip row throws Error") {
       "[idle]\n"
       "count = 4\n"
       "speed = 8.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(AnimationData::FromToml(reader), Error);
 }
 
 TEST_CASE("AnimationData::FromToml - reserved keys are not treated as clips") {
   // texture / width / height / draw_offset はクリップとして誤認されてはならない
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "texture = \"assets/images/player.png\"\n"
       "width = 32\n"
       "height = 64\n"
@@ -91,7 +91,7 @@ TEST_CASE("AnimationData::FromToml - reserved keys are not treated as clips") {
       "[draw_offset]\n"
       "x = 0.0\n"
       "y = 0.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   const AnimationData data = AnimationData::FromToml(reader);
   REQUIRE_FALSE(data.clips.contains(U"texture"));
   REQUIRE_FALSE(data.clips.contains(U"width"));

--- a/Ash2/tests/TestEnemyConfig.cpp
+++ b/Ash2/tests/TestEnemyConfig.cpp
@@ -4,7 +4,7 @@
 #include "Config/EnemyConfig.hpp"
 
 TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "max_hp = 100\n"
       "size_w = 60.0\n"
       "size_h = 80.0\n"
@@ -19,7 +19,7 @@ TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
       "knockback_sec = 1.00\n"
       "defeated_sec = 0.50\n"
       "respawn_sec = 1.00\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   const EnemyConfig cfg = EnemyConfig::FromToml(reader);
   REQUIRE(cfg.maxHp == 100);
   REQUIRE(cfg.size.x == 60.0);
@@ -38,7 +38,7 @@ TEST_CASE("EnemyConfig::FromToml - parses all fields correctly") {
 }
 
 TEST_CASE("EnemyConfig::FromToml - missing max_hp throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "size_w = 60.0\n"
       "size_h = 80.0\n"
       "capsule_radius = 30.0\n"
@@ -52,7 +52,7 @@ TEST_CASE("EnemyConfig::FromToml - missing max_hp throws Error") {
       "knockback_sec = 1.00\n"
       "defeated_sec = 0.50\n"
       "respawn_sec = 1.00\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(EnemyConfig::FromToml(reader), Error);
 }
 

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -8,7 +8,7 @@
 namespace {
 
 /// @brief 全必須キーを満たす PlayerConfig 用 TOML（テストの基準値）
-constexpr std::string_view KFullToml =
+constexpr std::string_view kFullToml =
     "speed = 150.0\n"
     "jump_speed = 400.0\n"
     "gravity = 900.0\n"
@@ -70,7 +70,7 @@ constexpr std::string_view KFullToml =
 }  // namespace
 
 TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
-  const TOMLReader reader{MemoryViewReader{KFullToml.data(), KFullToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kFullToml.data(), kFullToml.size()}};
   const PlayerConfig cfg = PlayerConfig::FromToml(reader);
   REQUIRE(cfg.speed == 150.0);
   REQUIRE(cfg.jumpSpeed == 400.0);
@@ -91,16 +91,16 @@ TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
 }
 
 TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "speed = 150.0\n"
       "jump_speed = 400.0\n"
       "gravity = 900.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
 }
 
 TEST_CASE("PlayerConfig::FromToml - missing speed throws Error") {
-  std::string toml{KFullToml};
+  std::string toml{kFullToml};
   const auto pos = toml.find("speed = 150.0\n");
   REQUIRE(pos != std::string::npos);
   toml.erase(pos, std::string_view{"speed = 150.0\n"}.size());
@@ -112,7 +112,7 @@ TEST_CASE(
     "PlayerConfig::FromToml - missing melee.stage trajectory throws Error "
     "(not \"unknown value\")"
 ) {
-  std::string toml{KFullToml};
+  std::string toml{kFullToml};
   const auto pos = toml.find("trajectory = \"thrust\"\n");
   REQUIRE(pos != std::string::npos);
   toml.erase(pos, std::string_view{"trajectory = \"thrust\"\n"}.size());
@@ -131,7 +131,7 @@ TEST_CASE(
     "PlayerConfig::FromToml - unknown melee.stage trajectory value throws "
     "Error"
 ) {
-  std::string toml{KFullToml};
+  std::string toml{kFullToml};
   const auto pos = toml.find("trajectory = \"thrust\"\n");
   REQUIRE(pos != std::string::npos);
   toml.replace(

--- a/Ash2/tests/TestProjectileSystem.cpp
+++ b/Ash2/tests/TestProjectileSystem.cpp
@@ -63,9 +63,9 @@ TEST_CASE("ProjectileSystem - destroys bullet when off-screen") {
   entt::registry registry;
 
   // 実行環境の画面サイズに依存しないよう、十分に遠い座標を使う
-  constexpr double KFarAway = 1.0e9;
+  constexpr double kFarAway = 1.0e9;
   const auto bullet = MakeBullet(
-      registry, WorldPos{.w = KFarAway, .h = 0.0, .d = 0.0},
+      registry, WorldPos{.w = kFarAway, .h = 0.0, .d = 0.0},
       Velocity{.w = 0.0, .h = 0.0, .d = 0.0}
   );
 

--- a/Ash2/tests/TestScenarioData.cpp
+++ b/Ash2/tests/TestScenarioData.cpp
@@ -6,12 +6,12 @@
 #include "Phase/WaitPhase.hpp"
 
 TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"wait\"\n"
       "duration = 1.5\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   const ScenarioData data = ScenarioData::FromToml(reader, GetPhaseLoaders());
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
@@ -24,12 +24,12 @@ TEST_CASE("ScenarioData::FromToml - push action creates StepPush") {
 }
 
 TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "[[intro]]\n"
       "action = \"reset\"\n"
       "phase = \"wait\"\n"
       "duration = 2.0\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   const ScenarioData data = ScenarioData::FromToml(reader, GetPhaseLoaders());
   REQUIRE(data.sections.contains(U"intro"));
   REQUIRE(data.sections.at(U"intro").size() == 1);
@@ -42,38 +42,38 @@ TEST_CASE("ScenarioData::FromToml - reset action creates StepReset") {
 }
 
 TEST_CASE("ScenarioData::FromToml - unknown phase name throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"nonexistent\"\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - unknown action throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "[[intro]]\n"
       "action = \"fly\"\n"
       "phase = \"wait\"\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - missing duration throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"wait\"\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 
 TEST_CASE("ScenarioData::FromToml - missing param throws Error") {
-  constexpr std::string_view KToml =
+  constexpr std::string_view kToml =
       "[[intro]]\n"
       "action = \"push\"\n"
       "phase = \"scenario\"\n";
-  const TOMLReader reader{MemoryViewReader{KToml.data(), KToml.size()}};
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
   REQUIRE_THROWS_AS(ScenarioData::FromToml(reader, GetPhaseLoaders()), Error);
 }
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -18,7 +18,7 @@
 | [`LocalOffset`](../Ash2/src/Component/LocalOffset.hpp) | 親からの相対座標（Hierarchy 付きエンティティのみ） |
 | [`Hierarchy`](../Ash2/src/Component/Hierarchy.hpp) | 親子関係（双方向連結リスト、static メンバで操作） |
 | [`Drawable`](../Ash2/src/Component/Drawable.hpp) | 描画形状の variant。詳細は下記「描画データ型」参照 |
-| [`DrawColor`](../Ash2/src/Component/DrawColor.hpp) | 描画色（`ColorF`）。図形では塗り色、テクスチャでは乗算色として使う。未所持は白・不透明（`KDefaultDrawColor`）として扱われる |
+| [`DrawColor`](../Ash2/src/Component/DrawColor.hpp) | 描画色（`ColorF`）。図形では塗り色、テクスチャでは乗算色として使う。未所持は白・不透明（`kDefaultDrawColor`）として扱われる |
 | [`SpriteAnimation`](../Ash2/src/Component/SpriteAnimation.hpp) | アニメーション再生状態（per-entity）。共有データは `AnimationDataRegistry` を `dataKey` で参照する |
 | [`Name`](../Ash2/src/Component/Name.hpp) | エンティティ名（`const String`、構築後不変。NameLookup と対応） |
 | [`Player`](../Ash2/src/Component/Player.hpp) | プレイヤータグ（データなし） |
@@ -303,7 +303,7 @@
   `knockbackSec`、`defeatedSec`/`respawnSec`）を持つ
 - `Knockback` の重力加速度は専用の値を持たず、`PlayerConfig::gravity` を敵にもそのまま付与して
   流用する（`PlayerTestPhase::spawnEnemy` 参照）
-- 色は toml 化せず `PlayerTestPhase.cpp` 側の定数（`KDummyColor`）に残す（パーサを増やさないため）
+- 色は toml 化せず `PlayerTestPhase.cpp` 側の定数（`kDummyColor`）に残す（パーサを増やさないため）
 - リアクション Lv（`ReactionLevel`）自体は config 化せず、各 `PlayerMotion` の `Tick()` が固定値で
   割り当てる。スタミナ連動の降格表を含む config 化は #233 のスコープ
 
@@ -350,7 +350,7 @@
 以下に正規化済み」という不変条件を持つ。この保証の責任は `toInputState()` を実装する各入力レイヤー側に
 あり、`PlayerMotion::Tick(Neutral&, ...)` は無条件にこの値を信頼してそのまま速度計算に使う
 （System 側で正規化やクランプを行わない）。`XInputAction` は左スティックのデッドゾーン定数
-（`KLeftThumbDeadZone`、`InputDeviceSelector` も参照する公開 `static constexpr` メンバ）を適用し、
+（`kLeftThumbDeadZone`、`InputDeviceSelector` も参照する公開 `static constexpr` メンバ）を適用し、
 十字ボタンの軸ベクトルと加算したうえで `limitLength(1.0)` により正規化する。
 
 **フェーズの直接キー入力：** `TestMenuPhase`（↑↓/Enter）・`PlayerTestPhase`（Esc）・
@@ -436,7 +436,7 @@
 
 - `Hierarchy` のメンバは必ず static メンバ関数（Attach/Detach/DestroyWithChildren）経由で操作する。
 - `Drawable` の型変更は `std::visit` を使い、DrawSystem と AnimationSystem の両方への影響を確認する。
-- 図形（`Drawable`）に `DrawColor` を付け忘れると白（`KDefaultDrawColor`）で描かれる。意図した色にしたい場合は忘れず付与すること。
+- 図形（`Drawable`）に `DrawColor` を付け忘れると白（`kDefaultDrawColor`）で描かれる。意図した色にしたい場合は忘れず付与すること。
 - 新クラス追加時は `Ash2.vcxproj` と `Ash2.vcxproj.filters` にも追加が必要。
 - `NameLookup` への挿入・削除は `NameLookupSystem::Connect` で自動化されている（`Name` コンポーネントの追加・削除に連動）。手動での `NameLookup[key] = entity` 登録は不要。
 - `Motion` に新しい状態型を追加したときは、その型に `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。`MotionSystem::Update` の `std::visit` が `MotionState` concept（`MotionSystem.hpp`）で制約されているため。


### PR DESCRIPTION
## 概要

`constexpr` 定数の接頭辞を大文字 `K` から小文字 `k` に変更する。

## 背景

Google C++ Style Guide の `kCamelCase` が一般的な記法であり、本プロジェクトは `.clang-format` でも Google スタイルを基礎としている。

また `readability-identifier-naming` は接頭辞を除いた残りが PascalCase かを検査するため、大文字 `K` では `Knockback` のように次が小文字になる語で `KKnockbackForce` と K を重ねる必要があった。小文字にすればこの回避策は不要になる。

## 変更内容

- `.clang-tidy` の `ConstexprVariablePrefix` を `k` に変更し、K を重ねる回避策の注記を削除
- 定数 30 種・133 箇所をリネーム
- `docs/REFERENCE.md` の参照 4 箇所を更新

## 単一コミットにした理由

`.clang-tidy` は `WarningsAsErrors: '*'` を設定している。設定変更とリネームを分けると、その間の状態で既存の定数がすべてエラーになる。

なお `tools/run-tidy.sh` は引数で渡された `.cpp` のみを対象とするため、部分的な移行では未変更のファイルが検査されず素通りする。ヘッダ内の定数は `--header-filter` により一斉に露見するため、段階的な移行は成立しない。

## 確認

format・clang-tidy・build・test をすべて実行し、問題なし（170 テストケース、425 アサーション通過）。

ビルド警告 2 件（`Main.cpp` の C4189、`HudSystem.hpp` の C4702）は本変更以前から存在するもので、差分はリネームのみであることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)