### PR TITLE
近接コンボを継続段と締め段の型へ分割する

### DIFF
--- a/Ash2/App/assets/config/animation/player.toml
+++ b/Ash2/App/assets/config/animation/player.toml
@@ -38,7 +38,7 @@ row = 6
 count = 2
 speed = 5.0
 
-[melee_3]
+[melee_finish]
 row = 7
 count = 2
 speed = 4.0

--- a/Ash2/App/assets/config/player.toml
+++ b/Ash2/App/assets/config/player.toml
@@ -7,7 +7,7 @@ cap_mid_h = 24.0
 reach     = 60.0
 damage    = 20
 
-[[melee.stage]]
+[[melee.chain]]
 trajectory        = "thrust"
 windup_sec        = 0.05
 active_sec        = 0.10
@@ -18,7 +18,7 @@ slash_rise_height = 0.0
 slash_curve       = 0.0
 hitstop_sec       = 0.05
 
-[[melee.stage]]
+[[melee.chain]]
 trajectory        = "slash"
 windup_sec        = 0.05
 active_sec        = 0.15
@@ -29,7 +29,7 @@ slash_rise_height = 48.0
 slash_curve       = 1.0
 hitstop_sec       = 0.05
 
-[[melee.stage]]
+[melee.finisher]
 trajectory        = "thrust"
 windup_sec        = 0.10
 active_sec        = 0.20
@@ -39,6 +39,8 @@ radius            = 32.0
 slash_rise_height = 0.0
 slash_curve       = 0.0
 hitstop_sec       = 0.13
+light_count       = 2
+light_gap         = 36.0
 
 [ranged]
 reach        = 200.0

--- a/Ash2/src/Component/Motion.hpp
+++ b/Ash2/src/Component/Motion.hpp
@@ -6,7 +6,8 @@
 
 /// @brief エンティティの排他的な行動状態（種別ごとの状態型の共有variant）
 using Motion = std::variant<
-    PlayerMotion::Neutral, PlayerMotion::Melee, PlayerMotion::Ranged,
-    PlayerMotion::Dash, PlayerMotion::DashAttack, PlayerMotion::AirAttack,
-    PlayerMotion::Landing, EnemyMotion::Idle, EnemyMotion::Stagger,
-    EnemyMotion::Repel, EnemyMotion::Knockback, EnemyMotion::Defeated>;
+    PlayerMotion::Neutral, PlayerMotion::MeleeChain,
+    PlayerMotion::MeleeFinisher, PlayerMotion::Ranged, PlayerMotion::Dash,
+    PlayerMotion::DashAttack, PlayerMotion::AirAttack, PlayerMotion::Landing,
+    EnemyMotion::Idle, EnemyMotion::Stagger, EnemyMotion::Repel,
+    EnemyMotion::Knockback, EnemyMotion::Defeated>;

