### PR TITLE
テストの整理と追加

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="tests\TestEnemyConfig.cpp" />
     <ClCompile Include="tests\TestEnemyMotionSystem.cpp" />
     <ClCompile Include="tests\TestFadeOutSystem.cpp" />
+    <ClCompile Include="tests\TestGravitySystem.cpp" />
     <ClCompile Include="tests\TestHierarchy.cpp" />
     <ClCompile Include="tests\TestHitReactionSystem.cpp" />
     <ClCompile Include="tests\TestHitstopSystem.cpp" />

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="tests\TestPlayerMotionSystem.cpp" />
     <ClCompile Include="tests\TestProjectileSystem.cpp" />
     <ClCompile Include="tests\TestMovementSystem.cpp" />
+    <ClCompile Include="tests\TestStaminaSystem.cpp" />
     <ClCompile Include="tests\TestNameLookup.cpp" />
     <ClCompile Include="tests\TestPhaseStack.cpp" />
     <ClCompile Include="tests\TestPlayerConfig.cpp" />

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="tests\TestEnemyConfig.cpp" />
     <ClCompile Include="tests\TestEnemyMotionSystem.cpp" />
     <ClCompile Include="tests\TestFadeOutSystem.cpp" />
+    <ClCompile Include="tests\TestHierarchy.cpp" />
     <ClCompile Include="tests\TestHitReactionSystem.cpp" />
     <ClCompile Include="tests\TestHitstopSystem.cpp" />
     <ClCompile Include="tests\TestHitSystem.cpp" />

--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -172,6 +172,7 @@
     <ClCompile Include="tests\TestHitSystem.cpp" />
     <ClCompile Include="tests\TestPlayerMotionSystem.cpp" />
     <ClCompile Include="tests\TestProjectileSystem.cpp" />
+    <ClCompile Include="tests\TestMotionTimeline.cpp" />
     <ClCompile Include="tests\TestMovementSystem.cpp" />
     <ClCompile Include="tests\TestStaminaSystem.cpp" />
     <ClCompile Include="tests\TestNameLookup.cpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -288,6 +288,9 @@
     <ClCompile Include="tests\TestAttachmentSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tests\TestHierarchy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="tests\TestHitSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClCompile Include="tests\TestHierarchy.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tests\TestGravitySystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="tests\TestHitSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -297,6 +297,9 @@
     <ClCompile Include="tests\TestStaminaSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tests\TestMotionTimeline.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="tests\TestHitSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -294,6 +294,9 @@
     <ClCompile Include="tests\TestGravitySystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tests\TestStaminaSystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="tests\TestHitSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Ash2/tests/TestAttachmentSystem.cpp
+++ b/Ash2/tests/TestAttachmentSystem.cpp
@@ -3,7 +3,6 @@
 #include <entt/entt.hpp>
 
 #include "Component/Hierarchy.hpp"
-#include "Component/LocalOffset.hpp"
 #include "Component/WorldPos.hpp"
 #include "System/AttachmentSystem.hpp"
 
