### PR TITLE
スプライトのぼやけを解消する（描画座標の整数化・サンプラー設定）

### DIFF
--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -35,6 +35,7 @@ void Main() {
 
   try {
     RegisterAssets();
+    Scene::SetTextureFilter(TextureFilter::Nearest);
 
     entt::registry registry;
     InitializeRegistry(registry);

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -6,6 +6,8 @@
 #include "Util/Overloaded.hpp"
 
 void DrawSystem::Draw(const entt::registry& registry) {
+  // HUD・フォント描画へ波及させないため、この関数のスコープに閉じる
+  const ScopedRenderStates2D sampler{SamplerState::ClampNearest};
   const Vec2 cameraOffset = Scene::Center();
 
   struct DrawEntry {
@@ -54,7 +56,8 @@ void DrawSystem::Draw(const entt::registry& registry) {
               circle.draw(color);
             },
             [&screenPos, &color](const TextureDrawable& shape) {
-              const Vec2 anchorPos = screenPos + shape.drawOffset;
+              // 図形は AA が効くので丸めない。テクスチャのみ整数化する
+              const Vec2 anchorPos = Math::Round(screenPos + shape.drawOffset);
               switch (shape.anchor) {
                 case DrawAnchor::BottomCenter:
                   shape.region.draw(Arg::bottomCenter(anchorPos), color);

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -134,7 +134,7 @@
 | [`EnemySystem::Update`](../Ash2/src/System/EnemySystem.hpp) | フェーズ内（PlayerTestPhase、ProjectileSystem の後） | `EnemyMotion::Defeated` の残り時間が尽きたエンティティを収集し、`MotionSystem` のビュー走査外でまとめて破棄する |
 | [`FadeOutSystem::Update`](../Ash2/src/System/FadeOutSystem.hpp) | フェーズ内（PlayerTestPhase、EnemySystem の後） | `FadeOut` の残り時間を減算して `DrawColor::color.a`（`get_or_emplace` で確保）に反映し、満了したエンティティを破棄する。`Hitstop` による除外はしない |
 | [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | `Hitstop` を持たない SpriteAnimation の elapsed を進め、切り出した `TextureRegion` を `TextureDrawable` に反映する（`facingRight` なら反転） |
-| [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（HudSystem の前） | WorldPos+Drawable を奥行き順にソートして描画。`DrawColor`（未所持は白・不透明）を塗り色・テクスチャの乗算色として適用する |
+| [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（HudSystem の前） | WorldPos+Drawable を奥行き順にソートして描画。`DrawColor`（未所持は白・不透明）を塗り色・テクスチャの乗算色として適用する。関数スコープに閉じた `ScopedRenderStates2D` で最近傍サンプラーを適用し、`TextureDrawable` の描画位置は `Math::Round` で整数化する（HUD・フォントには波及しない） |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画（プレイヤー 1 体のみ想定）。他のシステムと異なり実装をヘッダに直書きしている |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
 | [`HierarchySystem::Connect`](../Ash2/src/System/HierarchySystem.hpp) | 起動時 | Hierarchy 削除時に Detach を自動呼び出しするシグナル登録 |
@@ -374,7 +374,7 @@
 
 | 名前 | 役割 |
 |---|---|
-| [`Main`](../Ash2/src/Main.cpp) | アプリの入口。アセット登録 → registry 初期化 → `PhaseStack` を生成し、毎フレーム `PhaseStack::update` → `AttachmentSystem` → `DrawSystem` → `HudSystem` を回す。例外は `crash.log` に記録して再 throw。Debug ビルドで環境変数 `ASH2_RUN_TESTS` が設定されていれば Catch2 のテストのみ実行して終了 |
+| [`Main`](../Ash2/src/Main.cpp) | アプリの入口。アセット登録 → `Scene::SetTextureFilter(TextureFilter::Nearest)` → registry 初期化 → `PhaseStack` を生成し、毎フレーム `PhaseStack::update` → `AttachmentSystem` → `DrawSystem` → `HudSystem` を回す。例外は `crash.log` に記録して再 throw。Debug ビルドで環境変数 `ASH2_RUN_TESTS` が設定されていれば Catch2 のテストのみ実行して終了 |
 | [`InitializeRegistry`](../Ash2/src/GameSetup.hpp) | `registry.ctx()` へ `NameLookup` / 各 Config / `AnimationDataRegistry` / `ScenarioData` を登録し、シグナルを接続する |
 | [`ReloadConfig`](../Ash2/src/GameSetup.hpp) | Debug ビルド専用。`PlayerConfig` / `EnemyConfig` / アニメーションデータを再読込する |
 | [`GetAssetList`](../Ash2/src/Asset.hpp) | `Ash2/App/assets/asset_list` を読んでアセットパス一覧を返す |


### PR DESCRIPTION
close #257

## 変更概要

- `DrawSystem::Draw` でテクスチャの描画位置を `Math::Round` により整数化する
- `DrawSystem::Draw` の関数スコープに閉じた `ScopedRenderStates2D` で `SamplerState::ClampNearest` を適用する
- 起動時に `Scene::SetTextureFilter(TextureFilter::Nearest)` を設定する
- `docs/REFERENCE.md` の `DrawSystem::Draw` と `Main` の説明を更新する

## 解決した症状

プレイヤースプライトの上端に、スプライトシート上で1行上のセルの足元が 1px 分ぼんやり重なって見える現象。

`player.png` は 192x768 に 64x64 セルが 3列 x 12行でちょうど収まっており、セル間のパディングがない。Y 座標が小数のまま描画されると出力ピクセル行の中心がテクセル中心からずれ、バイリニア補間が `row*64 - 1`（1行上のセルの最下行＝足元）を混ぜ込む。描画位置を整数に丸めると混合の重みが (1.0, 0) になり、隣接セルを参照しなくなる。

## 実装判断の理由

### 丸めはテクスチャ描画のみに限定した

`RectDrawable` / `CircleDrawable` はベクタ描画でアンチエイリアスが効くため元々ぼやけない。丸めると滑らかさを失うだけで得がない。

丸めは `screenPos + drawOffset` を合成した後に適用している。先に `screenPos` だけ丸めると `drawOffset` の小数で元に戻るため。

### ワールド座標は `double` のままにした

描画の瞬間だけ丸めることで、物理演算と当たり判定を量子化しない。`WorldPos` を書き換えていないため `HitSystem` / `MovementSystem` の結果は不変。

副次的に、攻撃判定の可視化に使う Circle は丸めないためプレイヤーの表示と最大 0.5px ずれるが、判定自体はワールド座標のままなのでゲーム挙動には影響しない。

### 移動の量子化は許容した

横移動 200px/秒・60FPS では毎フレーム 3px と 4px が交互になる。丸めを避けても最近傍サンプラーにより滑らかさは戻らず、丸めの発生位置が暗黙になるだけであるため許容した。実機確認でも 64px セルの等倍表示では目立たなかった。

### サンプラーは `DrawSystem::Draw` のスコープに閉じた

`HudSystem` と各 Phase のフォント描画へ最近傍を波及させないため。フォントは拡大縮小を前提とするため、最近傍を全体に効かせるのは危険。

### `ClampNearest` と `Scene::SetTextureFilter` は保険として入れた

開発環境（ディスプレイ拡大率 100%・`WindowStyle::Fixed`・シーン 800x600 で 1:1 転送）では、この2つは通常表示では no-op であり、実際にぼやけを起こしていたのは描画座標の小数のみだった。

それでも入れたのは、丸めだけでは保証が不完全なため。シート高さ 768 に対し `64/768 = 1/12` は float32 で厳密に表現できず、セル境界の混合重みが厳密に 0 になる保証がない（残留は 10⁻⁵ 程度で 8bit 量子化には埋もれる）。`ClampNearest` は重みを 0 か 1 に確定させ、隣接セルの参照を原理的に封鎖する。役割分担は「丸め＝症状を消す」「Nearest＝消えた状態を保証する」。

`Scene::SetTextureFilter` は Alt+Enter のフルスクリーン時と、拡大率が 100% でない環境での拡大に備えるもの。

### 見送った案: `ResizeMode` の変更

- `ResizeMode::Actual` は拡大自体を消せるが、シーン解像度が環境の DPI 設定で変わり、`HudSystem` の固定座標と `ProjectileSystem` の画面外判定が環境依存になる
- `ResizeMode::Keep` + `Window::ResizeActual` で 1:1 固定する案は、高 DPI 環境でウィンドウが物理的に小さくなる

いずれも Nearest 拡大の見え方に不満が出たときの次善策として残す。

### テストは追加していない

描画結果は GPU 状態に依存し Catch2 から検証できない。丸め1行に対するテストはリグレッション保護がほぼ 0 のため、検証は実機起動で行った。

## 動作確認

- format / tidy / build / test すべて通過
- 実機で走り・ダッシュ時に上端の 1px の滲みが消えていることを確認（`idle` は row 0 で上に隣接セルがなく元々症状が出ないため検証には使用していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)