--- a/Ash2/src/Component/PlayerMotion.hpp
+++ b/Ash2/src/Component/PlayerMotion.hpp
@@ -9,16 +9,28 @@ namespace PlayerMotion {
 /// @brief 通常状態（待機・移動・ジャンプ可能）
 struct Neutral {};
 
-/// @brief 近接攻撃中（コンボ段は stage で参照する）
-struct Melee {
-  /// コンボ段のインデックス（0始まり、cfg.melee.stages を参照する）
+/// @brief 近接コンボの継続段（次段を持つ段）
+struct MeleeChain {
+  /// コンボ段のインデックス（0始まり、cfg.melee.chain を参照する）
   size_t stage = 0;
   /// モーション開始からの経過時間（秒）
   double elapsed = 0.0;
-  /// 攻撃判定の子エンティティ
+  /// 攻撃判定の子エンティティ（不可視）
   entt::entity hitboxEntity = entt::null;
-  /// 後隙中の次段への遷移予約（windup/active中の入力で立つ、最終段では不使用）
+  /// 見た目だけを担う光の子エンティティ
+  Array<entt::entity> lightEntities;
+  /// 後隙中の次段への遷移予約（windup/active中の入力で立つ）
   bool comboQueued = false;
+};
+
+/// @brief 近接コンボの締め段（コンボ継続・キャンセルを受け付けない）
+struct MeleeFinisher {
+  /// モーション開始からの経過時間（秒）
+  double elapsed = 0.0;
+  /// 攻撃判定の子エンティティ（不可視）
+  entt::entity hitboxEntity = entt::null;
+  /// 見た目だけを担う光の子エンティティ
+  Array<entt::entity> lightEntities;
 };
 
 /// @brief 遠距離攻撃中

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -34,19 +34,17 @@ namespace {
   };
 }
 
-/// @brief TOML から近接コンボ1段分の MeleeStageConfig を生成する
-/// @param index 段のインデックス（欠落キーのメッセージに `melee.stage[index]`
-/// として前置し、 実運用の複数段のうちどの段が不正かを示す）
-[[nodiscard]] std::expected<MeleeStageConfig, String> ParseMeleeStage(
-    const TOMLValue& stageToml, size_t index
+/// @brief TOML から近接1振り分の MeleeSwingConfig を生成する
+/// @param section 欠落キーのメッセージに前置するテーブル名
+[[nodiscard]] std::expected<MeleeSwingConfig, String> ParseMeleeSwing(
+    const TOMLValue& swingToml, StringView section
 ) {
-  const String prefix = U"melee.stage[" + Format(index) + U"]";
-  auto timeline = ParseTimeline(stageToml, prefix);
+  auto timeline = ParseTimeline(swingToml, section);
   if (!timeline) {
     return std::unexpected{std::move(timeline).error()};
   }
 
-  TomlFields f{stageToml, U"PlayerConfig::ParseMeleeStage", prefix};
+  TomlFields f{swingToml, U"PlayerConfig::ParseMeleeSwing", String{section}};
   const auto radius = f.get<double>(U"radius");
   const auto trajectoryStr = f.get<String>(U"trajectory");
   const auto slashRiseHeight = f.get<double>(U"slash_rise_height");
@@ -64,7 +62,7 @@ namespace {
     return std::unexpected{std::move(trajectory).error()};
   }
 
-  return MeleeStageConfig{
+  return MeleeSwingConfig{
       .timeline = *std::move(timeline),
       .radius = radius,
       .trajectory = *trajectory,
@@ -74,29 +72,68 @@ namespace {
   };
 }
 
+/// @brief TOML から締め段の MeleeFinisherConfig を生成する
+[[nodiscard]] std::expected<MeleeFinisherConfig, String> ParseMeleeFinisher(
+    const TOMLValue& finisherToml
+) {
+  auto swing = ParseMeleeSwing(finisherToml, U"melee.finisher");
+  if (!swing) {
+    return std::unexpected{std::move(swing).error()};
+  }
+
+  TomlFields f{
+      finisherToml, U"PlayerConfig::ParseMeleeFinisher", U"melee.finisher"
+  };
+  auto finisher = f.wrap(MeleeFinisherConfig{
+      .swing = *std::move(swing),
+      .lightCount = f.get<int32>(U"light_count"),
+      .lightGap = f.get<double>(U"light_gap"),
+  });
+  if (!finisher) {
+    return std::unexpected{std::move(finisher).error()};
+  }
+
+  // parse 時に不変条件（光は2つ以上）を確定させ、MeleeLightSpread
+  // 側では assert のみで済むようにする
+  if (finisher->lightCount < 2) {
+    return std::unexpected{
+        U"PlayerConfig::ParseMeleeFinisher: melee.finisher.light_count は "
+        U"2以上でなければなりません"
+    };
+  }
+
+  return finisher;
+}
+
 /// @brief TOML から近接攻撃の設定値を生成する
 [[nodiscard]] std::expected<MeleeConfig, String> ParseMelee(const TOMLValue& m
 ) {
-  Array<MeleeStageConfig> stages;
-  // Why not: m[U"stage"] がテーブル配列として存在しない場合に
+  Array<MeleeSwingConfig> chain;
+  // Why not: m[U"chain"] がテーブル配列として存在しない場合に
   // tableArrayView() を呼ぶと不正アクセスになるため、
   // 事前に isTableArray() で存在確認する。
-  if (const auto& stageValue = m[U"stage"]; stageValue.isTableArray()) {
+  if (const auto& chainValue = m[U"chain"]; chainValue.isTableArray()) {
     size_t index = 0;
-    for (const auto& stageToml : stageValue.tableArrayView()) {
-      auto stage = ParseMeleeStage(stageToml, index);
-      if (!stage) {
-        return std::unexpected{std::move(stage).error()};
+    for (const auto& chainToml : chainValue.tableArrayView()) {
+      auto swing =
+          ParseMeleeSwing(chainToml, U"melee.chain[" + Format(index) + U"]");
+      if (!swing) {
+        return std::unexpected{std::move(swing).error()};
       }
-      stages.push_back(*std::move(stage));
+      chain.push_back(*std::move(swing));
       ++index;
     }
   }
-  // stages が空だと Tick(Melee&, ...) の stages[state.stage] アクセスが
+  // chain が空だと Tick(MeleeChain&, ...) の chain[state.stage] アクセスが
   // 不正になるため許容しない
-  if (stages.isEmpty()) {
-    return std::unexpected{U"PlayerConfig::ParseMelee: melee.stage がありません"
+  if (chain.isEmpty()) {
+    return std::unexpected{U"PlayerConfig::ParseMelee: melee.chain がありません"
     };
+  }
+
+  auto finisher = ParseMeleeFinisher(m[U"finisher"]);
+  if (!finisher) {
+    return std::unexpected{std::move(finisher).error()};
   }
 
   TomlFields f{m, U"PlayerConfig::ParseMelee", U"melee"};
@@ -104,7 +141,8 @@ namespace {
       .capMidH = f.get<double>(U"cap_mid_h"),
       .reach = f.get<double>(U"reach"),
       .damage = f.get<int32>(U"damage"),
-      .stages = std::move(stages),
+      .chain = std::move(chain),
+      .finisher = *std::move(finisher),
   });
 }
 

--- a/Ash2/src/Config/PlayerConfig.hpp
+++ b/Ash2/src/Config/PlayerConfig.hpp
@@ -57,9 +57,9 @@ enum class MeleeTrajectory : uint8 {
   Slash,
 };
 
-/// @brief 近接コンボの段ごとの設定値
-struct MeleeStageConfig {
-  /// この段のタイムライン
+/// @brief 近接1振り分の共通設定
+struct MeleeSwingConfig {
+  /// この振りのタイムライン
   MotionTimeline timeline;
   /// 攻撃カプセルの半径
   double radius = 0.0;
@@ -75,6 +75,16 @@ struct MeleeStageConfig {
   double hitstopSec = 0.0;
 };
 
+/// @brief 近接コンボの締め段の設定値
+struct MeleeFinisherConfig {
+  /// 共通の振り設定
+  MeleeSwingConfig swing;
+  /// 見た目を担う光の数（2以上、parse 時に検証する）
+  int32 lightCount = 2;
+  /// 光どうしの間隔（h 方向）。攻撃開始時が最大で終了時に 0 へ閉じる
+  double lightGap = 0.0;
+};
+
 /// @brief 近距離攻撃の設定値
 struct MeleeConfig {
   /// 攻撃カプセルの高さ中点（WorldPos.h 方向オフセット）
@@ -83,8 +93,10 @@ struct MeleeConfig {
   double reach;
   /// 与えるダメージ量（全段共通）
   int32 damage;
-  /// コンボ段ごとの設定（先頭が1段目）
-  Array<MeleeStageConfig> stages;
+  /// 継続段の設定（1つ以上、先頭が1段目）
+  Array<MeleeSwingConfig> chain;
+  /// 締め段の設定
+  MeleeFinisherConfig finisher;
 };
 
 /// @brief ダッシュの設定値

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -146,8 +146,9 @@ void PlayerTestPhase::reloadPlayer(entt::registry& registry) {
 }
 
 void PlayerTestPhase::onBeforePop(entt::registry& registry) {
-  // 攻撃判定エンティティ（PlayerMotion::Melee.hitboxEntity 等）は
-  // m_playerRoot の子孫なので DestroyWithChildren で連動して破棄される
+  // 攻撃判定・光エンティティ（PlayerMotion::MeleeChain/MeleeFinisher の
+  // hitboxEntity・lightEntities 等）は m_playerRoot の子孫なので
+  // DestroyWithChildren で連動して破棄される
   if (m_playerRoot != entt::null) {
     Hierarchy::DestroyWithChildren(registry, m_playerRoot);
     m_playerRoot = entt::null;

--- a/Ash2/src/System/PlayerMotion/Helper.cpp
+++ b/Ash2/src/System/PlayerMotion/Helper.cpp
@@ -18,21 +18,37 @@ namespace {
 
 constexpr ColorF kMeleeOrbColor = {1.0, 0.9, 0.5};
 
-/// @brief 攻撃判定エンティティ（光の珠）を生成する
+/// @brief 珠エンティティ（判定用・見た目用いずれにも使う）を1つ生成する
+///
+/// 生成時点では構え中につき体の近くに静止した位置に置く。現在位置は
+/// UpdateAttackHitbox/UpdateAttackLights が更新する LocalOffset のみが担う。
+/// @param visible true なら Drawable/DrawColor を付与して描画対象にする
+entt::entity SpawnOrb(
+    entt::registry& registry, entt::entity owner, const WorldPos& pos,
+    double radius, bool visible
+) {
+  const auto orb = registry.create();
+  registry.emplace<WorldPos>(orb, pos);
+  registry.emplace<LocalOffset>(orb, LocalOffset{});
+  Hierarchy::Attach(registry, owner, orb);
+  if (visible) {
+    registry.emplace<Drawable>(orb, CircleDrawable{.radius = radius});
+    registry.emplace<DrawColor>(orb, DrawColor{.color = kMeleeOrbColor});
+  }
+  return orb;
+}
+
+/// @brief 攻撃判定エンティティを生成する
 ///
 /// Component/Attack.hpp の Attack（ダメージ用）を spec.damage
-/// で確定させて付与する（生成後の上書きは行わない）。生成時点では構え中につき
-/// 珠は体の近くに静止した位置に置く。Collider は珠エンティティ自身の原点からの
-/// オフセット 0 で固定し、珠の現在位置は UpdateAttackHitbox が更新する
-/// LocalOffset のみが担う。
+/// で確定させて付与する（生成後の上書きは行わない）。Collider は珠エンティティ
+/// 自身の原点からのオフセット 0 で固定し、珠の現在位置は UpdateAttackHitbox
+/// が更新する LocalOffset のみが担う。
 entt::entity SpawnAttackHitbox(
     entt::registry& registry, entt::entity owner, const WorldPos& pos,
     const HitboxSpec& spec
 ) {
-  const auto hitbox = registry.create();
-  registry.emplace<WorldPos>(hitbox, pos);
-  registry.emplace<LocalOffset>(hitbox, LocalOffset{});
-  Hierarchy::Attach(registry, owner, hitbox);
+  const auto hitbox = SpawnOrb(registry, owner, pos, spec.radius, spec.drawOrb);
   registry.emplace<Collider>(
       hitbox,
       Collider{
@@ -49,9 +65,13 @@ entt::entity SpawnAttackHitbox(
           .reaction = spec.reaction
       }
   );
-  registry.emplace<Drawable>(hitbox, CircleDrawable{.radius = spec.radius});
-  registry.emplace<DrawColor>(hitbox, DrawColor{.color = kMeleeOrbColor});
   return hitbox;
+}
+
+/// @brief 珠の LocalOffset をワールド相対オフセットへ更新する
+void SetOrbOffset(entt::registry& registry, entt::entity orb, Vec3 offset) {
+  auto& localOffset = registry.get<LocalOffset>(orb);
+  localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
 }
 
 }  // namespace
@@ -97,15 +117,46 @@ void UpdateAttackHitbox(
       hitboxEntity = SpawnAttackHitbox(registry, owner, pos, spec);
     }
 
-    const auto offset = offsetFn(timeline.activeProgress(elapsed));
-
-    auto& localOffset = registry.get<LocalOffset>(hitboxEntity);
-    localOffset.value = WorldPos{.w = offset.x, .h = offset.y, .d = offset.z};
+    SetOrbOffset(
+        registry, hitboxEntity, offsetFn(timeline.activeProgress(elapsed))
+    );
   }
 
   // 後隙以降：ヒットボックスが残っていれば解放する
   if (elapsed >= timeline.activeEnd() && hitboxEntity != entt::null) {
     hitboxEntity = ReleaseAttackHitbox(registry, hitboxEntity, spec.fadeSec);
+  }
+}
+
+void UpdateAttackLights(
+    entt::registry& registry, entt::entity owner, double elapsed,
+    const MotionTimeline& timeline, const LightSpec& spec,
+    Array<entt::entity>& lightEntities,
+    const std::function<Vec3(double, int32)>& offsetFn
+) {
+  // 攻撃フレーム中（未生成ならここで生成する）：光を前方へ移動させる
+  if (timeline.isActive(elapsed)) {
+    if (lightEntities.isEmpty()) {
+      const auto& pos = registry.get<WorldPos>(owner);
+      for (int32 i = 0; i < spec.count; ++i) {
+        lightEntities.push_back(
+            SpawnOrb(registry, owner, pos, spec.radius, /*visible=*/true)
+        );
+      }
+    }
+
+    const double progress = timeline.activeProgress(elapsed);
+    for (int32 i = 0; i < static_cast<int32>(lightEntities.size()); ++i) {
+      SetOrbOffset(registry, lightEntities[i], offsetFn(progress, i));
+    }
+  }
+
+  // 後隙以降：光が残っていれば解放する
+  if (elapsed >= timeline.activeEnd() && !lightEntities.isEmpty()) {
+    for (const auto light : lightEntities) {
+      ReleaseAttackHitbox(registry, light, spec.fadeSec);
+    }
+    lightEntities.clear();
   }
 }
 

--- a/Ash2/src/System/PlayerMotion/Helper.hpp
+++ b/Ash2/src/System/PlayerMotion/Helper.hpp
@@ -25,6 +25,18 @@ struct HitboxSpec {
   double hitstopSec = 0.0;
   /// 解放時のフェードアウト時間（秒）。0 以下なら即座に破棄する
   double fadeSec = 0.0;
+  /// 珠を描画するか（false: 見た目を別の光エンティティに分離する近接攻撃用）
+  bool drawOrb = true;
+};
+
+/// @brief 見た目だけを担う光エンティティ群の生成仕様をまとめた構造体
+struct LightSpec {
+  /// 生成する光の数
+  int32 count = 1;
+  /// 光の半径（CircleDrawable の表示半径）
+  double radius = 0.0;
+  /// 解放時のフェードアウト時間（秒）。0 以下なら即座に破棄する
+  double fadeSec = 0.0;
 };
 
 /// @brief クリップが変化していれば差し替え、再生位置をリセットする
@@ -52,6 +64,19 @@ void UpdateAttackHitbox(
     entt::registry& registry, entt::entity owner, double elapsed,
     const MotionTimeline& timeline, const HitboxSpec& spec,
     entt::entity& hitboxEntity, const std::function<Vec3(double)>& offsetFn
+);
+
+/// @brief 攻撃判定の発生区間に応じて見た目専用の光エンティティ群を
+/// 生成・更新・破棄する
+/// @param timeline 攻撃のタイムライン（active 区間の判定に使用）
+/// @param spec 生成時に確定させる光の数・半径・フェード時間
+/// @param offsetFn 攻撃フレーム内の進行度と光のインデックス（0始まり）から
+/// オフセットを算出する関数
+void UpdateAttackLights(
+    entt::registry& registry, entt::entity owner, double elapsed,
+    const MotionTimeline& timeline, const LightSpec& spec,
+    Array<entt::entity>& lightEntities,
+    const std::function<Vec3(double, int32)>& offsetFn
 );
 
 }  // namespace PlayerMotion

--- a/Ash2/src/System/PlayerMotion/Melee.cpp
+++ b/Ash2/src/System/PlayerMotion/Melee.cpp
@@ -1,5 +1,6 @@
 #include <Siv3D.hpp>
 
+#include <cassert>
 #include <functional>
 
 #include "Component/ReactionLevel.hpp"
@@ -13,7 +14,7 @@ namespace PlayerMotion {
 
 namespace {
 
-/// @brief 突き出し軌道（近接1・3段目）の珠オフセット（プレイヤー相対）を返す
+/// @brief 突き出し軌道（近接1・締め段）の珠オフセット（プレイヤー相対）を返す
 /// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
 Vec3 MeleeThrustOffset(
     double progress, bool facingRight, double reach, double capMidH
@@ -27,10 +28,10 @@ Vec3 MeleeThrustOffset(
 /// @param progress 攻撃フレーム内の進行度（0.0〜1.0）
 // reach / capMidH や各種の調整値は隣接する double 引数として渡すと取り違え
 // やすいため（bugprone-easily-swappable-parameters 対策）、それぞれを保持する
-// MeleeConfig / MeleeStageConfig への const 参照で受け取る。
+// MeleeConfig / MeleeSwingConfig への const 参照で受け取る。
 Vec3 MeleeSlashOffset(
     double progress, bool facingRight, const MeleeConfig& melee,
-    const MeleeStageConfig& stage
+    const MeleeSwingConfig& swing
 ) {
   const double sign = facingRight ? 1.0 : -1.0;
   const double eased = EaseOutQuad(Clamp(progress, 0.0, 1.0));
@@ -38,20 +39,20 @@ Vec3 MeleeSlashOffset(
   // 水平と同じ進行度で上下させると軌跡が直線になってしまうため、垂直だけ
   // 進行を遅らせて「前へ出てから跳ね上がる」弧を描かせる。始点・終点は
   // 変えないので、slashCurve が 0 なら従来どおりの直線に戻る。
-  const double verticalT = Math::Lerp(eased, eased * eased, stage.slashCurve);
+  const double verticalT = Math::Lerp(eased, eased * eased, swing.slashCurve);
   const double vertical =
-      melee.capMidH + (verticalT - 0.5) * stage.slashRiseHeight;
+      melee.capMidH + (verticalT - 0.5) * swing.slashRiseHeight;
   return Vec3{horizontal, vertical, 0.0};
 }
 
-/// @brief 段の軌道設定から、進行度→珠オフセットのラムダを作る
+/// @brief 振りの軌道設定から、進行度→珠オフセットのラムダを作る
 std::function<Vec3(double)> MakeMeleeOffsetFn(
-    const MeleeStageConfig& stage, bool facingRight, const MeleeConfig& melee
+    const MeleeSwingConfig& swing, bool facingRight, const MeleeConfig& melee
 ) {
-  switch (stage.trajectory) {
+  switch (swing.trajectory) {
     case MeleeTrajectory::Slash:
-      return [=, &melee, &stage](double progress) {
-        return MeleeSlashOffset(progress, facingRight, melee, stage);
+      return [=, &melee, &swing](double progress) {
+        return MeleeSlashOffset(progress, facingRight, melee, swing);
       };
     case MeleeTrajectory::Thrust:
     default:
@@ -69,20 +70,66 @@ void RestartClip(SpriteAnimation& anim, const String& clip) {
   anim.elapsed = 0.0;
 }
 
+/// @brief 近接判定用ヒットボックスを1つ更新する
+///
+/// 生成するヒットボックスは常に不可視になる。
+/// @param reaction ヒット成立時に被弾側へ適用するリアクションの強さ
+void UpdateMeleeHitbox(
+    entt::registry& registry, entt::entity owner, double elapsed,
+    const MotionTimeline& timeline, const MeleeConfig& melee,
+    const MeleeSwingConfig& swing, double fadeSec, ReactionLevel reaction,
+    entt::entity& hitboxEntity, const std::function<Vec3(double)>& offsetFn
+) {
+  UpdateAttackHitbox(
+      registry, owner, elapsed, timeline,
+      HitboxSpec{
+          .radius = swing.radius,
+          .damage = melee.damage,
+          .reaction = reaction,
+          .hitstopSec = swing.hitstopSec,
+          .fadeSec = fadeSec,
+          // 近接の見た目は光エンティティが担うため、判定の珠は描画しない
+          .drawOrb = false
+      },
+      hitboxEntity, offsetFn
+  );
+}
+
+/// @brief 光1つの中心軌道からの h 方向オフセットを返す
+/// @param index 光のインデックス（0 始まり、小さいほど下側）
+// progress と index は互いに暗黙変換できてしまうため、締め段設定を
+// 間に挟んで隣接させない（bugprone-easily-swappable-parameters 対策）。
+double MeleeLightSpread(
+    double progress, const MeleeFinisherConfig& finisher, int32 index
+) {
+  assert(finisher.lightCount >= 2 && "締め段の光は2つ以上でなければならない");
+  const double t = Clamp(progress, 0.0, 1.0);
+  // 中心軌道と同じ EaseOutQuad で閉じると序盤で間隔が詰まりきってしまい、
+  // 光が2つに見える時間がほとんど残らない。踏み込む間は開いたままにして、
+  // 終盤で一気に閉じさせる。
+  const double closed = t * t;
+  const double ratio =
+      static_cast<double>(index) / (finisher.lightCount - 1) - 0.5;
+  return finisher.lightGap * ratio * (1.0 - closed);
+}
+
 }  // namespace
 
-Melee MakeMelee(
-    SpriteAnimation& anim, size_t stage, entt::entity hitboxEntity
-) {
-  // 段ごとに専用クリップ（melee_1/melee_2/melee_3）へ切り替わるため、
+MeleeChain MakeMeleeChain(SpriteAnimation& anim, size_t stage) {
+  // 段ごとに専用クリップ（melee_1/melee_2/...）へ切り替わるため、
   // 呼び出し元（初回入場・コンボ継続いずれも）で必ずクリップ名が変わり、
   // RestartClip と SetClip の挙動差は生じない。
   RestartClip(anim, U"melee_{}"_fmt(stage + 1));
-  return Melee{.stage = stage, .elapsed = 0.0, .hitboxEntity = hitboxEntity};
+  return MeleeChain{.stage = stage};
+}
+
+MeleeFinisher MakeMeleeFinisher(SpriteAnimation& anim) {
+  RestartClip(anim, U"melee_finish");
+  return MeleeFinisher{};
 }
 
 Optional<Motion> Tick(
-    Melee& state, entt::registry& registry, entt::entity entity,
+    MeleeChain& state, entt::registry& registry, entt::entity entity,
     const FrameData& frameData
 ) {
   StopHorizontalMovement(registry, entity);
@@ -90,54 +137,98 @@ Optional<Motion> Tick(
   const auto& cfg = registry.ctx().get<PlayerConfig>();
   const auto& melee = cfg.melee;
   assert(
-      state.stage < melee.stages.size() &&
-      "state.stage は melee.stages の範囲内でなければならない"
+      state.stage < melee.chain.size() &&
+      "state.stage は melee.chain の範囲内でなければならない"
   );
-  const auto& stageCfg = melee.stages[state.stage];
-  const auto& timeline = stageCfg.timeline;
+  const auto& swing = melee.chain[state.stage];
+  const auto& timeline = swing.timeline;
   const auto& input = frameData.input;
   auto& anim = registry.get<SpriteAnimation>(entity);
 
   state.elapsed += frameData.dt;
 
-  const bool hasNextStage = state.stage + 1 < melee.stages.size();
-  // 次段を持つ1・2段目は小さくひるむだけ、締め技（最終段）は吹っ飛ばす
-  const ReactionLevel reaction =
-      hasNextStage ? ReactionLevel::Stagger : ReactionLevel::Blow;
-
-  const auto offsetFn = MakeMeleeOffsetFn(stageCfg, anim.facingRight, melee);
-  UpdateAttackHitbox(
+  const auto offsetFn = MakeMeleeOffsetFn(swing, anim.facingRight, melee);
+  UpdateMeleeHitbox(
+      registry, entity, state.elapsed, timeline, melee, swing,
+      cfg.attackEffect.fadeSec, ReactionLevel::Stagger, state.hitboxEntity,
+      offsetFn
+  );
+  UpdateAttackLights(
       registry, entity, state.elapsed, timeline,
-      HitboxSpec{
-          .radius = stageCfg.radius,
-          .damage = melee.damage,
-          .reaction = reaction,
-          .hitstopSec = stageCfg.hitstopSec,
+      LightSpec{
+          .count = 1,
+          .radius = swing.radius,
           .fadeSec = cfg.attackEffect.fadeSec
       },
-      state.hitboxEntity, offsetFn
+      state.lightEntities,
+      [&offsetFn](double progress, int32 /*index*/) {
+        return offsetFn(progress);
+      }
   );
 
-  if (hasNextStage) {
-    // 構え〜後隙A中の攻撃入力は次段への遷移を予約するのみ
-    if (!timeline.isCancelable(state.elapsed) && input.attackDown) {
-      state.comboQueued = true;
-    }
-
-    // 後隙Bに入った時点で予約済み、または後隙B中の新規入力があれば即座に次段へ
-    if (timeline.isCancelable(state.elapsed) &&
-        (state.comboQueued || input.attackDown)) {
-      return MakeMelee(anim, state.stage + 1);
-    }
-
-    // 後隙中のダッシュ入力でダッシュへキャンセル（ST不足時は無視）
-    // 締め技（最終段）はキャンセル不可のためこの分岐に入らない
-    if (timeline.isCancelable(state.elapsed) && input.dashDown &&
-        registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
-      return MakeDash(registry, entity, cfg, anim, /*air=*/false);
-    }
+  // 構え〜後隙A中の攻撃入力は次段への遷移を予約するのみ
+  if (!timeline.isCancelable(state.elapsed) && input.attackDown) {
+    state.comboQueued = true;
   }
 
+  // 後隙Bに入った時点で予約済み、または後隙B中の新規入力があれば即座に次段へ
+  if (timeline.isCancelable(state.elapsed) &&
+      (state.comboQueued || input.attackDown)) {
+    return state.stage + 1 < melee.chain.size()
+               ? Motion{MakeMeleeChain(anim, state.stage + 1)}
+               : Motion{MakeMeleeFinisher(anim)};
+  }
+
+  // 後隙中のダッシュ入力でダッシュへキャンセル（ST不足時は無視）
+  if (timeline.isCancelable(state.elapsed) && input.dashDown &&
+      registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
+    return MakeDash(registry, entity, cfg, anim, /*air=*/false);
+  }
+
+  if (timeline.isFinished(state.elapsed)) {
+    return Neutral{};
+  }
+
+  return none;
+}
+
+Optional<Motion> Tick(
+    MeleeFinisher& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+) {
+  StopHorizontalMovement(registry, entity);
+
+  const auto& cfg = registry.ctx().get<PlayerConfig>();
+  const auto& melee = cfg.melee;
+  const auto& finisher = melee.finisher;
+  const auto& swing = finisher.swing;
+  const auto& timeline = swing.timeline;
+  auto& anim = registry.get<SpriteAnimation>(entity);
+
+  state.elapsed += frameData.dt;
+
+  const auto offsetFn = MakeMeleeOffsetFn(swing, anim.facingRight, melee);
+  UpdateMeleeHitbox(
+      registry, entity, state.elapsed, timeline, melee, swing,
+      cfg.attackEffect.fadeSec, ReactionLevel::Blow, state.hitboxEntity,
+      offsetFn
+  );
+  UpdateAttackLights(
+      registry, entity, state.elapsed, timeline,
+      LightSpec{
+          .count = finisher.lightCount,
+          .radius = swing.radius,
+          .fadeSec = cfg.attackEffect.fadeSec
+      },
+      state.lightEntities,
+      [&offsetFn, &finisher](double progress, int32 index) {
+        Vec3 offset = offsetFn(progress);
+        offset.y += MeleeLightSpread(progress, finisher, index);
+        return offset;
+      }
+  );
+
+  // 締め段はコンボ継続・キャンセルを受け付けないため、満了のみで遷移する
   if (timeline.isFinished(state.elapsed)) {
     return Neutral{};
   }

--- a/Ash2/src/System/PlayerMotion/Neutral.cpp
+++ b/Ash2/src/System/PlayerMotion/Neutral.cpp
@@ -29,14 +29,15 @@ Optional<Motion> Tick(
     anim.facingRight = false;
   }
 
-  // Melee/Ranged への入場（接地中のみ）
+  // MeleeChain/Ranged への入場（接地中のみ）
   if (pos.isOnGround()) {
     if (input.attackDown) {
       // 直前で設定した横方向速度を打ち消す（持ち越すと1フレーム分滑る）
       vel.w = 0.0;
       vel.d = 0.0;
-      // ヒットボックス（光の珠）は攻撃フレーム開始時に Melee::Tick が生成する
-      return MakeMelee(anim, 0);
+      // ヒットボックス・光は攻撃フレーム開始時に Tick(MeleeChain&, ...)
+      // が生成する
+      return MakeMeleeChain(anim, 0);
     }
     if (input.rangedAttackDown &&
         registry.get<Stamina>(entity).current >= cfg.ranged.staminaCost) {

--- a/Ash2/src/System/PlayerMotion/Transition.hpp
+++ b/Ash2/src/System/PlayerMotion/Transition.hpp
@@ -10,12 +10,12 @@
 
 namespace PlayerMotion {
 
-/// @brief 指定段の Melee へ移行する（攻撃クリップを先頭から再生）
+/// @brief 指定段の MeleeChain へ移行する（攻撃クリップを先頭から再生）
 /// @param stage 移行先のコンボ段インデックス
-/// @param hitboxEntity 引き継ぐ攻撃判定エンティティ（通常は entt::null）
-Melee MakeMelee(
-    SpriteAnimation& anim, size_t stage, entt::entity hitboxEntity = entt::null
-);
+MeleeChain MakeMeleeChain(SpriteAnimation& anim, size_t stage);
+
+/// @brief MeleeFinisher へ移行する（締め技クリップを先頭から再生）
+MeleeFinisher MakeMeleeFinisher(SpriteAnimation& anim);
 
 /// @brief Ranged へ移行する（スタミナ消費、遠距離攻撃クリップの設定と timer
 /// の算出）

--- a/Ash2/src/System/PlayerMotionSystem.hpp
+++ b/Ash2/src/System/PlayerMotionSystem.hpp
@@ -8,19 +8,27 @@ struct FrameData;
 
 namespace PlayerMotion {
 
-/// @brief Neutral 状態の更新（移動・ジャンプ・向き・クリップ決定、Melee/Ranged/
-/// Dash への入場判定）
+/// @brief Neutral 状態の更新（移動・ジャンプ・向き・クリップ決定、
+/// MeleeChain/Ranged/Dash への入場判定）
 /// @return 遷移先がある場合はその Motion、なければ none
 [[nodiscard]] Optional<Motion> Tick(
     Neutral& state, entt::registry& registry, entt::entity entity,
     const FrameData& frameData
 );
 
-/// @brief Melee 状態の更新（横移動停止・タイマー減算・ヒットボックス管理・
-/// コンボ予約判定。段の設定は cfg.melee.stages[state.stage] を参照する）
+/// @brief MeleeChain 状態の更新（横移動停止・タイマー減算・判定/光の管理・
+/// コンボ予約判定。段の設定は cfg.melee.chain[state.stage] を参照する）
 /// @return 遷移先がある場合はその Motion、なければ none
 [[nodiscard]] Optional<Motion> Tick(
-    Melee& state, entt::registry& registry, entt::entity entity,
+    MeleeChain& state, entt::registry& registry, entt::entity entity,
+    const FrameData& frameData
+);
+
+/// @brief MeleeFinisher 状態の更新（横移動停止・タイマー減算・判定/光の管理。
+/// コンボ継続・キャンセルは受け付けない）
+/// @return 遷移先がある場合はその Motion、なければ none
+[[nodiscard]] Optional<Motion> Tick(
+    MeleeFinisher& state, entt::registry& registry, entt::entity entity,
     const FrameData& frameData
 );
 

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -16,7 +16,7 @@ constexpr std::string_view kFullToml =
     "cap_mid_h = 30.0\n"
     "reach = 60.0\n"
     "damage = 20\n"
-    "[[melee.stage]]\n"
+    "[[melee.chain]]\n"
     "windup_sec = 0.1\n"
     "active_sec = 0.1\n"
     "recovery_a_sec = 0.1\n"
@@ -26,6 +26,18 @@ constexpr std::string_view kFullToml =
     "slash_rise_height = 0.0\n"
     "slash_curve = 0.0\n"
     "hitstop_sec = 0.05\n"
+    "[melee.finisher]\n"
+    "windup_sec = 0.2\n"
+    "active_sec = 0.2\n"
+    "recovery_a_sec = 0.2\n"
+    "recovery_b_sec = 0.0\n"
+    "radius = 25.0\n"
+    "trajectory = \"thrust\"\n"
+    "slash_rise_height = 0.0\n"
+    "slash_curve = 0.0\n"
+    "hitstop_sec = 0.1\n"
+    "light_count = 2\n"
+    "light_gap = 36.0\n"
     "[ranged]\n"
     "reach = 200.0\n"
     "radius = 15.0\n"
@@ -78,9 +90,13 @@ TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
   REQUIRE(cfg.melee.capMidH == 30.0);
   REQUIRE(cfg.melee.reach == 60.0);
   REQUIRE(cfg.melee.damage == 20);
-  REQUIRE(cfg.melee.stages.size() == 1);
-  REQUIRE(cfg.melee.stages[0].trajectory == MeleeTrajectory::Thrust);
-  REQUIRE(cfg.melee.stages[0].radius == 20.0);
+  REQUIRE(cfg.melee.chain.size() == 1);
+  REQUIRE(cfg.melee.chain[0].trajectory == MeleeTrajectory::Thrust);
+  REQUIRE(cfg.melee.chain[0].radius == 20.0);
+  REQUIRE(cfg.melee.finisher.swing.trajectory == MeleeTrajectory::Thrust);
+  REQUIRE(cfg.melee.finisher.swing.radius == 25.0);
+  REQUIRE(cfg.melee.finisher.lightCount == 2);
+  REQUIRE(cfg.melee.finisher.lightGap == 36.0);
   REQUIRE(cfg.ranged.damage == 15);
   REQUIRE(cfg.dash.speed == 600.0);
   REQUIRE(cfg.dashAttack.damage == 25);
@@ -90,7 +106,7 @@ TEST_CASE("PlayerConfig::FromToml - parses all fields correctly") {
   REQUIRE(cfg.attackEffect.fadeSec == 0.30);
 }
 
-TEST_CASE("PlayerConfig::FromToml - missing melee.stage throws Error") {
+TEST_CASE("PlayerConfig::FromToml - missing melee.chain throws Error") {
   constexpr std::string_view kToml =
       "speed = 150.0\n"
       "jump_speed = 400.0\n"
@@ -109,7 +125,7 @@ TEST_CASE("PlayerConfig::FromToml - missing speed throws Error") {
 }
 
 TEST_CASE(
-    "PlayerConfig::FromToml - missing melee.stage trajectory throws Error "
+    "PlayerConfig::FromToml - missing melee.chain trajectory throws Error "
     "(not \"unknown value\")"
 ) {
   std::string toml{kFullToml};
@@ -128,7 +144,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerConfig::FromToml - unknown melee.stage trajectory value throws "
+    "PlayerConfig::FromToml - unknown melee.chain trajectory value throws "
     "Error"
 ) {
   std::string toml{kFullToml};
@@ -137,6 +153,20 @@ TEST_CASE(
   toml.replace(
       pos, std::string_view{"trajectory = \"thrust\"\n"}.size(),
       "trajectory = \"spin\"\n"
+  );
+  const TOMLReader reader{MemoryViewReader{toml.data(), toml.size()}};
+  REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
+}
+
+TEST_CASE(
+    "PlayerConfig::FromToml - melee.finisher light_count below 2 throws "
+    "Error"
+) {
+  std::string toml{kFullToml};
+  const auto pos = toml.find("light_count = 2\n");
+  REQUIRE(pos != std::string::npos);
+  toml.replace(
+      pos, std::string_view{"light_count = 2\n"}.size(), "light_count = 1\n"
   );
   const TOMLReader reader{MemoryViewReader{toml.data(), toml.size()}};
   REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -4,6 +4,7 @@
 
 #include "Component/Attack.hpp"
 #include "Component/Collider.hpp"
+#include "Component/Drawable.hpp"
 #include "Component/FadeOut.hpp"
 #include "Component/Hierarchy.hpp"
 #include "Component/Hitstop.hpp"
@@ -37,10 +38,10 @@ void SetupContext(entt::registry& registry) {
               .capMidH = 40.0,
               .reach = 50.0,
               .damage = 10,
-              .stages =
+              .chain =
                   {
                       // 1段目相当（突き出し）
-                      MeleeStageConfig{
+                      MeleeSwingConfig{
                           .timeline =
                               {.windupSec = 0.05,
                                .activeSec = 0.10,
@@ -51,7 +52,7 @@ void SetupContext(entt::registry& registry) {
                           .hitstopSec = 0.05,
                       },
                       // 2段目相当（斬り上げ）
-                      MeleeStageConfig{
+                      MeleeSwingConfig{
                           .timeline =
                               {.windupSec = 0.05,
                                .activeSec = 0.15,
@@ -62,17 +63,22 @@ void SetupContext(entt::registry& registry) {
                           .slashRiseHeight = 40.0,
                           .hitstopSec = 0.05,
                       },
-                      // 3段目相当（締め技、突き出し）
-                      MeleeStageConfig{
-                          .timeline =
-                              {.windupSec = 0.10,
-                               .activeSec = 0.20,
-                               .recoveryASec = 0.0,
-                               .recoveryBSec = 0.20},
-                          .radius = 25.0,
-                          .trajectory = MeleeTrajectory::Thrust,
-                          .hitstopSec = 0.13,
-                      },
+                  },
+              .finisher =
+                  {
+                      // 締め段相当（突き出し、光2つ）
+                      .swing =
+                          MeleeSwingConfig{
+                              .timeline =
+                                  {.windupSec = 0.10,
+                                   .activeSec = 0.20,
+                                   .recoveryASec = 0.0,
+                                   .recoveryBSec = 0.20},
+                              .radius = 25.0,
+                              .trajectory = MeleeTrajectory::Thrust,
+                              .hitstopSec = 0.13,
+                          },
+                      .lightGap = 36.0,
                   },
           },
       .ranged =
@@ -151,10 +157,10 @@ entt::entity MakePlayer(entt::registry& registry) {
 }  // namespace
 
 TEST_CASE(
-    "PlayerMotionSystem - melee attack input transitions Neutral to Melee "
-    "stage 0"
+    "PlayerMotionSystem - melee attack input transitions Neutral to "
+    "MeleeChain stage 0"
 ) {
-  // 近接攻撃入力で Neutral から Melee（1段目）へ遷移する
+  // 近接攻撃入力で Neutral から MeleeChain（1段目）へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -165,14 +171,14 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
 
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.stage == 0);
-  REQUIRE(melee.elapsed == Approx(0.0));
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.stage == 0);
+  REQUIRE(chain.elapsed == Approx(0.0));
   // 構え中（windupSec 未満）はヒットボックス未生成
-  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
-  REQUIRE_FALSE(melee.comboQueued);
+  REQUIRE(chain.hitboxEntity == entt::entity{entt::null});
+  REQUIRE_FALSE(chain.comboQueued);
 
   REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_1");
 }
@@ -328,7 +334,7 @@ TEST_CASE(
       PlayerMotion::AirAttack{.elapsed = 0.0, .hitboxEntity = entt::null}
   );
 
-  // windupSec(0.05) ちょうどまで進め、progress 0.0（w = -orbitRadius）にする
+  // windupSec(0.05) ちょうどまで進め、progress 0.0(w = -orbitRadius) にする
   const FrameData frameData{.dt = 0.05};
   MotionSystem::Update(registry, frameData);
 
@@ -421,9 +427,9 @@ TEST_CASE(
 
 TEST_CASE(
     "PlayerMotionSystem - simultaneous jump and melee attack input "
-    "transitions to Melee without vertical velocity"
+    "transitions to MeleeChain without vertical velocity"
 ) {
-  // 同一フレームのジャンプ＋近接攻撃入力は Melee へ遷移し、上昇しない
+  // 同一フレームのジャンプ＋近接攻撃入力は MeleeChain へ遷移し、上昇しない
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -435,7 +441,7 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
   REQUIRE(registry.get<Velocity>(player).h == Approx(0.0));
 }
 
@@ -479,19 +485,23 @@ TEST_CASE(
   REQUIRE(registry.get<Velocity>(player).h == Approx(0.0));
 }
 
-TEST_CASE("PlayerMotionSystem - elapsed expiry transitions Melee to Neutral") {
+TEST_CASE(
+    "PlayerMotionSystem - elapsed expiry transitions MeleeChain to Neutral"
+) {
   // elapsed が windupSec+activeSec+recoveryBSec を超え、comboQueued
-  // が立っていない場合は Melee から Neutral
+  // が立っていない場合は MeleeChain から Neutral
   // へ遷移し、ヒットボックスが残っていれば解放する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
-  // ヒットボックスエンティティ（Melee.hitboxEntity 用のダミー）
+  // ヒットボックスエンティティ（MeleeChain.hitboxEntity 用のダミー）
   const auto hitbox = registry.create();
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.34, .hitboxEntity = hitbox}
+      PlayerMotion::MeleeChain{
+          .stage = 0, .elapsed = 0.34, .hitboxEntity = hitbox
+      }
   );
 
   const FrameData frameData{.dt = 0.5};
@@ -523,17 +533,17 @@ TEST_CASE("PlayerMotionSystem - timer expiry transitions Ranged to Neutral") {
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 elapsed increases but stays in "
-    "Melee"
+    "PlayerMotionSystem - MeleeChain stage 0 elapsed increases but stays "
+    "in MeleeChain"
 ) {
-  // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
+  // recoveryEnd 未満の間は MeleeChain のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -542,22 +552,22 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).elapsed == Approx(0.1));
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).elapsed == Approx(0.1));
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 spawns hitbox when entering active "
-    "frame"
+    "PlayerMotionSystem - MeleeChain stage 0 spawns hitbox when entering "
+    "active frame"
 ) {
-  // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
+  // 構え時間（windupSec）を超えた瞬間にヒットボックス（不可視）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -567,17 +577,17 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
-  REQUIRE(registry.valid(melee.hitboxEntity));
-  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(chain.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(chain.hitboxEntity));
 
-  const auto& attack = registry.get<Attack>(melee.hitboxEntity);
+  const auto& attack = registry.get<Attack>(chain.hitboxEntity);
   REQUIRE(attack.hitstopSec > 0.0);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 destroys hitbox when entering "
+    "PlayerMotionSystem - MeleeChain stage 0 destroys hitbox when entering "
     "recovery"
 ) {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
@@ -590,7 +600,9 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.10, .hitboxEntity = hitbox}
+      PlayerMotion::MeleeChain{
+          .stage = 0, .elapsed = 0.10, .hitboxEntity = hitbox
+      }
   );
 
   // windupSec+activeSec(0.15) を跨ぐ dt
@@ -598,8 +610,8 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.hitboxEntity == entt::entity{entt::null});
   // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
   // へ引き渡す（親からも切り離される）
   REQUIRE(registry.valid(hitbox));
@@ -608,15 +620,15 @@ TEST_CASE(
   REQUIRE_FALSE(registry.all_of<Hierarchy>(hitbox));
 }
 
-TEST_CASE("PlayerMotionSystem - Melee stage 0 stops horizontal movement") {
-  // Melee 中は移動入力があっても横移動が止まる
+TEST_CASE("PlayerMotionSystem - MeleeChain stage 0 stops horizontal movement") {
+  // MeleeChain 中は移動入力があっても横移動が止まる
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -631,8 +643,8 @@ TEST_CASE("PlayerMotionSystem - Melee stage 0 stops horizontal movement") {
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 attack input during windup only "
-    "sets comboQueued"
+    "PlayerMotionSystem - MeleeChain stage 0 attack input during windup "
+    "only sets comboQueued"
 ) {
   // windup中（elapsed < activeStart）の攻撃入力では即時遷移せず、
   // comboQueued が立つのみ
@@ -642,7 +654,7 @@ TEST_CASE(
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -652,13 +664,13 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).comboQueued);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).comboQueued);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 attack input during active only "
-    "sets comboQueued"
+    "PlayerMotionSystem - MeleeChain stage 0 attack input during active "
+    "only sets comboQueued"
 ) {
   // active中（activeStart <= elapsed < activeEnd）の攻撃入力でも
   // 即時遷移せず、comboQueued が立つのみ
@@ -669,7 +681,7 @@ TEST_CASE(
   // windupSec(0.05) を超え activeEnd(0.15) 未満
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.10, .hitboxEntity = entt::null
       }
   );
@@ -679,13 +691,13 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).comboQueued);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).comboQueued);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 transitions to stage 1 immediately "
-    "when comboQueued at activeEnd"
+    "PlayerMotionSystem - MeleeChain stage 0 transitions to stage 1 "
+    "immediately when comboQueued at activeEnd"
 ) {
   // activeEnd 到達時に comboQueued が立っていれば即座に次段へ遷移する
   entt::registry registry;
@@ -695,7 +707,7 @@ TEST_CASE(
   // activeEnd は windupSec+activeSec = 0.15
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0,
           .elapsed = 0.14,
           .hitboxEntity = entt::null,
@@ -707,13 +719,13 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 1);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).stage == 1);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 transitions to stage 1 immediately "
-    "on new attack input during recovery"
+    "PlayerMotionSystem - MeleeChain stage 0 transitions to stage 1 "
+    "immediately on new attack input during recovery"
 ) {
   // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に次段へ遷移する
   entt::registry registry;
@@ -723,7 +735,7 @@ TEST_CASE(
   // activeEnd(0.15) を既に過ぎている状態（comboQueued は未予約）
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null
       }
   );
@@ -733,13 +745,13 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 1);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).stage == 1);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 attack input during recoveryA only "
-    "sets comboQueued and fires after entering recoveryB"
+    "PlayerMotionSystem - MeleeChain stage 0 attack input during recoveryA "
+    "only sets comboQueued and fires after entering recoveryB"
 ) {
   // 後隙A中（activeEnd <= elapsed < recoveryAEnd）の攻撃入力では即時遷移せず
   // 予約のみ行い、後隙Bに入ってから次段へ遷移する
@@ -748,12 +760,12 @@ TEST_CASE(
   const auto player = MakePlayer(registry);
 
   // 1段目に後隙Aを設定する（activeEnd=0.15、recoveryAEnd=0.25）
-  registry.ctx().get<PlayerConfig>().melee.stages[0].timeline.recoveryASec =
+  registry.ctx().get<PlayerConfig>().melee.chain[0].timeline.recoveryASec =
       0.10;
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null
       }
   );
@@ -765,9 +777,9 @@ TEST_CASE(
 
   {
     const auto& motion = registry.get<Motion>(player);
-    REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-    REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 0);
-    REQUIRE(std::get<PlayerMotion::Melee>(motion).comboQueued);
+    REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+    REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).stage == 0);
+    REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).comboQueued);
   }
 
   // 後隙Bへ入るまで進める（elapsed 0.17 → 0.27）：予約が発動して次段へ
@@ -776,13 +788,13 @@ TEST_CASE(
 
   {
     const auto& motion = registry.get<Motion>(player);
-    REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-    REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 1);
+    REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+    REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).stage == 1);
   }
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 transitions to Neutral when "
+    "PlayerMotionSystem - MeleeChain stage 0 transitions to Neutral when "
     "recoveryEnd exceeded without comboQueued"
 ) {
   // comboQueued が立っていない状態で recoveryEnd を超えたら Neutral へ遷移する
@@ -793,7 +805,7 @@ TEST_CASE(
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.35
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.34, .hitboxEntity = entt::null
       }
   );
@@ -806,8 +818,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 comboQueued accumulates across "
-    "frames"
+    "PlayerMotionSystem - MeleeChain stage 0 comboQueued accumulates "
+    "across frames"
 ) {
   // comboQueued は一度立ったら立ったまま（OR的に蓄積）
   entt::registry registry;
@@ -816,7 +828,7 @@ TEST_CASE(
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -826,31 +838,30 @@ TEST_CASE(
   frameData1.input.attackDown = true;
   MotionSystem::Update(registry, frameData1);
 
-  REQUIRE(
-      std::get<PlayerMotion::Melee>(registry.get<Motion>(player)).comboQueued
-  );
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(registry.get<Motion>(player))
+              .comboQueued);
 
   // 2フレーム目：攻撃入力なし、comboQueued は立ったまま
   const FrameData frameData2{.dt = 0.01};
   MotionSystem::Update(registry, frameData2);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).comboQueued);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).comboQueued);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 elapsed increases but stays in "
-    "Melee"
+    "PlayerMotionSystem - MeleeChain stage 1 elapsed increases but stays "
+    "in MeleeChain"
 ) {
-  // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
+  // recoveryEnd 未満の間は MeleeChain のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -859,22 +870,22 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).elapsed == Approx(0.1));
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).elapsed == Approx(0.1));
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 spawns hitbox when entering active "
-    "frame"
+    "PlayerMotionSystem - MeleeChain stage 1 spawns hitbox when entering "
+    "active frame"
 ) {
-  // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
+  // 構え時間（windupSec）を超えた瞬間にヒットボックス（不可視）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -884,14 +895,14 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
-  REQUIRE(registry.valid(melee.hitboxEntity));
-  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(chain.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(chain.hitboxEntity));
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 destroys hitbox when entering "
+    "PlayerMotionSystem - MeleeChain stage 1 destroys hitbox when entering "
     "recovery"
 ) {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
@@ -904,7 +915,9 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 1, .elapsed = 0.15, .hitboxEntity = hitbox}
+      PlayerMotion::MeleeChain{
+          .stage = 1, .elapsed = 0.15, .hitboxEntity = hitbox
+      }
   );
 
   // windupSec+activeSec(0.20) を跨ぐ dt
@@ -912,8 +925,8 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.hitboxEntity == entt::entity{entt::null});
   // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
   // へ引き渡す（親からも切り離される）
   REQUIRE(registry.valid(hitbox));
@@ -923,7 +936,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 transitions to Neutral when "
+    "PlayerMotionSystem - MeleeChain stage 1 transitions to Neutral when "
     "recoveryEnd exceeded"
 ) {
   // recoveryEnd を超えたら Neutral へ遷移する
@@ -934,7 +947,7 @@ TEST_CASE(
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.40
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.39, .hitboxEntity = entt::null
       }
   );
@@ -947,8 +960,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 attack input during windup only "
-    "sets comboQueued"
+    "PlayerMotionSystem - MeleeChain stage 1 attack input during windup "
+    "only sets comboQueued"
 ) {
   // windup中（elapsed < activeStart）の攻撃入力では即時遷移せず、
   // comboQueued が立つのみ
@@ -958,7 +971,7 @@ TEST_CASE(
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
@@ -968,15 +981,15 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).comboQueued);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).comboQueued);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 transitions to stage 2 immediately "
-    "when comboQueued at activeEnd"
+    "PlayerMotionSystem - MeleeChain stage 1 transitions to MeleeFinisher "
+    "immediately when comboQueued at activeEnd"
 ) {
-  // activeEnd 到達時に comboQueued が立っていれば即座に次段へ遷移する
+  // activeEnd 到達時に comboQueued が立っていれば即座に締め段へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -984,7 +997,7 @@ TEST_CASE(
   // activeEnd は windupSec+activeSec = 0.20
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1,
           .elapsed = 0.19,
           .hitboxEntity = entt::null,
@@ -996,15 +1009,15 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 2);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeFinisher>(motion));
+  REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_finish");
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 transitions to stage 2 immediately "
-    "on new attack input during recovery"
+    "PlayerMotionSystem - MeleeChain stage 1 transitions to MeleeFinisher "
+    "immediately on new attack input during recovery"
 ) {
-  // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に次段へ遷移する
+  // recovery中（elapsed >= activeEnd）の新規攻撃入力で即座に締め段へ遷移する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -1012,7 +1025,7 @@ TEST_CASE(
   // activeEnd(0.20) を既に過ぎている状態（comboQueued は未予約）
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.21, .hitboxEntity = entt::null
       }
   );