@@ -63,115 +62,6 @@ TEST_CASE("AttachmentSystem - zero offset child is at parent position") {
   REQUIRE(pos.w == 5.0);
   REQUIRE(pos.h == 3.0);
   REQUIRE(pos.d == 2.0);
-}
-
-TEST_CASE("AttachmentSystem - DestroyWithChildren destroys entire subtree") {
-  entt::registry registry;
-
-  auto parent = registry.create();
-  registry.emplace<WorldPos>(parent);
-
-  auto child = registry.create();
-  registry.emplace<WorldPos>(child);
-  Hierarchy::Attach(registry, parent, child);
-
-  auto grandchild = registry.create();
-  registry.emplace<WorldPos>(grandchild);
-  Hierarchy::Attach(registry, child, grandchild);
-
-  Hierarchy::DestroyWithChildren(registry, parent);
-
-  REQUIRE_FALSE(registry.valid(parent));
-  REQUIRE_FALSE(registry.valid(child));
-  REQUIRE_FALSE(registry.valid(grandchild));
-}
-
-TEST_CASE("AttachmentSystem - Attach sets up linked list correctly") {
-  entt::registry registry;
-
-  auto parent = registry.create();
-  registry.emplace<WorldPos>(parent);
-
-  auto child1 = registry.create();
-  registry.emplace<WorldPos>(child1);
-  Hierarchy::Attach(registry, parent, child1);
-
-  auto child2 = registry.create();
-  registry.emplace<WorldPos>(child2);
-  Hierarchy::Attach(registry, parent, child2);
-
-  // child2 は先頭挿入なので firstChild == child2
-  const auto& parentNode = registry.get<const Hierarchy>(parent);
-  REQUIRE(parentNode.firstChild() == child2);
-  REQUIRE(registry.get<const Hierarchy>(child2).nextSibling() == child1);
-  REQUIRE(registry.get<const Hierarchy>(child1).prevSibling() == child2);
-}
-
-TEST_CASE("AttachmentSystem - Detach removes child from linked list") {
-  entt::registry registry;
-
-  auto parent = registry.create();
-  registry.emplace<WorldPos>(parent);
-
-  auto child = registry.create();
-  registry.emplace<WorldPos>(child);
-  Hierarchy::Attach(registry, parent, child);
-
-  Hierarchy::Detach(registry, child);
-
-  REQUIRE(
-      registry.get<const Hierarchy>(parent).firstChild() ==
-      entt::entity{entt::null}
-  );
-  REQUIRE(
-      registry.get<const Hierarchy>(child).parent() == entt::entity{entt::null}
-  );
-  REQUIRE_FALSE(registry.all_of<LocalOffset>(child));
-}
-
-TEST_CASE("AttachmentSystem - re-attaching child to different parent") {
-  entt::registry registry;
-
-  auto parent1 = registry.create();
-  registry.emplace<WorldPos>(parent1);
-  auto parent2 = registry.create();
-  registry.emplace<WorldPos>(parent2);
-  auto child = registry.create();
-  registry.emplace<WorldPos>(child);
-
-  Hierarchy::Attach(registry, parent1, child);
-  Hierarchy::Attach(registry, parent2, child);
-
-  REQUIRE(
-      registry.get<const Hierarchy>(parent1).firstChild() ==
-      entt::entity{entt::null}
-  );
-  REQUIRE(registry.get<const Hierarchy>(parent2).firstChild() == child);
-  REQUIRE(registry.get<const Hierarchy>(child).parent() == parent2);
-  REQUIRE(
-      registry.get<const Hierarchy>(child).prevSibling() ==
-      entt::entity{entt::null}
-  );
-  REQUIRE(
-      registry.get<const Hierarchy>(child).nextSibling() ==
-      entt::entity{entt::null}
-  );
-}
-
-TEST_CASE("Hierarchy - DestroyWithChildren on already-destroyed entity is safe"
-) {
-  entt::registry registry;
-  auto parent = registry.create();
-  auto child = registry.create();
-  Hierarchy::Attach(registry, parent, child);
-
-  // 親を破棄（子も巻き込まれる）
-  Hierarchy::DestroyWithChildren(registry, parent);
-  // 破棄済みエンティティを再度呼んでもクラッシュしない
-  Hierarchy::DestroyWithChildren(registry, parent);
-  Hierarchy::DestroyWithChildren(registry, child);
-  REQUIRE_FALSE(registry.valid(parent));
-  REQUIRE_FALSE(registry.valid(child));
 }
 
 #endif

