### PR TITLE
CI に Release ビルドと生成物の同期チェックを追加する

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # asset_list / Resource.rc は sync-assets.sh の生成物。
+      # 生成物のコミット漏れは Release 実行時まで表面化しない（埋め込み漏れが throw になる）ため、
+      # ビルドより前に検出する。--ignore-cr-at-eol は autocrlf による改行差での誤検知を避けるもの。
+      - name: Check generated assets are in sync
+        shell: bash
+        run: |
+          ./tools/sync-assets.sh
+          git diff --exit-code --ignore-cr-at-eol -- Ash2/App/assets/asset_list Ash2/App/Resource.rc \
+            || { echo "::error::生成物が最新ではありません。tools/sync-assets.sh を実行してコミットしてください。"; exit 1; }
+
       - name: Download Siv3D SDK
         shell: pwsh
         run: |
@@ -72,3 +82,17 @@ jobs:
         shell: bash
         timeout-minutes: 10
         run: ./tools/run-tests.sh
+
+      # 出荷されるのは Release だが、Debug ビルドでは `_DEBUG` の #else 側
+      # （Asset.hpp の埋め込みリソース経路・Debug.hpp の no-op な APP_LOG）が
+      # 一度もコンパイルされない。その経路とリソースコンパイル・Release リンクを検証する。
+      # テストは `_DEBUG` ガード内にあり Release には含まれないため、実行はしない。
+      - name: Build (Release)
+        shell: pwsh
+        run: |
+          msbuild Ash2\Ash2.sln `
+            -p:Configuration=Release `
+            -p:Platform=x64 `
+            -m `
+            -v:minimal `
+            -nologo


### PR DESCRIPTION
## 概要

`build-test` ワークフローにステップを2つ追加する。対応する Issue はなし（CI の環境整備）。

## Release ビルドの追加

これまで CI は Debug 構成のみをビルドしていたため、`_DEBUG` の #else 側が一度もコンパイルされていなかった。

- `Ash2/src/Asset.hpp` の埋め込みリソース経路
- `Ash2/src/Debug.hpp` の no-op 版 `APP_LOG`

出荷されるのは Release 構成であるため、この経路と Resource.rc のリソースコンパイル・Release リンクを検証する。

特に `APP_LOG` は Release で引数を評価しないため、ログのためだけに使っている変数が Release でのみ未使用になる、という壊れ方が起こり得る。Debug のみのビルドではこれを検出できない。

テストは各テストファイルの1行目の `#ifdef _DEBUG` で囲まれており Release では空の翻訳単位になるため、Release でのテスト実行は行わない。

## 生成物の同期チェックの追加

`asset_list` / `Resource.rc` は `tools/sync-assets.sh` の生成物で、`tools/build.sh` が毎回呼んでいる。ただし生成物のコミット漏れを検出する手段がなく、その場合の失敗は Release 実行時の throw（埋め込み漏れ）まで表面化しない。

CI で `sync-assets.sh` を実行し差分が出たら失敗させる。ビルドより前に置いたのは、古い生成物のまま後続ステップが進んで問題が隠れるのを避けるため。

`--ignore-cr-at-eol` を付けているのは、`Resource.rc` が CRLF・`asset_list` が LF と改行コードが混在しており、autocrlf の設定差で誤検知させないため。

## 確認したこと

- Release 構成のローカルビルドが成功する（警告0件）
- `sync-assets.sh` 実行後に差分が出ない

このワークフロー自体が PR で正しく動くかは、この PR の CI 結果で確認する。