@@ -1022,12 +1035,12 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 2);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeFinisher>(motion));
+  REQUIRE(registry.get<SpriteAnimation>(player).currentClip == U"melee_finish");
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 transitions to Neutral when "
+    "PlayerMotionSystem - MeleeChain stage 1 transitions to Neutral when "
     "recoveryEnd exceeded without comboQueued"
 ) {
   // comboQueued が立っていない状態で recoveryEnd を超えたら Neutral へ遷移する
@@ -1038,7 +1051,7 @@ TEST_CASE(
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.40
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.39, .hitboxEntity = entt::null
       }
   );
@@ -1051,56 +1064,47 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 2 elapsed increases but stays in "
-    "Melee"
+    "PlayerMotionSystem - MeleeFinisher elapsed increases but stays in "
+    "MeleeFinisher"
 ) {
-  // recoveryEnd 未満の間は Melee のまま、elapsed が加算される
+  // recoveryEnd 未満の間は MeleeFinisher のまま、elapsed が加算される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
-  registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
-      }
-  );
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{.elapsed = 0.0});
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).elapsed == Approx(0.1));
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeFinisher>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeFinisher>(motion).elapsed == Approx(0.1));
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 2 spawns hitbox when entering active "
+    "PlayerMotionSystem - MeleeFinisher spawns hitbox when entering active "
     "frame"
 ) {
-  // 構え時間（windupSec）を超えた瞬間にヒットボックス（光の珠）が生成される
+  // 構え時間（windupSec）を超えた瞬間にヒットボックス（不可視）が生成される
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
-  registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
-      }
-  );
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{.elapsed = 0.0});
 
   // windupSec(0.10) を跨ぐ dt
   const FrameData frameData{.dt = 0.11};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.hitboxEntity != entt::entity{entt::null});