--- a/Ash2/tests/TestGravitySystem.cpp
+++ b/Ash2/tests/TestGravitySystem.cpp
@@ -1,0 +1,91 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/Gravity.hpp"
+#include "Component/Hitstop.hpp"
+#include "Component/Velocity.hpp"
+#include "Component/WorldPos.hpp"
+#include "System/GravitySystem.hpp"
+
+namespace {
+
+constexpr double kAccel = 1000.0;
+
+/// @brief 重力を受けるエンティティを生成する
+/// @param h 初期の高さ（0 が地面）
+/// @param velH 初期の垂直速度
+entt::entity MakeFaller(entt::registry& registry, double h, double velH = 0.0) {
+  const auto entity = registry.create();
+  registry.emplace<WorldPos>(entity, WorldPos{.h = h});
+  registry.emplace<Velocity>(entity, Velocity{.h = velH});
+  registry.emplace<Gravity>(entity, Gravity{.accel = kAccel});
+  return entity;
+}
+
+}  // namespace
+
+TEST_CASE("GravitySystem - accelerates downward while airborne") {
+  // 加速は速度にのみ効く。位置の更新は MovementSystem の担当
+  entt::registry registry;
+  const auto entity = MakeFaller(registry, 100.0);
+
+  GravitySystem::Update(registry, 0.5);
+
+  REQUIRE(registry.get<Velocity>(entity).h == Approx(-500.0));
+  REQUIRE(registry.get<WorldPos>(entity).h == Approx(100.0));
+
+  GravitySystem::Update(registry, 0.5);
+
+  REQUIRE(registry.get<Velocity>(entity).h == Approx(-1000.0));
+}
+
+TEST_CASE("GravitySystem - clamps a sunken entity onto the ground") {
+  // 地面を割り込んだ位置は 0 に戻し、垂直速度も落とす
+  entt::registry registry;
+  const auto entity = MakeFaller(registry, -5.0, -300.0);
+
+  GravitySystem::Update(registry, 0.1);
+
+  REQUIRE(registry.get<WorldPos>(entity).h == Approx(0.0));
+  // 加速後の -400.0 ではなく 0。クランプは同じ呼び出しの中で後に効く
+  REQUIRE(registry.get<Velocity>(entity).h == Approx(0.0));
+}
+
+TEST_CASE("GravitySystem - keeps upward velocity at ground level") {
+  // ジャンプした瞬間は接地したまま上向きの速度を持つ。ここで速度を
+  // 打ち消すとジャンプが成立しなくなる（クランプ条件が h < 0 である理由）
+  entt::registry registry;
+  const auto entity = MakeFaller(registry, 0.0, 300.0);
+
+  GravitySystem::Update(registry, 0.1);
+
+  REQUIRE(registry.get<Velocity>(entity).h == Approx(200.0));
+  REQUIRE(registry.get<WorldPos>(entity).h == Approx(0.0));
+}
+
+TEST_CASE("GravitySystem - skips entities in hitstop") {
+  entt::registry registry;
+  const auto entity = MakeFaller(registry, 100.0, -50.0);
+  registry.emplace<Hitstop>(entity, Hitstop{.remaining = 0.1});
+
+  GravitySystem::Update(registry, 0.1);
+
+  REQUIRE(registry.get<Velocity>(entity).h == Approx(-50.0));
+  REQUIRE(registry.get<WorldPos>(entity).h == Approx(100.0));
+}
+
+TEST_CASE("GravitySystem - leaves entities without Gravity untouched") {
+  // 重力は Gravity の付与で選択する（種別による分岐を持たない）
+  entt::registry registry;
+  const auto entity = registry.create();
+  registry.emplace<WorldPos>(entity, WorldPos{.h = -5.0});
+  registry.emplace<Velocity>(entity, Velocity{.h = -300.0});
+
+  GravitySystem::Update(registry, 0.1);
+
+  REQUIRE(registry.get<Velocity>(entity).h == Approx(-300.0));
+  REQUIRE(registry.get<WorldPos>(entity).h == Approx(-5.0));
+}
+
+#endif

