### PR TITLE
テストコードと攻撃の光ループの clang-tidy エラーを解消する

### DIFF
--- a/Ash2/src/System/PlayerMotion/Helper.cpp
+++ b/Ash2/src/System/PlayerMotion/Helper.cpp
@@ -146,8 +146,10 @@ void UpdateAttackLights(
     }
 
     const double progress = timeline.activeProgress(elapsed);
-    for (int32 i = 0; i < static_cast<int32>(lightEntities.size()); ++i) {
-      SetOrbOffset(registry, lightEntities[i], offsetFn(progress, i));
+    for (size_t i = 0; i < lightEntities.size(); ++i) {
+      SetOrbOffset(
+          registry, lightEntities[i], offsetFn(progress, static_cast<int32>(i))
+      );
     }
   }
 

--- a/Ash2/tests/TestGravitySystem.cpp
+++ b/Ash2/tests/TestGravitySystem.cpp
@@ -13,12 +13,14 @@ namespace {
 constexpr double kAccel = 1000.0;
 
 /// @brief 重力を受けるエンティティを生成する
-/// @param h 初期の高さ（0 が地面）
-/// @param velH 初期の垂直速度
-entt::entity MakeFaller(entt::registry& registry, double h, double velH = 0.0) {
+/// @param pos 初期位置（h が 0 で接地）
+/// @param vel 初期速度
+entt::entity MakeFaller(
+    entt::registry& registry, const WorldPos& pos, const Velocity& vel = {}
+) {
   const auto entity = registry.create();
-  registry.emplace<WorldPos>(entity, WorldPos{.h = h});
-  registry.emplace<Velocity>(entity, Velocity{.h = velH});
+  registry.emplace<WorldPos>(entity, pos);
+  registry.emplace<Velocity>(entity, vel);
   registry.emplace<Gravity>(entity, Gravity{.accel = kAccel});
   return entity;
 }
@@ -28,7 +30,7 @@ entt::entity MakeFaller(entt::registry& registry, double h, double velH = 0.0) {
 TEST_CASE("GravitySystem - accelerates downward while airborne") {
   // 加速は速度にのみ効く。位置の更新は MovementSystem の担当
   entt::registry registry;
-  const auto entity = MakeFaller(registry, 100.0);
+  const auto entity = MakeFaller(registry, WorldPos{.h = 100.0});
 
   GravitySystem::Update(registry, 0.5);
 
@@ -43,7 +45,8 @@ TEST_CASE("GravitySystem - accelerates downward while airborne") {
 TEST_CASE("GravitySystem - clamps a sunken entity onto the ground") {
   // 地面を割り込んだ位置は 0 に戻し、垂直速度も落とす
   entt::registry registry;
-  const auto entity = MakeFaller(registry, -5.0, -300.0);
+  const auto entity =
+      MakeFaller(registry, WorldPos{.h = -5.0}, Velocity{.h = -300.0});
 
   GravitySystem::Update(registry, 0.1);
 
@@ -56,7 +59,8 @@ TEST_CASE("GravitySystem - keeps upward velocity at ground level") {
   // ジャンプした瞬間は接地したまま上向きの速度を持つ。ここで速度を
   // 打ち消すとジャンプが成立しなくなる（クランプ条件が h < 0 である理由）
   entt::registry registry;
-  const auto entity = MakeFaller(registry, 0.0, 300.0);
+  const auto entity =
+      MakeFaller(registry, WorldPos{.h = 0.0}, Velocity{.h = 300.0});
 
   GravitySystem::Update(registry, 0.1);
 
@@ -66,7 +70,8 @@ TEST_CASE("GravitySystem - keeps upward velocity at ground level") {
 
 TEST_CASE("GravitySystem - skips entities in hitstop") {
   entt::registry registry;
-  const auto entity = MakeFaller(registry, 100.0, -50.0);
+  const auto entity =
+      MakeFaller(registry, WorldPos{.h = 100.0}, Velocity{.h = -50.0});
   registry.emplace<Hitstop>(entity, Hitstop{.remaining = 0.1});
 
   GravitySystem::Update(registry, 0.1);

--- a/Ash2/tests/TestMotionTimeline.cpp
+++ b/Ash2/tests/TestMotionTimeline.cpp
@@ -59,13 +59,13 @@ TEST_CASE("MotionTimeline - activeProgress spans 0 to 1 across the section") {
 TEST_CASE("MotionTimeline - a zero-length active section is never active") {
   // isActive が常に false になることで、activeProgress の 0 除算を
   // 呼び出し側が踏まないようになっている
-  constexpr MotionTimeline noActive{
+  constexpr MotionTimeline kNoActive{
       .windupSec = 0.10, .activeSec = 0.0, .recoveryBSec = 0.20
   };
 
-  REQUIRE_FALSE(noActive.isActive(0.09));
-  REQUIRE_FALSE(noActive.isActive(0.10));
-  REQUIRE_FALSE(noActive.isActive(0.11));
+  REQUIRE_FALSE(kNoActive.isActive(0.09));
+  REQUIRE_FALSE(kNoActive.isActive(0.10));
+  REQUIRE_FALSE(kNoActive.isActive(0.11));
 }
 
 #endif


### PR DESCRIPTION
clang-tidy のエラー3件を解消する。close #270

Issue 本文の2件（テストコード）に加え、調査中に Code scanning で見つかった本番コードの1件も本 PR で扱う（スコープ拡大は Issue にコメント済み）。

## 変更内容

### `MakeFaller` の隣接する double 引数を解消する

`bugprone-easily-swappable-parameters` / `Ash2/tests/TestGravitySystem.cpp`

`double h, double velH` をやめ、`const WorldPos&` と `const Velocity&` を受ける形にした。

- 別のクラス型になるため取り違えようがない
- 呼び出し側で `.h =` を明示でき、意図が読める
- 同じテスト群の `MakeEnemy` が「registry + コンポーネント型の const 参照」の形をすでに採っており、それに合わせた

デフォルト引数は `const Velocity& vel = {}` とし、呼び出し側に `Velocity{}` を書かせない。
`Velocity` は全メンバに既定値を持つ集成体なので、従来の `velH = 0.0` と等価である。

### constexpr 変数を命名規則に合わせる

`readability-identifier-naming` / `Ash2/tests/TestMotionTimeline.cpp`

`noActive` を `kNoActive` にリネームした。参照が1テスト内のみのため、定義位置はそのまま動かしていない。

### 攻撃の光ループの添字を size_t にする

`modernize-use-integer-sign-comparison` / `Ash2/src/System/PlayerMotion/Helper.cpp`

```diff
-for (int32 i = 0; i < static_cast<int32>(lightEntities.size()); ++i) {
-  SetOrbOffset(registry, lightEntities[i], offsetFn(progress, i));
+for (size_t i = 0; i < lightEntities.size(); ++i) {
+  SetOrbOffset(
+      registry, lightEntities[i], offsetFn(progress, static_cast<int32>(i))
+  );
 }
```

このチェックはキャストの内側の変換元を見るため、`static_cast<int32>` を挟んでも
`size_t` との比較として検出される。両辺の型をそろえる必要があった。

`offsetFn` の index は `int32` のまま維持し、渡す直前でキャストする。
シグネチャを変えると `Melee.cpp` のラムダ2箇所と `MeleeLightSpread` まで波及するため。

反復回数・`offsetFn` に渡すインデックス値はいずれも変更前と同一で、挙動は変わらない。

## 見送った案

- `NOLINTNEXTLINE` による抑制 — リポジトリに前例がなく、抑制の前例を作りたくない
- `tests/.clang-tidy` での規則緩和 — テスト固有の理由がある除外に限定したい
- `std::cmp_less` — 添字が `int32` のまま残り、「添字・サイズには `size_t`」という規約と逆行する

## 検証

- clang-tidy: テストコードの2件が消えたことを確認
- ビルド成功、テスト全件パス（191 test cases / 496 assertions）

`Helper.cpp` の1件のみ、ローカルの clang-tidy 19.1.1 にチェック自体が存在しない（20 で追加）ため
手元で解消を確認できていない。ローカルと CI のバージョン統一は #271 で対応する。