-  REQUIRE(registry.valid(melee.hitboxEntity));
-  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(melee.hitboxEntity));
+  const auto& finisher = std::get<PlayerMotion::MeleeFinisher>(motion);
+  REQUIRE(finisher.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.valid(finisher.hitboxEntity));
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(finisher.hitboxEntity)
+  );
 
-  const auto& attack = registry.get<Attack>(melee.hitboxEntity);
+  const auto& attack = registry.get<Attack>(finisher.hitboxEntity);
   REQUIRE(attack.hitstopSec > 0.0);
 }
 
@@ -1108,42 +1112,40 @@ TEST_CASE(
     "PlayerMotionSystem - Melee hitstopSec differs per stage, following "
     "config"
 ) {
-  // 締め技（3段目）は1段目より長いヒットストップ時間を持つ（コンボ段との連動）
+  // 締め段は継続段より長いヒットストップ時間を持つ（コンボ段との連動）
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
       }
   );
   // windupSec(0.05) を跨ぐ dt
   MotionSystem::Update(registry, FrameData{.dt = 0.06});
   const auto stage0Hitbox =
-      std::get<PlayerMotion::Melee>(registry.get<Motion>(player)).hitboxEntity;
+      std::get<PlayerMotion::MeleeChain>(registry.get<Motion>(player))
+          .hitboxEntity;
   const double stage0HitstopSec = registry.get<Attack>(stage0Hitbox).hitstopSec;
 