--- a/Ash2/tests/TestHierarchy.cpp
+++ b/Ash2/tests/TestHierarchy.cpp
@@ -1,0 +1,197 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/Hierarchy.hpp"
+#include "Component/LocalOffset.hpp"
+#include "Component/WorldPos.hpp"
+#include "System/AttachmentSystem.hpp"
+#include "System/HierarchySystem.hpp"
+
+// 親子関係は「親を動かしたときに子が追従するか」で検証する。
+// 兄弟の並び順は実装上の都合であり、振る舞いとして保証しない。
+//
+// 各テストは本番（InitializeRegistry）と同じく HierarchySystem::Connect を
+// 呼ぶ。破棄シグナル経由の Detach がないと、破棄済みの子がリストに残る。
+
+namespace {
+
+/// @brief WorldPos を持つエンティティを生成する
+entt::entity MakeNode(entt::registry& registry, const WorldPos& pos = {}) {
+  const auto entity = registry.create();
+  registry.emplace<WorldPos>(entity, pos);
+  return entity;
+}
+
+/// @brief 親の絶対座標を移動させて伝播を1回走らせる
+void MoveParent(entt::registry& registry, entt::entity parent, double w) {
+  registry.get<WorldPos>(parent).w = w;
+  AttachmentSystem::UpdateTransform(registry);
+}
+
+}  // namespace
+
+TEST_CASE("Hierarchy::Attach - records the given offset as LocalOffset") {
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child = MakeNode(registry);
+
+  Hierarchy::Attach(
+      registry, parent, child, WorldPos{.w = 1.0, .h = 2.0, .d = 3.0}
+  );
+
+  REQUIRE(registry.all_of<LocalOffset>(child));
+  const auto& offset = registry.get<const LocalOffset>(child).value;
+  REQUIRE(offset.w == Approx(1.0));
+  REQUIRE(offset.h == Approx(2.0));
+  REQUIRE(offset.d == Approx(3.0));
+}
+
+TEST_CASE("Hierarchy::Attach - child follows a parent that had no Hierarchy") {
+  // Hierarchy 未所持のエンティティ同士でも関係を張れる
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent, child, WorldPos{.w = 1.0});
+  MoveParent(registry, parent, 100.0);
+
+  REQUIRE(registry.get<const WorldPos>(child).w == Approx(101.0));
+}
+
+TEST_CASE("Hierarchy::Attach - every attached child follows the parent") {
+  // 子が何体いても全員が追従する（並び順は問わない）
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child1 = MakeNode(registry);
+  const auto child2 = MakeNode(registry);
+  const auto child3 = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent, child1, WorldPos{.w = 1.0});
+  Hierarchy::Attach(registry, parent, child2, WorldPos{.w = 2.0});
+  Hierarchy::Attach(registry, parent, child3, WorldPos{.w = 3.0});
+
+  MoveParent(registry, parent, 100.0);
+
+  REQUIRE(registry.get<const WorldPos>(child1).w == Approx(101.0));
+  REQUIRE(registry.get<const WorldPos>(child2).w == Approx(102.0));
+  REQUIRE(registry.get<const WorldPos>(child3).w == Approx(103.0));
+}
+
+TEST_CASE(
+    "Hierarchy::Attach - re-attaching switches which parent the child follows"
+) {
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent1 = MakeNode(registry);
+  const auto parent2 = MakeNode(registry);
+  const auto child = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent1, child, WorldPos{.w = 1.0});
+  Hierarchy::Attach(registry, parent2, child, WorldPos{.w = 1.0});
+
+  registry.get<WorldPos>(parent1).w = 100.0;
+  MoveParent(registry, parent2, 500.0);
+
+  // 旧親（100.0）ではなく新親（500.0）に追従する
+  REQUIRE(registry.get<const WorldPos>(child).w == Approx(501.0));
+}
+
+TEST_CASE("Hierarchy::Detach - detached child stops following and loses offset"
+) {
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent, child, WorldPos{.w = 1.0});
+  MoveParent(registry, parent, 100.0);
+
+  Hierarchy::Detach(registry, child);
+  REQUIRE_FALSE(registry.all_of<LocalOffset>(child));
+
+  MoveParent(registry, parent, 500.0);
+
+  // 切り離した時点の座標に留まる
+  REQUIRE(registry.get<const WorldPos>(child).w == Approx(101.0));
+}
+
+TEST_CASE("Hierarchy::Detach - the remaining children keep following") {
+  // 途中の子を切り離しても、残りの子への伝播経路は壊れない
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child1 = MakeNode(registry);
+  const auto child2 = MakeNode(registry);
+  const auto child3 = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent, child1, WorldPos{.w = 1.0});
+  Hierarchy::Attach(registry, parent, child2, WorldPos{.w = 2.0});
+  Hierarchy::Attach(registry, parent, child3, WorldPos{.w = 3.0});
+
+  Hierarchy::Detach(registry, child2);
+  MoveParent(registry, parent, 100.0);
+
+  REQUIRE(registry.get<const WorldPos>(child1).w == Approx(101.0));
+  REQUIRE(registry.get<const WorldPos>(child3).w == Approx(103.0));
+}
+
+TEST_CASE("Hierarchy::DestroyWithChildren - destroys the entire subtree") {
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child = MakeNode(registry);
+  const auto grandchild = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent, child);
+  Hierarchy::Attach(registry, child, grandchild);
+
+  Hierarchy::DestroyWithChildren(registry, parent);
+
+  REQUIRE_FALSE(registry.valid(parent));
+  REQUIRE_FALSE(registry.valid(child));
+  REQUIRE_FALSE(registry.valid(grandchild));
+}
+
+TEST_CASE("Hierarchy::DestroyWithChildren - leaves siblings of the subtree") {
+  // 部分木だけを破棄し、親に残る他の子は生き続ける
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto doomed = MakeNode(registry);
+  const auto survivor = MakeNode(registry);
+
+  Hierarchy::Attach(registry, parent, doomed);
+  Hierarchy::Attach(registry, parent, survivor, WorldPos{.w = 3.0});
+
+  Hierarchy::DestroyWithChildren(registry, doomed);
+
+  REQUIRE_FALSE(registry.valid(doomed));
+  REQUIRE(registry.valid(survivor));
+
+  MoveParent(registry, parent, 100.0);
+  REQUIRE(registry.get<const WorldPos>(survivor).w == Approx(103.0));
+}
+
+TEST_CASE(
+    "Hierarchy::DestroyWithChildren - is safe on an already-destroyed entity"
+) {
+  entt::registry registry;
+  HierarchySystem::Connect(registry);
+  const auto parent = MakeNode(registry);
+  const auto child = MakeNode(registry);
+  Hierarchy::Attach(registry, parent, child);
+
+  Hierarchy::DestroyWithChildren(registry, parent);
+  // 破棄済みエンティティを再度渡してもクラッシュしない
+  Hierarchy::DestroyWithChildren(registry, parent);
+  Hierarchy::DestroyWithChildren(registry, child);
+
+  REQUIRE_FALSE(registry.valid(parent));
+  REQUIRE_FALSE(registry.valid(child));
+}
+
+#endif