-  registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
-      }
-  );
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{.elapsed = 0.0});
   // windupSec(0.10) を跨ぐ dt
   MotionSystem::Update(registry, FrameData{.dt = 0.11});
-  const auto stage2Hitbox =
-      std::get<PlayerMotion::Melee>(registry.get<Motion>(player)).hitboxEntity;
-  const double stage2HitstopSec = registry.get<Attack>(stage2Hitbox).hitstopSec;
+  const auto finisherHitbox =
+      std::get<PlayerMotion::MeleeFinisher>(registry.get<Motion>(player))
+          .hitboxEntity;
+  const double finisherHitstopSec =
+      registry.get<Attack>(finisherHitbox).hitstopSec;
 
   REQUIRE(stage0HitstopSec == Approx(0.05));
-  REQUIRE(stage2HitstopSec == Approx(0.13));
-  REQUIRE(stage2HitstopSec > stage0HitstopSec);
+  REQUIRE(finisherHitstopSec == Approx(0.13));
+  REQUIRE(finisherHitstopSec > stage0HitstopSec);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 2 destroys hitbox when entering "
+    "PlayerMotionSystem - MeleeFinisher destroys hitbox when entering "
     "recovery"
 ) {
   // 攻撃判定終了（windupSec+activeSec）を過ぎたらヒットボックスが解放される
@@ -1156,7 +1158,7 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 2, .elapsed = 0.29, .hitboxEntity = hitbox}
+      PlayerMotion::MeleeFinisher{.elapsed = 0.29, .hitboxEntity = hitbox}
   );
 
   // windupSec+activeSec(0.30) を跨ぐ dt