--- a/Ash2/tests/TestMotionTimeline.cpp
+++ b/Ash2/tests/TestMotionTimeline.cpp
@@ -1,0 +1,71 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+
+#include "Config/PlayerConfig.hpp"
+
+// 全アクション共通の4区間判定。境界が1つずれるとヒットボックスの生成・解放
+// フレームが全モーションでずれるため、境界そのものを検証する。
+
+namespace {
+
+/// 構え 0.10 / 有効 0.20 / 後隙A 0.30 / 後隙B 0.40
+constexpr MotionTimeline kTimeline{
+    .windupSec = 0.10,
+    .activeSec = 0.20,
+    .recoveryASec = 0.30,
+    .recoveryBSec = 0.40
+};
+
+}  // namespace
+
+TEST_CASE("MotionTimeline - section boundaries accumulate in order") {
+  REQUIRE(kTimeline.activeStart() == Approx(0.10));
+  REQUIRE(kTimeline.activeEnd() == Approx(0.30));
+  REQUIRE(kTimeline.recoveryAEnd() == Approx(0.60));
+  REQUIRE(kTimeline.recoveryBEnd() == Approx(1.00));
+}
+
+// 境界は区間秒数の加算結果であり、10進リテラルとは一致しない
+// （0.10 + 0.20 は 0.30 にならない）。境界そのものはアクセサから取る。
+constexpr double kEpsilon = 0.01;
+
+TEST_CASE("MotionTimeline - isActive includes its start but not its end") {
+  // [activeStart, activeEnd) の半開区間
+  REQUIRE_FALSE(kTimeline.isActive(kTimeline.activeStart() - kEpsilon));
+  REQUIRE(kTimeline.isActive(kTimeline.activeStart()));
+  REQUIRE(kTimeline.isActive(kTimeline.activeEnd() - kEpsilon));
+  REQUIRE_FALSE(kTimeline.isActive(kTimeline.activeEnd()));
+}
+
+TEST_CASE("MotionTimeline - isCancelable starts when recovery A ends") {
+  // 後隙Aはキャンセル不可、後隙Bはキャンセル可
+  REQUIRE_FALSE(kTimeline.isCancelable(kTimeline.activeEnd()));
+  REQUIRE_FALSE(kTimeline.isCancelable(kTimeline.recoveryAEnd() - kEpsilon));
+  REQUIRE(kTimeline.isCancelable(kTimeline.recoveryAEnd()));
+  REQUIRE(kTimeline.isCancelable(kTimeline.recoveryBEnd() - kEpsilon));
+}
+
+TEST_CASE("MotionTimeline - isFinished starts when recovery B ends") {
+  REQUIRE_FALSE(kTimeline.isFinished(kTimeline.recoveryBEnd() - kEpsilon));
+  REQUIRE(kTimeline.isFinished(kTimeline.recoveryBEnd()));
+}
+
+TEST_CASE("MotionTimeline - activeProgress spans 0 to 1 across the section") {
+  REQUIRE(kTimeline.activeProgress(kTimeline.activeStart()) == Approx(0.0));
+  REQUIRE(kTimeline.activeProgress(0.20) == Approx(0.5));
+  REQUIRE(kTimeline.activeProgress(kTimeline.activeEnd()) == Approx(1.0));
+}
+
+TEST_CASE("MotionTimeline - a zero-length active section is never active") {
+  // isActive が常に false になることで、activeProgress の 0 除算を
+  // 呼び出し側が踏まないようになっている
+  constexpr MotionTimeline noActive{
+      .windupSec = 0.10, .activeSec = 0.0, .recoveryBSec = 0.20
+  };
+
+  REQUIRE_FALSE(noActive.isActive(0.09));
+  REQUIRE_FALSE(noActive.isActive(0.10));
+  REQUIRE_FALSE(noActive.isActive(0.11));
+}
+
+#endif