@@ -1164,8 +1166,8 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.hitboxEntity == entt::entity{entt::null});
+  const auto& finisher = std::get<PlayerMotion::MeleeFinisher>(motion);
+  REQUIRE(finisher.hitboxEntity == entt::entity{entt::null});
   // ヒットボックスは即座に破棄せず、Attack を外して FadeOut
   // へ引き渡す（親からも切り離される）
   REQUIRE(registry.valid(hitbox));
@@ -1175,7 +1177,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 2 transitions to Neutral when "
+    "PlayerMotionSystem - MeleeFinisher transitions to Neutral when "
     "recoveryEnd exceeded"
 ) {
   // recoveryEnd を超えたら Neutral へ遷移する
@@ -1185,10 +1187,7 @@ TEST_CASE(
 
   // recoveryEnd は windupSec+activeSec+recoveryBSec = 0.50
   registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.49, .hitboxEntity = entt::null
-      }
+      player, PlayerMotion::MeleeFinisher{.elapsed = 0.49}
   );
 
   const FrameData frameData{.dt = 0.01};
@@ -1198,45 +1197,34 @@ TEST_CASE(
   REQUIRE(std::holds_alternative<PlayerMotion::Neutral>(motion));
 }
 
-TEST_CASE("PlayerMotionSystem - Melee stage 2 (finisher) ignores attack input"
-) {
-  // 最終段（次段を持たない）は締め技のため攻撃入力を無視し、
-  // recoveryEnd 未満では Melee のまま
+TEST_CASE("PlayerMotionSystem - MeleeFinisher ignores attack input") {
+  // 締め段はコンボ継続を受け付けないため攻撃入力を無視し、
+  // recoveryEnd 未満では MeleeFinisher のまま
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
-  registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
-      }
-  );
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{.elapsed = 0.0});
 
   FrameData frameData{.dt = 0.01};
   frameData.input.attackDown = true;
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 2);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeFinisher>(motion));
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 2 (finisher) ignores dash input "
-    "during recovery"
+    "PlayerMotionSystem - MeleeFinisher ignores dash input during recovery"
 ) {
-  // 最終段はキャンセル不可のため、後隙中のダッシュ入力を無視する
+  // 締め段はキャンセル不可のため、後隙中のダッシュ入力を無視する
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
   // activeEnd(0.30) を既に過ぎている状態
   registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.31, .hitboxEntity = entt::null
-      }
+      player, PlayerMotion::MeleeFinisher{.elapsed = 0.31}
   );
 
   FrameData frameData{.dt = 0.01};
@@ -1244,22 +1232,17 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeFinisher>(motion));
   REQUIRE(registry.get<Stamina>(player).current == 100);
 }
 
-TEST_CASE("PlayerMotionSystem - Melee stage 2 stops horizontal movement") {
-  // Melee 中は移動入力があっても横移動が止まる
+TEST_CASE("PlayerMotionSystem - MeleeFinisher stops horizontal movement") {
+  // MeleeFinisher 中は移動入力があっても横移動が止まる
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
 
-  registry.replace<Motion>(
-      player,
-      PlayerMotion::Melee{
-          .stage = 2, .elapsed = 0.0, .hitboxEntity = entt::null
-      }
-  );
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{.elapsed = 0.0});
 
   FrameData frameData{.dt = 0.1};
   frameData.input.moveAxis = Vec2{1.0, 0.0};
@@ -1268,6 +1251,158 @@ TEST_CASE("PlayerMotionSystem - Melee stage 2 stops horizontal movement") {
   const auto& vel = registry.get<Velocity>(player);
   REQUIRE(vel.w == Approx(0.0));
   REQUIRE(vel.d == Approx(0.0));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - MeleeChain hitbox is invisible while its light "
+    "carries the visual"
+) {
+  // 継続段の判定は不可視（Drawable なし）、見た目は光1つが担う
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::MeleeChain{
+          .stage = 0, .elapsed = 0.0, .hitboxEntity = entt::null
+      }
+  );
+
+  // windupSec(0.05) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(chain.hitboxEntity));
+  REQUIRE_FALSE(registry.all_of<Drawable>(chain.hitboxEntity));
+
+  REQUIRE(chain.lightEntities.size() == 1);
+  const auto light = chain.lightEntities[0];
+  REQUIRE(registry.all_of<Drawable, LocalOffset>(light));
+  REQUIRE_FALSE(registry.all_of<Attack>(light));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - MeleeFinisher spawns one hitbox and two lights, "
+    "spread by half lightGap at progress 0.0"
+) {
+  // 締め段は判定1つ・光2つを持ち、光は Attack を持たない。進行度0.0では
+  // lightGap の半分ずつ上下へ開く
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{.elapsed = 0.0});
+
+  // windupSec(0.10) ちょうどまで進め、progress 0.0 にする
+  const FrameData frameData{.dt = 0.10};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& finisher = std::get<PlayerMotion::MeleeFinisher>(motion);
+  REQUIRE(finisher.hitboxEntity != entt::entity{entt::null});
+  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(finisher.hitboxEntity)
+  );
+  REQUIRE_FALSE(registry.all_of<Drawable>(finisher.hitboxEntity));
+
+  REQUIRE(finisher.lightEntities.size() == 2);
+  for (const auto light : finisher.lightEntities) {
+    REQUIRE(registry.all_of<Drawable, LocalOffset>(light));
+    REQUIRE_FALSE(registry.all_of<Attack>(light));
+  }
+
+  // capMidH(40.0)、lightGap(36.0) の半分ずつ上下に開く
+  constexpr double kCapMidH = 40.0;
+  constexpr double kHalfLightGap = 36.0 / 2.0;
+  const auto& offset0 = registry.get<LocalOffset>(finisher.lightEntities[0]);
+  const auto& offset1 = registry.get<LocalOffset>(finisher.lightEntities[1]);
+  REQUIRE(offset0.value.h == Approx(kCapMidH - kHalfLightGap));
+  REQUIRE(offset1.value.h == Approx(kCapMidH + kHalfLightGap));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - MeleeChain hands its light over to FadeOut when "
+    "leaving active frame"
+) {
+  // 攻撃判定終了後、光エンティティも Attack を外され親から切り離されて
+  // FadeOut へ引き渡される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const auto light = registry.create();
+  registry.emplace<LocalOffset>(light);
+  registry.emplace<Drawable>(light, CircleDrawable{.radius = 20.0});
+  Hierarchy::Attach(registry, player, light);
+
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::MeleeChain{
+          .stage = 0, .elapsed = 0.10, .lightEntities = {light}
+      }
+  );
+
+  // windupSec+activeSec(0.15) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.lightEntities.isEmpty());
+  REQUIRE(registry.valid(light));
+  REQUIRE(registry.all_of<FadeOut>(light));
+  // Hierarchy::Detach は Hierarchy 自体は残し、親子のリンクと LocalOffset
+  // を外す
+  REQUIRE(registry.get<Hierarchy>(light).parent() == entt::entity{entt::null});
+  REQUIRE_FALSE(registry.all_of<LocalOffset>(light));
+}
+
+TEST_CASE(
+    "PlayerMotionSystem - MeleeFinisher hands both lights over to FadeOut "
+    "when leaving active frame"
+) {
+  // 締め段も光すべてが FadeOut へ引き渡される
+  entt::registry registry;
+  SetupContext(registry);
+  const auto player = MakePlayer(registry);
+
+  const auto light0 = registry.create();
+  registry.emplace<LocalOffset>(light0);
+  registry.emplace<Drawable>(light0, CircleDrawable{.radius = 25.0});
+  Hierarchy::Attach(registry, player, light0);
+
+  const auto light1 = registry.create();
+  registry.emplace<LocalOffset>(light1);
+  registry.emplace<Drawable>(light1, CircleDrawable{.radius = 25.0});
+  Hierarchy::Attach(registry, player, light1);
+
+  registry.replace<Motion>(
+      player,
+      PlayerMotion::MeleeFinisher{
+          .elapsed = 0.29, .lightEntities = {light0, light1}
+      }
+  );
+
+  // windupSec+activeSec(0.30) を跨ぐ dt
+  const FrameData frameData{.dt = 0.06};
+  MotionSystem::Update(registry, frameData);
+
+  const auto& motion = registry.get<Motion>(player);
+  const auto& finisher = std::get<PlayerMotion::MeleeFinisher>(motion);
+  REQUIRE(finisher.lightEntities.isEmpty());
+  for (const auto light : {light0, light1}) {
+    REQUIRE(registry.valid(light));
+    REQUIRE(registry.all_of<FadeOut>(light));
+    // Hierarchy::Detach は Hierarchy 自体は残し、親子のリンクと LocalOffset
+    // を外す
+    REQUIRE(
+        registry.get<Hierarchy>(light).parent() == entt::entity{entt::null}
+    );
+    REQUIRE_FALSE(registry.all_of<LocalOffset>(light));
+  }
 }
 
 TEST_CASE("PlayerMotionSystem - dash input transitions Neutral to Dash") {
@@ -1473,10 +1608,10 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 recovery dash input cancels into "
-    "Dash"
+    "PlayerMotionSystem - MeleeChain stage 0 recovery dash input cancels "
+    "into Dash"
 ) {
-  // Melee（1段目）の後隙中にダッシュ入力があるとダッシュへキャンセルする
+  // MeleeChain（1段目）の後隙中にダッシュ入力があるとダッシュへキャンセルする
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -1484,7 +1619,7 @@ TEST_CASE(
   // activeEnd(0.15) を既に過ぎている状態
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.16, .hitboxEntity = entt::null
       }
   );