--- a/Ash2/tests/TestPlayerConfig.cpp
+++ b/Ash2/tests/TestPlayerConfig.cpp
@@ -172,24 +172,4 @@ TEST_CASE(
   REQUIRE_THROWS_AS(PlayerConfig::FromToml(reader), Error);
 }
 
-TEST_CASE("PlayerConfig - can set speed directly") {
-  // 直接値をセットできる（TOML なしでテスト可能）
-  const PlayerConfig cfg{.speed = 100.0, .jumpSpeed = 300.0, .gravity = 800.0};
-  REQUIRE(cfg.speed == 100.0);
-  REQUIRE(cfg.jumpSpeed == 300.0);
-  REQUIRE(cfg.gravity == 800.0);
-}
-
-TEST_CASE("PlayerConfig - speed is positive") {
-  // 速度は正の値であること
-  const PlayerConfig cfg{.speed = 100.0, .jumpSpeed = 300.0, .gravity = 800.0};
-  REQUIRE(cfg.speed > 0.0);
-}
-
-TEST_CASE("PlayerConfig - gravity is positive") {
-  // 重力加速度は正の値であること
-  const PlayerConfig cfg{.speed = 100.0, .jumpSpeed = 300.0, .gravity = 800.0};
-  REQUIRE(cfg.gravity > 0.0);
-}
-
 #endif

--- a/Ash2/tests/TestProjectileSystem.cpp
+++ b/Ash2/tests/TestProjectileSystem.cpp
@@ -57,21 +57,4 @@ TEST_CASE("ProjectileSystem - destroys bullet on impact (hitTargets non-empty)"
   REQUIRE_FALSE(registry.valid(bullet));
 }
 