@@ -1500,10 +1635,10 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 1 recovery dash input cancels into "
-    "Dash"
+    "PlayerMotionSystem - MeleeChain stage 1 recovery dash input cancels "
+    "into Dash"
 ) {
-  // Melee（2段目）の後隙中にダッシュ入力があるとダッシュへキャンセルする
+  // MeleeChain（2段目）の後隙中にダッシュ入力があるとダッシュへキャンセルする
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -1511,7 +1646,7 @@ TEST_CASE(
   // activeEnd(0.20) を既に過ぎている状態
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 1, .elapsed = 0.21, .hitboxEntity = entt::null
       }
   );
@@ -1526,10 +1661,10 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee stage 0 recovery dash input is ignored "
-    "without leftover hitbox"
+    "PlayerMotionSystem - MeleeChain stage 0 recovery dash input is "
+    "ignored without leftover hitbox"
 ) {
-  // Melee 後隙からダッシュへキャンセルする際、ヒットボックスは既に解放済み
+  // MeleeChain 後隙からダッシュへキャンセルする際、ヒットボックスは既に解放済み
   entt::registry registry;
   SetupContext(registry);
   const auto player = MakePlayer(registry);
@@ -1540,7 +1675,9 @@ TEST_CASE(
   // activeEnd(0.15) を跨ぐ dt でヒットボックスが解放される
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.14, .hitboxEntity = hitbox}
+      PlayerMotion::MeleeChain{
+          .stage = 0, .elapsed = 0.14, .hitboxEntity = hitbox
+      }
   );
 
   FrameData frameData{.dt = 0.02};
@@ -1963,8 +2100,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Hitstop freezes Melee elapsed and keeps the same "
-    "hitboxEntity"
+    "PlayerMotionSystem - Hitstop freezes MeleeChain elapsed and keeps the "
+    "same hitboxEntity"
 ) {
   // Hitstop 中は dt = 0 で Tick されるため、elapsed もヒットボックスの再生成も
   // 起きない
@@ -1978,16 +2115,18 @@ TEST_CASE(
   registry.emplace<Collider>(hitbox);
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{.stage = 0, .elapsed = 0.06, .hitboxEntity = hitbox}
+      PlayerMotion::MeleeChain{
+          .stage = 0, .elapsed = 0.06, .hitboxEntity = hitbox
+      }
   );
 
   const FrameData frameData{.dt = 0.1};
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
-  REQUIRE(melee.elapsed == Approx(0.06));
-  REQUIRE(melee.hitboxEntity == hitbox);
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+  REQUIRE(chain.elapsed == Approx(0.06));
+  REQUIRE(chain.hitboxEntity == hitbox);
   REQUIRE(registry.valid(hitbox));
 }
 
@@ -2004,7 +2143,7 @@ TEST_CASE(
   // windupSec(0.05) を超え activeEnd(0.15) 未満（active区間）
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0, .elapsed = 0.10, .hitboxEntity = entt::null
       }
   );
@@ -2014,15 +2153,15 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   const auto& motion = registry.get<Motion>(player);
-  const auto& melee = std::get<PlayerMotion::Melee>(motion);
+  const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
   // elapsed は凍結されたまま