-TEST_CASE("ProjectileSystem - destroys bullet when off-screen") {
-  // WorldPos を画面座標に変換した結果が Scene::Rect()
-  // の範囲外の場合は破棄される
-  entt::registry registry;
-
-  // 実行環境の画面サイズに依存しないよう、十分に遠い座標を使う
-  constexpr double kFarAway = 1.0e9;
-  const auto bullet = MakeBullet(
-      registry, WorldPos{.w = kFarAway, .h = 0.0, .d = 0.0},
-      Velocity{.w = 0.0, .h = 0.0, .d = 0.0}
-  );
-
-  ProjectileSystem::Update(registry);
-
-  REQUIRE_FALSE(registry.valid(bullet));
-}
-
 #endif

--- a/Ash2/tests/TestStaminaSystem.cpp
+++ b/Ash2/tests/TestStaminaSystem.cpp
@@ -1,0 +1,96 @@
+#ifdef _DEBUG
+#include <ThirdParty/Catch2/catch.hpp>
+#include <entt/entt.hpp>
+
+#include "Component/Motion.hpp"
+#include "Component/Player.hpp"
+#include "Component/PlayerMotion.hpp"
+#include "Component/Stamina.hpp"
+#include "Config/PlayerConfig.hpp"
+#include "System/StaminaSystem.hpp"
+
+namespace {
+
+/// @brief スタミナ設定だけを載せた registry.ctx() を用意する
+void SetupContext(
+    entt::registry& registry, double recoveryDelay, double recoveryRate
+) {
+  registry.ctx().emplace<PlayerConfig>(PlayerConfig{
+      .stamina = {.recoveryDelay = recoveryDelay, .recoveryRate = recoveryRate},
+  });
+}
+
+/// @brief Neutral 状態のプレイヤーを生成する
+entt::entity MakePlayer(entt::registry& registry, int32 max, int32 current) {
+  const auto player = registry.create();
+  registry.emplace<Player>(player);
+  registry.emplace<Stamina>(player, Stamina{.max = max, .current = current});
+  registry.emplace<Motion>(player, PlayerMotion::Neutral{});
+  return player;
+}
+
+}  // namespace
+
+TEST_CASE("StaminaSystem - does not recover before the delay elapses") {
+  entt::registry registry;
+  SetupContext(registry, /*recoveryDelay=*/0.5, /*recoveryRate=*/1.0);
+  const auto player = MakePlayer(registry, 100, 50);
+
+  StaminaSystem::Update(registry, 0.2);
+
+  REQUIRE(registry.get<Stamina>(player).current == 50);
+}
+
+TEST_CASE("StaminaSystem - recovers once the delay has elapsed") {
+  // 不足分（50）に recoveryRate * dt を掛けた量が回復する
+  entt::registry registry;
+  SetupContext(registry, /*recoveryDelay=*/0.5, /*recoveryRate=*/1.0);
+  const auto player = MakePlayer(registry, 100, 50);
+
+  StaminaSystem::Update(registry, 0.5);
+
+  REQUIRE(registry.get<Stamina>(player).current == 75);
+}
+
+TEST_CASE("StaminaSystem - a non-Neutral motion restarts the delay") {
+  // 行動中は回復せず、Neutral に戻ってから改めて待機時間を数え直す
+  entt::registry registry;
+  SetupContext(registry, /*recoveryDelay=*/0.5, /*recoveryRate=*/1.0);
+  const auto player = MakePlayer(registry, 100, 50);
+  registry.replace<Motion>(player, PlayerMotion::MeleeFinisher{});
+
+  StaminaSystem::Update(registry, 1.0);
+  REQUIRE(registry.get<Stamina>(player).current == 50);
+
+  registry.replace<Motion>(player, PlayerMotion::Neutral{});
+  StaminaSystem::Update(registry, 0.2);
+
+  // 行動前の経過時間は持ち越さないため、まだ回復しない
+  REQUIRE(registry.get<Stamina>(player).current == 50);
+}
+
+TEST_CASE("StaminaSystem - fills up even when each frame gains less than one") {
+  // 1フレームの回復量が 1 未満でも、端数を積み立てるため必ず満タンに届く。
+  // 端数を切り捨てる実装ではここで永久に回復しなくなる
+  entt::registry registry;
+  SetupContext(registry, /*recoveryDelay=*/0.0, /*recoveryRate=*/0.5);
+  const auto player = MakePlayer(registry, 100, 1);
+
+  for (int32 i = 0; i < 1000; ++i) {
+    StaminaSystem::Update(registry, 0.016);
+  }
+
+  REQUIRE(registry.get<Stamina>(player).current == 100);
+}
+
+TEST_CASE("StaminaSystem - never exceeds the maximum") {
+  entt::registry registry;
+  SetupContext(registry, /*recoveryDelay=*/0.0, /*recoveryRate=*/1.0);
+  const auto player = MakePlayer(registry, 100, 100);
+
+  StaminaSystem::Update(registry, 1.0);
+
+  REQUIRE(registry.get<Stamina>(player).current == 100);
+}
+
+#endif


### PR DESCRIPTION
## 概要

`/full-review` で挙がったテストの所見に対応する。
`docs/TEST_POLICY.md` の4本柱と既存テストの仕分け rubric に沿って整理し、
保護が抜けていた3箇所にテストを追加した。

テストケース 175 → 191、アサーション 460 → 496。

## 変更内容

### 価値のないテストの削除（281b03c）

- `TestPlayerConfig.cpp` の3件は、リテラルで初期化した集成体をその場で読み返すだけで、
  `PlayerConfig` をどう変えても壊れなかった（rubric 4: 何も検証していない）
- `TestProjectileSystem.cpp` の画面外テストは、テスト実行中に存在しない `Scene` に依存し、
  `1.0e9` という極端な座標で回避していた（rubric 3: 管理外依存）

### Hierarchy テストの分割（3990e7e）

- 1ファイル1対象（`.claude/rules/test.md`）に揃え、`TestAttachmentSystem.cpp` は座標伝播、
  `TestHierarchy.cpp` は `Attach` / `Detach` / `DestroyWithChildren` を担当する
- 内部表現（`firstChild` / `nextSibling` / `prevSibling`）への結合を解消した（rubric 1）

### テストの追加（588072b / 23822e4 / 28f8502）

- `TestGravitySystem.cpp`: 加速と地面クランプの順序、接地時の上向き速度の保持
- `TestStaminaSystem.cpp`: 回復ディレイ、行動によるリセット、端数の積み立て
- `TestMotionTimeline.cpp`: 4区間の境界、半開区間、`activeSec = 0` の扱い

## 実装判断

**兄弟の並び順は検証しない。** 子の間に優劣や順序を設ける仕様はなく、連結リストは
実装上の都合であるため。代わりに「真ん中の子を `Detach` しても残りが追従する」
「部分木を破棄しても兄弟が追従する」でリストの整合性を振る舞いとして守る。
実装を配列に変えても壊れず、壊れたときは追従が止まるため検出できる。

**`TestHierarchy.cpp` は `HierarchySystem::Connect` を呼ぶ。** 本番の
`InitializeRegistry` と同じ配線にするため。破棄シグナル経由の `Detach` がないと、
破棄済みの子が親のリストに残り伝播時に落ちる（実際に作成中クラッシュした）。

**`MotionTimeline` の境界はアクセサから取る。** 境界は区間秒数の加算結果であり、
`0.10 + 0.20` は `0.30` にならない。10進リテラルと突き合わせると 1 ULP ずれる。
検証したいのは半開区間という契約なので、アクセサ自身を基準にした。

**弾の画面外判定は今回テストを書き直さない。** 消滅条件がまだ確定していない
（未使用の `RangedConfig::reach` が残っており、射程による消滅の検討跡がある）。
条件が固まった時点で `Scene` への依存を引数へ切り出し、境界を検証する形で書き直す。
着弾テストは `Scene` に依存せず `HitSystem` との契約を検証しているため残した。

## 確認

`./tools/build.sh` → `./tools/run-tests.sh` で `All tests passed (496 assertions in 191 test cases)`。