-  REQUIRE(melee.elapsed == Approx(0.10));
-  REQUIRE(melee.comboQueued);
+  REQUIRE(chain.elapsed == Approx(0.10));
+  REQUIRE(chain.comboQueued);
 }
 
 TEST_CASE(
-    "PlayerMotionSystem - Melee resumes and transitions to next stage once "
-    "Hitstop clears"
+    "PlayerMotionSystem - MeleeChain resumes and transitions to next stage "
+    "once Hitstop clears"
 ) {
   // 停止中は次段への遷移が起きず、Hitstop 除去後の後隙Bで初めて遷移する
   entt::registry registry;
@@ -2033,7 +2172,7 @@ TEST_CASE(
   // activeEnd(0.15) 手前、次段への予約は既に立っている
   registry.replace<Motion>(
       player,
-      PlayerMotion::Melee{
+      PlayerMotion::MeleeChain{
           .stage = 0,
           .elapsed = 0.14,
           .hitboxEntity = entt::null,
@@ -2041,13 +2180,13 @@ TEST_CASE(
       }
   );
 
-  // 停止中：dt を与えても elapsed は凍結されたまま、まだ Melee stage 0
+  // 停止中：dt を与えても elapsed は凍結されたまま、まだ MeleeChain stage 0
   MotionSystem::Update(registry, FrameData{.dt = 0.1});
   {
     const auto& motion = registry.get<Motion>(player);
-    const auto& melee = std::get<PlayerMotion::Melee>(motion);
-    REQUIRE(melee.stage == 0);
-    REQUIRE(melee.elapsed == Approx(0.14));
+    const auto& chain = std::get<PlayerMotion::MeleeChain>(motion);
+    REQUIRE(chain.stage == 0);
+    REQUIRE(chain.elapsed == Approx(0.14));
   }
 
   // 停止解除後：activeEnd を跨いで後隙Bへ入り、予約済みの次段へ遷移する
@@ -2055,8 +2194,8 @@ TEST_CASE(
   MotionSystem::Update(registry, FrameData{.dt = 0.02});
 
   const auto& motion = registry.get<Motion>(player);
-  REQUIRE(std::holds_alternative<PlayerMotion::Melee>(motion));
-  REQUIRE(std::get<PlayerMotion::Melee>(motion).stage == 1);
+  REQUIRE(std::holds_alternative<PlayerMotion::MeleeChain>(motion));
+  REQUIRE(std::get<PlayerMotion::MeleeChain>(motion).stage == 1);
 }
 
 #endif

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Debug ビルドでは `Console.open()` で起動し、環境変数 `ASH2_RUN_TES
 プレイヤーと敵の行動状態は `Motion`（`std::variant`）1つのコンポーネントで表す。
 
 状態は排他的（同時に2つは成立しない）で、種類は有限かつコンパイル時に確定している。
-variant なら状態ごとに必要なデータ（`Melee::stage`、`Dash::lastDashDir` 等）をそのまま持てて、
+variant なら状態ごとに必要なデータ（`MeleeChain::stage`、`Dash::lastDashDir` 等）をそのまま持てて、
 動的確保も仮想関数も要らない。プレイヤーと敵で variant を共有しているため、ディスパッチを
 `MotionSystem` 1つに集約できる。
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -66,7 +66,7 @@
 
 ## モーション状態型
 
-`Motion` は `std::variant<PlayerMotion::Neutral, Melee, Ranged, Dash, DashAttack, AirAttack, Landing, EnemyMotion::Idle, Stagger, Repel, Knockback, Defeated>`。
+`Motion` は `std::variant<PlayerMotion::Neutral, MeleeChain, MeleeFinisher, Ranged, Dash, DashAttack, AirAttack, Landing, EnemyMotion::Idle, Stagger, Repel, Knockback, Defeated>`。
 
 遷移を `Tick()` の戻り値でのみ表現する理由は [ARCHITECTURE.md](ARCHITECTURE.md) の
 「Motion — variant による排他的な行動状態」を参照。
@@ -84,8 +84,9 @@
 
 | 状態 | 主な遷移先 | 実装 |
 |---|---|---|
-| `Neutral` | 接地中の入力で `Melee`/`Ranged`/`Dash`、空中の入力で `AirAttack`/`Ranged`/`Dash` | [`Neutral.cpp`](../Ash2/src/System/PlayerMotion/Neutral.cpp) |
-| `Melee` | 後隙Bの攻撃入力・予約で次段の `Melee`、後隙Bのダッシュ入力で `Dash`、満了で `Neutral` | [`Melee.cpp`](../Ash2/src/System/PlayerMotion/Melee.cpp) |
+| `Neutral` | 接地中の入力で `MeleeChain`/`Ranged`/`Dash`、空中の入力で `AirAttack`/`Ranged`/`Dash` | [`Neutral.cpp`](../Ash2/src/System/PlayerMotion/Neutral.cpp) |
+| `MeleeChain` | 後隙Bの攻撃入力・予約で次段の `MeleeChain`（残っていれば）または `MeleeFinisher`、後隙Bのダッシュ入力で `Dash`、満了で `Neutral` | [`Melee.cpp`](../Ash2/src/System/PlayerMotion/Melee.cpp) |
+| `MeleeFinisher` | コンボ継続・キャンセルは受け付けない。満了で `Neutral` | [`Melee.cpp`](../Ash2/src/System/PlayerMotion/Melee.cpp) |
 | `Ranged` | 満了で `Neutral`（空中発動時も着地処理を挟まず地上と同一） | [`Ranged.cpp`](../Ash2/src/System/PlayerMotion/Ranged.cpp) |
 | `Dash` | 後隙Bの予約で `DashAttack`（`air` を引き継ぐ）／再ダッシュの `Dash`、満了で `Neutral`、接地で `Landing`（`air=true` のみ） | [`Dash.cpp`](../Ash2/src/System/PlayerMotion/Dash.cpp) |
 | `DashAttack` | 満了で `Neutral`、接地で `Landing`（`air=true` のみ） | [`DashAttack.cpp`](../Ash2/src/System/PlayerMotion/DashAttack.cpp) |
@@ -110,7 +111,7 @@
 - `air=true` の `Dash`/`DashAttack` と `AirAttack` は、後隙中も含め毎フレーム接地を検出して
   `Landing` へ強制遷移する（タイマー満了より先に評価する）
 - `Dash` は構え・ダッシュ中のみ `Invincible` を毎フレーム付与し、後隙入りで除去する
-- `Melee` の後隙A/Bの配分は段ごとに異なる（次段を持つ段はキャンセル可、締め技はキャンセル不可）
+- 近接の後隙A/Bの配分は段ごとに異なる（`MeleeChain` はキャンセル可、`MeleeFinisher` はキャンセル不可）
 - 敵の状態遷移は `Tick()` の戻り値ではなく `HitReactionSystem` が直接行う
   （[ARCHITECTURE.md](ARCHITECTURE.md) の「例外：外部要因による強制遷移」）
 
@@ -147,9 +148,9 @@
 | `Attack.reaction` | 割り当て元 | 遷移先 |
 |---|---|---|
 | `None`（既定） | `Ranged` の弾 | 遷移しない（無反応） |
-| `Stagger` | `Melee`（次段を持つ段） | `EnemyMotion::Stagger` |
+| `Stagger` | `MeleeChain` | `EnemyMotion::Stagger` |
 | `Repel` | `DashAttack` / `AirAttack` | `EnemyMotion::Repel` |
-| `Blow` | `Melee`（最終段） | `EnemyMotion::Knockback` |
+| `Blow` | `MeleeFinisher` | `EnemyMotion::Knockback` |
 
 `Hp` 枯渇時は `reaction` によらず `Collider`/`Hp` を除去して `EnemyMotion::Defeated` へ遷移する。
 `Repel`/`Knockback` の `Velocity` は攻撃側本体との `WorldPos.w` 比較で向きを決める。
@@ -186,12 +187,15 @@
 
 | 名前 | 役割 | 定義 |
 |---|---|---|
-| `HitboxSpec` | 攻撃判定エンティティの生成仕様（半径・ダメージ・リアクション・ヒットストップ時間・フェード時間）をまとめた構造体 | `Helper.hpp` |
+| `HitboxSpec` | 攻撃判定エンティティの生成仕様（半径・ダメージ・リアクション・ヒットストップ時間・フェード時間・描画有無 `drawOrb`）をまとめた構造体。近接だけ `drawOrb = false` を渡し、見た目を光エンティティ側に分離する | `Helper.hpp` |
+| `LightSpec` | 見た目だけを担う光エンティティ群の生成仕様（数・半径・フェード時間） | `Helper.hpp` |
 | `SetClip` | クリップが変化していれば差し替え、再生位置をリセットする | `Helper.hpp`/`.cpp` |
 | `StopHorizontalMovement` | 横方向（w・d）の速度を 0 にする | `Helper.hpp`/`.cpp` |
-| `ReleaseAttackHitbox` | ヒットボックスを `Hierarchy::Detach` → `Attack` 除去 → `FadeOut` 付与の順で解放する。`fadeSec` が 0 以下なら即座に破棄する | `Helper.hpp`/`.cpp` |
-| `UpdateAttackHitbox` | active 区間に応じて攻撃判定エンティティ（光の珠）を生成・`LocalOffset` 更新し、後隙入りで `ReleaseAttackHitbox` を呼ぶ。オフセットは `offsetFn(progress)` で決まる | `Helper.hpp`/`.cpp` |
-| `MakeMelee` | 指定段の `Melee` を生成（`melee_{stage+1}` クリップを先頭から再生） | `Transition.hpp` / `Melee.cpp` |
+| `ReleaseAttackHitbox` | ヒットボックス（判定・光いずれも）を `Hierarchy::Detach` → `Attack` 除去 → `FadeOut` 付与の順で解放する。`fadeSec` が 0 以下なら即座に破棄する。光は元々 `Attack` を持たないため切り離しとフェード付与だけが働く | `Helper.hpp`/`.cpp` |
+| `UpdateAttackHitbox` | active 区間に応じて攻撃判定エンティティを生成・`LocalOffset` 更新し、後隙入りで `ReleaseAttackHitbox` を呼ぶ。オフセットは `offsetFn(progress)` で決まる | `Helper.hpp`/`.cpp` |
+| `UpdateAttackLights` | active 区間に応じて光エンティティ群を生成・`LocalOffset` 更新し、後隙入りで解放する。オフセットは `offsetFn(progress, index)` で決まる | `Helper.hpp`/`.cpp` |
+| `MakeMeleeChain` | 指定段の `MeleeChain` を生成（`melee_{stage+1}` クリップを先頭から再生） | `Transition.hpp` / `Melee.cpp` |
+| `MakeMeleeFinisher` | `MeleeFinisher` を生成（`melee_finish` クリップを先頭から再生） | `Transition.hpp` / `Melee.cpp` |
 | `MakeRanged` | `Ranged` を生成（スタミナ消費、`timer` はクリップ再生時間から算出） | `Transition.hpp` / `Ranged.cpp` |
 | `MakeDash` | `Dash` を生成（スタミナ消費、`air` フラグ設定） | `Transition.hpp` / `Dash.cpp` |
 | `MakeDashAttack` | `DashAttack` を生成（`air`・`dashDir` を引き継ぐ） | `Transition.hpp` / `DashAttack.cpp` |
@@ -276,10 +280,11 @@
 
 | 名前 | 役割 |
 |---|---|
-| `MotionTimeline` | 攻撃・ダッシュ系共通の4区間タイムライン（windup / active / 後隙A＝キャンセル不可 / 後隙B＝キャンセル可）。`activeStart`/`activeEnd`/`recoveryAEnd`/`recoveryBEnd` と `isActive`/`isCancelable`/`isFinished`/`activeProgress` を提供する。`DashConfig`/`DashAttackConfig`/`AirAttackConfig`/`MeleeStageConfig` が共通で持つ |
+| `MotionTimeline` | 攻撃・ダッシュ系共通の4区間タイムライン（windup / active / 後隙A＝キャンセル不可 / 後隙B＝キャンセル可）。`activeStart`/`activeEnd`/`recoveryAEnd`/`recoveryBEnd` と `isActive`/`isCancelable`/`isFinished`/`activeProgress` を提供する。`DashConfig`/`DashAttackConfig`/`AirAttackConfig`/`MeleeSwingConfig` が共通で持つ |
 | `MeleeTrajectory` | 近接攻撃の軌道パターン（`Thrust` 突き出し / `Slash` 斬り上げ。`Slash` は `slashCurve` で弧の曲がり具合を指定し、0 なら直線になる） |
-| `MeleeStageConfig` | コンボ段ごとの設定（`timeline`/`radius`/`trajectory`/`slashRiseHeight`/`slashCurve`/`hitstopSec`） |
-| `MeleeConfig` | 段共通のパラメータ（`capMidH`/`reach`/`damage`）とコンボ段配列 `stages`（先頭が1段目） |
+| `MeleeSwingConfig` | 近接1振り分の共通設定（`timeline`/`radius`/`trajectory`/`slashRiseHeight`/`slashCurve`/`hitstopSec`）。継続段・締め段の両方が持つ |
+| `MeleeFinisherConfig` | 締め段の設定。`MeleeSwingConfig swing` を集約し、見た目の光の数 `lightCount`（2以上、parse 時に検証）と間隔 `lightGap` を足す |
+| `MeleeConfig` | 段共通のパラメータ（`capMidH`/`reach`/`damage`）と継続段配列 `chain`（先頭が1段目）・締め段 `finisher` |
 | `RangedConfig` | リーチ・半径・ダメージ・弾速・発射高さ・スタミナ消費 |
 | `DashConfig` | 速度・タイムライン・スタミナ消費 |
 | `DashAttackConfig` | タイムライン・突進速度・軌道半径（w-d 平面）・カプセル半径・ダメージ・ヒットストップ時間 |
@@ -288,12 +293,12 @@
 | `LandingConfig` | 着地硬直時間 `recoverySec` |
 | `AttackEffectConfig` | ヒットボックス解放後のフェードアウト時間 `fadeSec`（全攻撃共通の1値。`HitboxSpec::fadeSec` として渡される） |
 
-- `hitstopSec`（`MeleeStageConfig`/`DashAttackConfig`/`AirAttackConfig` が個別に持つ）はヒット成立時に
+- `hitstopSec`（`MeleeSwingConfig`/`DashAttackConfig`/`AirAttackConfig` が個別に持つ）はヒット成立時に
   `Attack.hitstopSec` へ渡す停止時間で、段・アクションごとに調整できる（`RangedConfig` は持たない。
   弾は `reaction` が `None` で無反応の仕様のため）
 - 近接攻撃はスタミナを消費しない（`MeleeConfig` は `staminaCost` を持たない）
-- `[[melee.stage]]` が0件（欠落含む）の場合、`FromToml` は `Error` を投げる
-  （`Tick(Melee&, ...)` の `stages[state.stage]` アクセスを不正にしないため）
+- `[[melee.chain]]` が0件（欠落含む）の場合、`FromToml` は `Error` を投げる
+  （`Tick(MeleeChain&, ...)` の `chain[state.stage]` アクセスを不正にしないため）
 
 ### [`EnemyConfig`](../Ash2/src/Config/EnemyConfig.hpp)
 
@@ -397,7 +402,8 @@
 | `idle` | `Neutral`（静止時） |
 | `move` | `Neutral`（移動時） |
 | `jump_rise` / `jump_fall` | `Neutral`（上昇中／落下中） |
-| `melee_1` / `melee_2` / `melee_3` | `MakeMelee`（段番号 +1 で決まる） |
+| `melee_1` / `melee_2` | `MakeMeleeChain`（段番号 +1 で決まる） |
+| `melee_finish` | `MakeMeleeFinisher` |
 | `ranged_attack` | `MakeRanged`（`Ranged::timer` の算出元にもなる） |
 | `dash` | `MakeDash` |
 | `dash_attack` | `MakeDashAttack` |


### PR DESCRIPTION
close #260

## 概要

近接コンボの3段を `PlayerMotion::Melee` 1つの型・1つの `Tick` で処理していたため、段固有の挙動を設定値の分岐でしか表現できなかった。次段を持つ継続段 `MeleeChain` と、コンボ継続もキャンセルも受け付けない締め段 `MeleeFinisher` の2つへ分割した。

- 各 `Tick` は自段に必要な処理だけを持つ。締め段はコンボ予約もダッシュキャンセルも書かれていない
- リアクションの強さは各 `Tick` の定数となり、`hasNextStage` による分岐を廃止した
- config を `[[melee.chain]]`（1つ以上）と `[melee.finisher]` へ分割し、共通の振り設定を `MeleeSwingConfig` に括った
- 近接の判定と見た目を分離した。判定は常に不可視のヒットボックス1つ、見た目は光エンティティ（継続段1つ・締め段 `light_count` 個）
- クリップ `melee_3` を `melee_finish` へ改名した
- `MakeMelee` の使われていない `hitboxEntity` 引数を削除した

## 実装判断

**`MeleeFinisherConfig` は `MeleeSwingConfig` を継承ではなく集約する**
基底クラスを持つ集成体は designated initializer で基底のメンバを書けない。テストと `ParseMeleeFinisher` の双方が `.swing = ...` の形で組み立てられる集約を採った。

**光の数のガードを関数から外し、parse 時の検証へ移した**
`light_count <= 1` を関数側でガードすると「値によってスキップされる関数」が残り、Issue の目的を満たさない。`ParseMeleeFinisher` で `light_count >= 2` を検証し、関数側は `assert` で不変条件を示すだけにした。

**段送りは条件演算子の両辺を `Motion{}` で包む**
`MeleeChain` と `MeleeFinisher` に共通型がないため、包まないとコンパイルが通らない。

**判定と見た目の分離を別コミットに分けなかった**
`Helper` 側の追加（`LightSpec` / `UpdateAttackLights`）は近接の型分割のために入れたもので、単独では呼び出し元のない死にコードになる。論理的に分けられないため1コミットにまとめた。

**光の解放テストの表明を直した**
`Hierarchy::Detach` は `Hierarchy` コンポーネント自体を残し、親子のリンクと `LocalOffset` を外す実装のため、`parent()` と `LocalOffset` を見る形にした。既存のヒットボックス解放テストが `REQUIRE_FALSE(all_of<Hierarchy>(...))` で通っているのは、対象を `Hierarchy::Attach` せずに作っており表明が空振りしているため。こちらは本 PR の対象外として触っていない。

## スコープの補足

Issue 本文が前提としている `blade_count` / `drawOrb` は未マージのブランチ `feature/melee-stage3-tuning`（`aaafee2`）にのみ存在し、`main` には無かった。そのブランチはマージせず参照用として残す方針としたため、本 PR は暗黙規約を「消す」のではなく「作らずに済ませる」実装になっている。

これに伴い締め段の2つの光の見た目は本 PR で新規に実装した。`motion_design.md` は `main` の時点で既に「2つの光の刃で斬りつける」と記載しており、実装が仕様へ追いつく形になる。数値（`light_gap = 36.0`、閉じ方の easing `closed = t * t`）は `aaafee2` から引き継いだ。

## 確認

- format / tidy / build / test：すべて通過（175 テストケース / 460 表明）
- 実機で起動し、正常終了を確認
- テストは型名の置換に加え、判定と見た目の分離に伴う新規テストを4件追加した

🤖 Generated with [Claude Code](https://claude.com/claude-code)
