### PR TITLE
clang-tidy / clang-format のバージョンをローカルと CI で統一する

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,14 +14,19 @@ on:
       - '**/*.cpp'
       - '**/*.hpp'
 
+env:
+  LLVM_VERSION: 22.1.8
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - name: Install clang-format
-        run: sudo apt-get install -y clang-format-19
+        run: pipx install clang-format==${{ env.LLVM_VERSION }}
       - name: Check formatting
         run: |
+          CLANG_FORMAT="$(pipx environment --value PIPX_BIN_DIR)/clang-format"
+          "$CLANG_FORMAT" --version
           find Ash2/src Ash2/tests -name '*.cpp' -o -name '*.hpp' | \
-          xargs clang-format-19 --dry-run --Werror
+          xargs "$CLANG_FORMAT" --dry-run --Werror

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   SIV3D_VERSION: 0.6.16
+  LLVM_VERSION: 22.1.8
 
 jobs:
   clang-tidy:
@@ -47,12 +48,18 @@ jobs:
         shell: pwsh
         run: cargo install clang-tidy-sarif --version 0.8.0 --locked
 
+      - name: Install clang-tidy
+        shell: pwsh
+        run: pip install clang-tidy==${{ env.LLVM_VERSION }}
+
       - name: Run clang-tidy
         id: tidy
         shell: pwsh
         run: |
           $sdkRoot    = "C:\OpenSiv3D_SDK_${{ env.SIV3D_VERSION }}"
           $projectDir = "$env:GITHUB_WORKSPACE\Ash2"
+          $clangTidy  = python -c "import clang_tidy; print(clang_tidy.get_executable('clang-tidy'))"
+          & $clangTidy --version
 
           $tidyOpts = @(
             "--header-filter=.*Ash2[\\/](src|tests)[\\/].*"
@@ -85,7 +92,7 @@ jobs:
             Where-Object { $_.Name -ne "stdafx.cpp" } |
             ForEach-Object {
               Write-Host "Checking: $($_.Name)"
-              $output = clang-tidy @tidyOpts $_.FullName '--' @compileFlags 2>&1
+              $output = & $clangTidy @tidyOpts $_.FullName '--' @compileFlags 2>&1
               $output | Write-Host
               $output | Out-File -FilePath $rawLog -Append -Encoding utf8
               if ($LASTEXITCODE -ne 0) { $hasWarnings = $true }

--- a/Ash2/.clang-format
+++ b/Ash2/.clang-format
@@ -1,5 +1,8 @@
 BasedOnStyle: Google
 AlignAfterOpenBracket: BlockIndent
+# 開き括弧への揃えより、スコープからのブロックインデントを優先させる。
+# 有効域は 6〜9（5 以下ではぶら下がり字下げが残り、10 以上では返り値の型が分断される）
+PenaltyIndentedWhitespace: 8
 PenaltyBreakScopeResolution: 1000000
 SortIncludes: CaseSensitive
 IncludeBlocks: Regroup

--- a/Ash2/src/Config/AnimationData.cpp
+++ b/Ash2/src/Config/AnimationData.cpp
@@ -10,15 +10,18 @@ namespace {
     const TOMLValue& clip, StringView name
 ) {
   TomlFields f{clip, U"AnimationData::ParseClip", String{name}};
-  return f.wrap(AnimationClip{
-      .row = f.get<int32>(U"row"),
-      .count = f.get<int32>(U"count"),
-      .speed = f.get<double>(U"speed"),
-  });
+  return f.wrap(
+      AnimationClip{
+          .row = f.get<int32>(U"row"),
+          .count = f.get<int32>(U"count"),
+          .speed = f.get<double>(U"speed"),
+      }
+  );
 }
 
 /// @brief TOML からアニメーション共有データを生成する
-[[nodiscard]] std::expected<AnimationData, String> Parse(const TOMLValue& toml
+[[nodiscard]] std::expected<AnimationData, String> Parse(
+    const TOMLValue& toml
 ) {
   TomlFields f{toml, U"AnimationData::Parse"};
   const auto textureKey = f.get<String>(U"texture");
@@ -35,11 +38,13 @@ namespace {
     return std::unexpected{std::move(result).error()};
   }
 
-  auto wrapped = f.wrap(AnimationData{
-      .textureKey = textureKey,
-      .size = size,
-      .drawOffset = drawOffset,
-  });
+  auto wrapped = f.wrap(
+      AnimationData{
+          .textureKey = textureKey,
+          .size = size,
+          .drawOffset = drawOffset,
+      }
+  );
   if (!wrapped) {
     return std::unexpected{std::move(wrapped).error()};
   }

--- a/Ash2/src/Config/EnemyConfig.cpp
+++ b/Ash2/src/Config/EnemyConfig.cpp
@@ -7,21 +7,23 @@ namespace {
 /// @brief TOML から EnemyConfig を生成する
 [[nodiscard]] std::expected<EnemyConfig, String> Parse(const TOMLValue& toml) {
   TomlFields f{toml, U"EnemyConfig::Parse"};
-  return f.wrap(EnemyConfig{
-      .maxHp = f.get<int32>(U"max_hp"),
-      .size = {f.get<double>(U"size_w"), f.get<double>(U"size_h")},
-      .capsuleRadius = f.get<double>(U"capsule_radius"),
-      .capsuleHeight = f.get<double>(U"capsule_height"),
-      .spawnW = f.get<double>(U"spawn_w"),
-      .staggerSec = f.get<double>(U"stagger_sec"),
-      .repelSpeed = f.get<double>(U"repel_speed"),
-      .repelSec = f.get<double>(U"repel_sec"),
-      .blowSpeedW = f.get<double>(U"blow_speed_w"),
-      .blowSpeedH = f.get<double>(U"blow_speed_h"),
-      .knockbackSec = f.get<double>(U"knockback_sec"),
-      .defeatedSec = f.get<double>(U"defeated_sec"),
-      .respawnSec = f.get<double>(U"respawn_sec"),
-  });
+  return f.wrap(
+      EnemyConfig{
+          .maxHp = f.get<int32>(U"max_hp"),
+          .size = {f.get<double>(U"size_w"), f.get<double>(U"size_h")},
+          .capsuleRadius = f.get<double>(U"capsule_radius"),
+          .capsuleHeight = f.get<double>(U"capsule_height"),
+          .spawnW = f.get<double>(U"spawn_w"),
+          .staggerSec = f.get<double>(U"stagger_sec"),
+          .repelSpeed = f.get<double>(U"repel_speed"),
+          .repelSec = f.get<double>(U"repel_sec"),
+          .blowSpeedW = f.get<double>(U"blow_speed_w"),
+          .blowSpeedH = f.get<double>(U"blow_speed_h"),
+          .knockbackSec = f.get<double>(U"knockback_sec"),
+          .defeatedSec = f.get<double>(U"defeated_sec"),
+          .respawnSec = f.get<double>(U"respawn_sec"),
+      }
+  );
 }
 
 }  // namespace

--- a/Ash2/src/Config/PlayerConfig.cpp
+++ b/Ash2/src/Config/PlayerConfig.cpp
@@ -13,12 +13,14 @@ namespace {
     const TOMLValue& toml, StringView section
 ) {
   TomlFields f{toml, U"PlayerConfig::ParseTimeline", String{section}};
-  return f.wrap(MotionTimeline{
-      .windupSec = f.get<double>(U"windup_sec"),
-      .activeSec = f.get<double>(U"active_sec"),
-      .recoveryASec = f.get<double>(U"recovery_a_sec"),
-      .recoveryBSec = f.get<double>(U"recovery_b_sec"),
-  });
+  return f.wrap(
+      MotionTimeline{
+          .windupSec = f.get<double>(U"windup_sec"),
+          .activeSec = f.get<double>(U"active_sec"),
+          .recoveryASec = f.get<double>(U"recovery_a_sec"),
+          .recoveryBSec = f.get<double>(U"recovery_b_sec"),
+      }
+  );
 }
 
 /// @brief TOML の trajectory 文字列を MeleeTrajectory へ変換する
@@ -84,11 +86,13 @@ namespace {
   TomlFields f{
       finisherToml, U"PlayerConfig::ParseMeleeFinisher", U"melee.finisher"
   };
-  auto finisher = f.wrap(MeleeFinisherConfig{
-      .swing = *std::move(swing),
-      .lightCount = f.get<int32>(U"light_count"),
-      .lightGap = f.get<double>(U"light_gap"),
-  });
+  auto finisher = f.wrap(
+      MeleeFinisherConfig{
+          .swing = *std::move(swing),
+          .lightCount = f.get<int32>(U"light_count"),
+          .lightGap = f.get<double>(U"light_gap"),
+      }
+  );
   if (!finisher) {
     return std::unexpected{std::move(finisher).error()};
   }
@@ -106,7 +110,8 @@ namespace {
 }
 
 /// @brief TOML から近接攻撃の設定値を生成する
-[[nodiscard]] std::expected<MeleeConfig, String> ParseMelee(const TOMLValue& m
+[[nodiscard]] std::expected<MeleeConfig, String> ParseMelee(
+    const TOMLValue& m
 ) {
   Array<MeleeSwingConfig> chain;
   // Why not: m[U"chain"] がテーブル配列として存在しない場合に
@@ -127,7 +132,8 @@ namespace {
   // chain が空だと Tick(MeleeChain&, ...) の chain[state.stage] アクセスが
   // 不正になるため許容しない
   if (chain.isEmpty()) {
-    return std::unexpected{U"PlayerConfig::ParseMelee: melee.chain がありません"
+    return std::unexpected{
+        U"PlayerConfig::ParseMelee: melee.chain がありません"
     };
   }
 
@@ -137,27 +143,32 @@ namespace {
   }
 
   TomlFields f{m, U"PlayerConfig::ParseMelee", U"melee"};
-  return f.wrap(MeleeConfig{
-      .capMidH = f.get<double>(U"cap_mid_h"),
-      .reach = f.get<double>(U"reach"),
-      .damage = f.get<int32>(U"damage"),
-      .chain = std::move(chain),
-      .finisher = *std::move(finisher),
-  });
+  return f.wrap(
+      MeleeConfig{
+          .capMidH = f.get<double>(U"cap_mid_h"),
+          .reach = f.get<double>(U"reach"),
+          .damage = f.get<int32>(U"damage"),
+          .chain = std::move(chain),
+          .finisher = *std::move(finisher),
+      }
+  );
 }
 
 /// @brief TOML から遠距離攻撃の設定値を生成する
-[[nodiscard]] std::expected<RangedConfig, String> ParseRanged(const TOMLValue& r
+[[nodiscard]] std::expected<RangedConfig, String> ParseRanged(
+    const TOMLValue& r
 ) {
   TomlFields f{r, U"PlayerConfig::ParseRanged", U"ranged"};
-  return f.wrap(RangedConfig{
-      .reach = f.get<double>(U"reach"),
-      .radius = f.get<double>(U"radius"),
-      .damage = f.get<int32>(U"damage"),
-      .bulletSpeed = f.get<double>(U"bullet_speed"),
-      .spawnHeight = f.get<double>(U"spawn_height"),
-      .staminaCost = f.get<int32>(U"stamina_cost"),
-  });
+  return f.wrap(
+      RangedConfig{
+          .reach = f.get<double>(U"reach"),
+          .radius = f.get<double>(U"radius"),
+          .damage = f.get<int32>(U"damage"),
+          .bulletSpeed = f.get<double>(U"bullet_speed"),
+          .spawnHeight = f.get<double>(U"spawn_height"),
+          .staminaCost = f.get<int32>(U"stamina_cost"),
+      }
+  );
 }
 
 /// @brief TOML からダッシュの設定値を生成する
@@ -168,11 +179,13 @@ namespace {
   }
 
   TomlFields f{d, U"PlayerConfig::ParseDash", U"dash"};
-  return f.wrap(DashConfig{
-      .speed = f.get<double>(U"speed"),
-      .timeline = *std::move(timeline),
-      .staminaCost = f.get<int32>(U"stamina_cost"),
-  });
+  return f.wrap(
+      DashConfig{
+          .speed = f.get<double>(U"speed"),
+          .timeline = *std::move(timeline),
+          .staminaCost = f.get<int32>(U"stamina_cost"),
+      }
+  );
 }
 
 /// @brief TOML からダッシュ攻撃の設定値を生成する
@@ -185,14 +198,16 @@ namespace {
   }
 
   TomlFields f{da, U"PlayerConfig::ParseDashAttack", U"dash_attack"};
-  return f.wrap(DashAttackConfig{
-      .timeline = *std::move(timeline),
-      .speed = f.get<double>(U"speed"),
-      .orbitRadius = f.get<double>(U"orbit_radius"),
-      .radius = f.get<double>(U"radius"),
-      .damage = f.get<int32>(U"damage"),
-      .hitstopSec = f.get<double>(U"hitstop_sec"),
-  });
+  return f.wrap(
+      DashAttackConfig{
+          .timeline = *std::move(timeline),
+          .speed = f.get<double>(U"speed"),
+          .orbitRadius = f.get<double>(U"orbit_radius"),
+          .radius = f.get<double>(U"radius"),
+          .damage = f.get<int32>(U"damage"),
+          .hitstopSec = f.get<double>(U"hitstop_sec"),
+      }
+  );
 }
 
 /// @brief TOML から空中攻撃の設定値を生成する
@@ -205,13 +220,15 @@ namespace {
   }
 
   TomlFields f{aa, U"PlayerConfig::ParseAirAttack", U"air_attack"};
-  return f.wrap(AirAttackConfig{
-      .timeline = *std::move(timeline),
-      .orbitRadius = f.get<double>(U"orbit_radius"),
-      .radius = f.get<double>(U"radius"),
-      .damage = f.get<int32>(U"damage"),
-      .hitstopSec = f.get<double>(U"hitstop_sec"),
-  });
+  return f.wrap(
+      AirAttackConfig{
+          .timeline = *std::move(timeline),
+          .orbitRadius = f.get<double>(U"orbit_radius"),
+          .radius = f.get<double>(U"radius"),
+          .damage = f.get<int32>(U"damage"),
+          .hitstopSec = f.get<double>(U"hitstop_sec"),
+      }
+  );
 }
 
 /// @brief TOML からスタミナ回復の設定値を生成する
@@ -219,10 +236,12 @@ namespace {
     const TOMLValue& s
 ) {
   TomlFields f{s, U"PlayerConfig::ParseStamina", U"stamina"};
-  return f.wrap(StaminaConfig{
-      .recoveryDelay = f.get<double>(U"recovery_delay"),
-      .recoveryRate = f.get<double>(U"recovery_rate"),
-  });
+  return f.wrap(
+      StaminaConfig{
+          .recoveryDelay = f.get<double>(U"recovery_delay"),
+          .recoveryRate = f.get<double>(U"recovery_rate"),
+      }
+  );
 }
 
 /// @brief TOML から着地硬直の設定値を生成する
@@ -230,9 +249,11 @@ namespace {
     const TOMLValue& l
 ) {
   TomlFields f{l, U"PlayerConfig::ParseLanding", U"landing"};
-  return f.wrap(LandingConfig{
-      .recoverySec = f.get<double>(U"recovery_sec"),
-  });
+  return f.wrap(
+      LandingConfig{
+          .recoverySec = f.get<double>(U"recovery_sec"),
+      }
+  );
 }
 
 /// @brief TOML から攻撃演出共通の設定値を生成する
@@ -240,9 +261,11 @@ namespace {
     const TOMLValue& ae
 ) {
   TomlFields f{ae, U"PlayerConfig::ParseAttackEffect", U"attack_effect"};
-  return f.wrap(AttackEffectConfig{
-      .fadeSec = f.get<double>(U"fade_sec"),
-  });
+  return f.wrap(
+      AttackEffectConfig{
+          .fadeSec = f.get<double>(U"fade_sec"),
+      }
+  );
 }
 
 /// @brief TOML からプレイヤー設定を生成する
@@ -281,19 +304,21 @@ namespace {
   }
 
   TomlFields f{toml, U"PlayerConfig::Parse"};
-  return f.wrap(PlayerConfig{
-      .speed = f.get<double>(U"speed"),
-      .jumpSpeed = f.get<double>(U"jump_speed"),
-      .gravity = f.get<double>(U"gravity"),
-      .melee = *std::move(melee),
-      .ranged = *std::move(ranged),
-      .dash = *std::move(dash),
-      .dashAttack = *std::move(dashAttack),
-      .airAttack = *std::move(airAttack),
-      .stamina = *std::move(stamina),
-      .landing = *std::move(landing),
-      .attackEffect = *std::move(attackEffect),
-  });
+  return f.wrap(
+      PlayerConfig{
+          .speed = f.get<double>(U"speed"),
+          .jumpSpeed = f.get<double>(U"jump_speed"),
+          .gravity = f.get<double>(U"gravity"),
+          .melee = *std::move(melee),
+          .ranged = *std::move(ranged),
+          .dash = *std::move(dash),
+          .dashAttack = *std::move(dashAttack),
+          .airAttack = *std::move(airAttack),
+          .stamina = *std::move(stamina),
+          .landing = *std::move(landing),
+          .attackEffect = *std::move(attackEffect),
+      }
+  );
 }
 
 }  // namespace

--- a/Ash2/src/Debug.hpp
+++ b/Ash2/src/Debug.hpp
@@ -6,9 +6,10 @@ namespace AppDebug {
 inline bool testMode = false;
 }  // namespace AppDebug
 // 複数値の結合には << でなく + か Format() を使う: APP_LOG(U"n=" + Format(n))
-#define APP_LOG(msg)                         \
-  (AppDebug::testMode ? static_cast<void>(0) \
-                      : static_cast<void>(Console << (msg)))
+#define APP_LOG(msg)          \
+  (AppDebug::testMode         \
+       ? static_cast<void>(0) \
+       : static_cast<void>(Console << (msg)))
 #else
 #define APP_LOG(msg) static_cast<void>(0)
 #endif

--- a/Ash2/src/Input/InputDeviceSelector.hpp
+++ b/Ash2/src/Input/InputDeviceSelector.hpp
@@ -34,11 +34,13 @@ inline InputState InputDeviceSelector::update() {
        XInput(0).buttonX.down() || XInput(0).buttonY.down() ||
        !stickAxis.isZero())) {
     m_activeDevice = Device::Gamepad;
-  } else if (!Keyboard::GetAllInputs().isEmpty() ||
-             !Mouse::GetAllInputs().isEmpty()) {
+  } else if (
+      !Keyboard::GetAllInputs().isEmpty() || !Mouse::GetAllInputs().isEmpty()
+  ) {
     m_activeDevice = Device::Keyboard;
   }
 
-  return (m_activeDevice == Device::Gamepad) ? XInputAction::ToInputState()
-                                             : m_keyboardAction.toInputState();
+  return (m_activeDevice == Device::Gamepad)
+             ? XInputAction::ToInputState()
+             : m_keyboardAction.toInputState();
 }

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -88,9 +88,11 @@ IPhase::PhaseCommand AnimationViewerPhase::update(
   Scene::SetBackground(ColorF{kBgBrightness});
   m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(kTitleX, kTitleY);
   if (!m_clips.empty()) {
-    m_font(U"Clip [{}/{}]: {}"_fmt(
-               m_clipIndex + 1, m_clips.size(), m_clips[m_clipIndex]
-           ))
+    m_font(
+        U"Clip [{}/{}]: {}"_fmt(
+            m_clipIndex + 1, m_clips.size(), m_clips[m_clipIndex]
+        )
+    )
         .draw(kTitleX, kClipInfoY);
   }
   m_font(U"← → : clip  F : flip  Esc : back")

--- a/Ash2/src/Phase/PhaseLoaders.cpp
+++ b/Ash2/src/Phase/PhaseLoaders.cpp
@@ -10,9 +10,10 @@ namespace {
 
 /// @brief IPhase を継承し、const Param& から構築可能な Param を持つフェーズ型
 template <typename T>
-concept PhaseWithParam = std::derived_from<T, IPhase> &&
-                         std::move_constructible<typename T::Param> &&
-                         std::constructible_from<T, const typename T::Param&>;
+concept PhaseWithParam =
+    std::derived_from<T, IPhase> &&
+    std::move_constructible<typename T::Param> &&
+    std::constructible_from<T, const typename T::Param&>;
 
 /// @brief 型 T のパラメータを保持し、make() で T を生成する IPhaseMaker
 template <PhaseWithParam T>
@@ -33,8 +34,8 @@ class PhaseMaker : public IPhaseMaker {
 /// unexpected でエラーメッセージを返す）
 template <PhaseWithParam T, typename F>
 PhaseLoader MakeLoader(F&& parse) {
-  return [p = std::forward<F>(parse)](const TOMLValue& step
-         ) -> std::expected<IPhaseMaker::Ptr, String> {
+  return [p = std::forward<F>(parse)](const TOMLValue& step)
+             -> std::expected<IPhaseMaker::Ptr, String> {
     auto param = p(step);
     if (!param) {
       return std::unexpected{std::move(param).error()};
@@ -62,8 +63,8 @@ const PhaseLoaderTable& GetPhaseLoaders() {
        )},
       {U"animation_viewer",
        MakeLoader<AnimationViewerPhase>(
-           [](const TOMLValue& step
-           ) -> std::expected<AnimationViewerPhase::Param, String> {
+           [](const TOMLValue& step)
+               -> std::expected<AnimationViewerPhase::Param, String> {
              const auto dataKey = step[U"param"].getOpt<String>();
              if (!dataKey) {
                return std::unexpected{
@@ -76,8 +77,8 @@ const PhaseLoaderTable& GetPhaseLoaders() {
        )},
       {U"scenario",
        MakeLoader<ScenarioPhase>(
-           [](const TOMLValue& step
-           ) -> std::expected<ScenarioPhase::Param, String> {
+           [](const TOMLValue& step)
+               -> std::expected<ScenarioPhase::Param, String> {
              const auto sectionName = step[U"param"].getOpt<String>();
              if (!sectionName) {
                return std::unexpected{
@@ -89,8 +90,8 @@ const PhaseLoaderTable& GetPhaseLoaders() {
        )},
       {U"wait",
        MakeLoader<WaitPhase>(
-           [](const TOMLValue& step
-           ) -> std::expected<WaitPhase::Param, String> {
+           [](const TOMLValue& step)
+               -> std::expected<WaitPhase::Param, String> {
              const auto duration = step[U"duration"].getOpt<double>();
              if (!duration) {
                return std::unexpected{

--- a/Ash2/src/System/DrawSystem.cpp
+++ b/Ash2/src/System/DrawSystem.cpp
@@ -21,8 +21,9 @@ void DrawSystem::Draw(const entt::registry& registry) {
        registry.view<const WorldPos, const Drawable>().each()) {
     const auto* drawColor = registry.try_get<DrawColor>(entity);
     entries.push_back(
-        {std::cref(pos), std::cref(drawable),
-         (drawColor != nullptr) ? drawColor->color : kDefaultDrawColor}
+        {.pos = std::cref(pos),
+         .drawable = std::cref(drawable),
+         .color = (drawColor != nullptr) ? drawColor->color : kDefaultDrawColor}
     );
   }
 

--- a/Ash2/src/System/HitReactionSystem.cpp
+++ b/Ash2/src/System/HitReactionSystem.cpp
@@ -36,11 +36,11 @@ void HitReactionSystem::Apply(
     if (attack.hitstopSec > 0.0) {
       // 長い停止中に別ヒットの短い停止で上書きされないよう、
       // 既に付与済みなら長い方を残す
-      const auto grantHitstop = [&registry,
-                                 sec = attack.hitstopSec](entt::entity e) {
-        auto& hitstop = registry.get_or_emplace<Hitstop>(e);
-        hitstop.remaining = Max(hitstop.remaining, sec);
-      };
+      const auto grantHitstop =
+          [&registry, sec = attack.hitstopSec](entt::entity e) {
+            auto& hitstop = registry.get_or_emplace<Hitstop>(e);
+            hitstop.remaining = Max(hitstop.remaining, sec);
+          };
       grantHitstop(attackerOwner);
       grantHitstop(hit.target);
     }

--- a/Ash2/src/System/PlayerMotion/AirAttack.cpp
+++ b/Ash2/src/System/PlayerMotion/AirAttack.cpp
@@ -24,8 +24,9 @@ Vec3 AirAttackOrbOffset(
     double progress, const AirAttackConfig& aa, double capMidH, bool facingRight
 ) {
   const double angle = Math::TwoPi * progress;
-  const double w = facingRight ? aa.orbitRadius * Math::Cos(angle)
-                               : -aa.orbitRadius * Math::Cos(angle);
+  const double w =
+      facingRight ? aa.orbitRadius * Math::Cos(angle)
+                  : -aa.orbitRadius * Math::Cos(angle);
   return Vec3{w, capMidH - aa.orbitRadius * Math::Sin(angle), 0.0};
 }
 

--- a/Ash2/src/System/PlayerMotion/Melee.cpp
+++ b/Ash2/src/System/PlayerMotion/Melee.cpp
@@ -160,8 +160,7 @@ Optional<Motion> Tick(
           .radius = swing.radius,
           .fadeSec = cfg.attackEffect.fadeSec
       },
-      state.lightEntities,
-      [&offsetFn](double progress, int32 /*index*/) {
+      state.lightEntities, [&offsetFn](double progress, int32 /*index*/) {
         return offsetFn(progress);
       }
   );

--- a/Ash2/src/System/PlayerMotion/Neutral.cpp
+++ b/Ash2/src/System/PlayerMotion/Neutral.cpp
@@ -55,8 +55,10 @@ Optional<Motion> Tick(
     vel.w = 0.0;
     vel.d = 0.0;
     return MakeAirAttack(anim);
-  } else if (input.rangedAttackDown &&
-             registry.get<Stamina>(entity).current >= cfg.ranged.staminaCost) {
+  } else if (
+      input.rangedAttackDown &&
+      registry.get<Stamina>(entity).current >= cfg.ranged.staminaCost
+  ) {
     // 空中遠距離攻撃への入場。Ranged は地上・空中で共有するため、
     // 着地しても Landing を挟まずタイマー満了で Neutral
     // に戻る（地上と同一挙動）。
@@ -64,8 +66,10 @@ Optional<Motion> Tick(
     vel.d = 0.0;
     SpawnProjectile(registry, pos, anim.facingRight, cfg);
     return MakeRanged(registry, entity, cfg, anim);
-  } else if (input.dashDown &&
-             registry.get<Stamina>(entity).current >= cfg.dash.staminaCost) {
+  } else if (
+      input.dashDown &&
+      registry.get<Stamina>(entity).current >= cfg.dash.staminaCost
+  ) {
     // 空中ダッシュへの入場（Dash::Tick が air フラグにより接地検出で Landing
     // へ遷移させる）
     return MakeDash(registry, entity, cfg, anim, /*air=*/true);

--- a/Ash2/tests/TestEnemyMotionSystem.cpp
+++ b/Ash2/tests/TestEnemyMotionSystem.cpp
@@ -82,7 +82,8 @@ TEST_CASE(
   const auto& rect = std::get<RectDrawable>(registry.get<Drawable>(enemy));
   REQUIRE(rect.size.x == Approx(60.0));
   REQUIRE(rect.size.y == Approx(80.0));
-  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
   );
 }
 
@@ -99,7 +100,8 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(0.0));
-  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
   );
 }
 
@@ -113,8 +115,9 @@ TEST_CASE("EnemyMotionSystem - Repel keeps velocity while remaining") {
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(-250.0));
-  REQUIRE(std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(enemy)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(enemy))
+  );
 }
 
 TEST_CASE(
@@ -136,7 +139,8 @@ TEST_CASE(
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(300.0));
 }
 
-TEST_CASE("EnemyMotionSystem - Knockback zeroes horizontal velocity on landing"
+TEST_CASE(
+    "EnemyMotionSystem - Knockback zeroes horizontal velocity on landing"
 ) {
   entt::registry registry;
   SetupContext(registry);
@@ -150,9 +154,11 @@ TEST_CASE("EnemyMotionSystem - Knockback zeroes horizontal velocity on landing"
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.get<Velocity>(enemy).w == Approx(0.0));
-  REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(enemy)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Knockback>(
+          registry.get<Motion>(enemy)
+      )
+  );
 }
 
 TEST_CASE(
@@ -181,7 +187,8 @@ TEST_CASE("EnemyMotionSystem - Knockback transitions to Idle on expiry") {
   const FrameData frameData{.dt = 0.02};
   MotionSystem::Update(registry, frameData);
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(enemy))
   );
 }
 
@@ -228,7 +235,8 @@ TEST_CASE("EnemySystem - destroys entity when Defeated has expired") {
   REQUIRE_FALSE(registry.valid(enemy));
 }
 
-TEST_CASE("EnemySystem - keeps entity while Defeated still has remaining time"
+TEST_CASE(
+    "EnemySystem - keeps entity while Defeated still has remaining time"
 ) {
   entt::registry registry;
   SetupContext(registry);

--- a/Ash2/tests/TestHierarchy.cpp
+++ b/Ash2/tests/TestHierarchy.cpp
@@ -100,7 +100,8 @@ TEST_CASE(
   REQUIRE(registry.get<const WorldPos>(child).w == Approx(501.0));
 }
 
-TEST_CASE("Hierarchy::Detach - detached child stops following and loses offset"
+TEST_CASE(
+    "Hierarchy::Detach - detached child stops following and loses offset"
 ) {
   entt::registry registry;
   HierarchySystem::Connect(registry);

--- a/Ash2/tests/TestHitReactionSystem.cpp
+++ b/Ash2/tests/TestHitReactionSystem.cpp
@@ -99,8 +99,9 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(target
-  )));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Repel>(registry.get<Motion>(target))
+  );
   REQUIRE(registry.get<Velocity>(target).w == Approx(250.0));
 }
 
@@ -117,9 +118,11 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Knockback>(
+          registry.get<Motion>(target)
+      )
+  );
   REQUIRE(registry.get<Velocity>(target).w == Approx(300.0));
   REQUIRE(registry.get<Velocity>(target).h == Approx(300.0));
 }
@@ -134,8 +137,9 @@ TEST_CASE("HitReactionSystem - None reaction leaves Enemy in Idle") {
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Idle>(registry.get<Motion>(target))
+  );
 }
 
 TEST_CASE(
@@ -152,9 +156,11 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Defeated>(
-      registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Defeated>(
+          registry.get<Motion>(target)
+      )
+  );
   REQUIRE_FALSE(registry.all_of<Collider>(target));
   REQUIRE_FALSE(registry.all_of<Hp>(target));
 }
@@ -208,9 +214,11 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Knockback>(
+          registry.get<Motion>(target)
+      )
+  );
   REQUIRE_FALSE(registry.all_of<Hitstop>(target));
 }
 
@@ -229,9 +237,11 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Defeated>(
-      registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Defeated>(
+          registry.get<Motion>(target)
+      )
+  );
   REQUIRE_FALSE(registry.all_of<Hitstop>(target));
 }
 
@@ -271,9 +281,11 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Knockback>(
+          registry.get<Motion>(target)
+      )
+  );
   const auto& rect = std::get<RectDrawable>(registry.get<Drawable>(target));
   REQUIRE(rect.size.y == Approx(80.0));
 }
@@ -296,9 +308,11 @@ TEST_CASE(
       registry, {HitPair{.attacker = attacker, .target = target}}
   );
 
-  REQUIRE(std::holds_alternative<EnemyMotion::Knockback>(
-      registry.get<Motion>(target)
-  ));
+  REQUIRE(
+      std::holds_alternative<EnemyMotion::Knockback>(
+          registry.get<Motion>(target)
+      )
+  );
   REQUIRE(registry.get<Velocity>(target).w == Approx(300.0));
   REQUIRE(registry.get<Velocity>(target).h == Approx(300.0));
 }

--- a/Ash2/tests/TestPlayerMotionSystem.cpp
+++ b/Ash2/tests/TestPlayerMotionSystem.cpp
@@ -838,8 +838,10 @@ TEST_CASE(
   frameData1.input.attackDown = true;
   MotionSystem::Update(registry, frameData1);
 
-  REQUIRE(std::get<PlayerMotion::MeleeChain>(registry.get<Motion>(player))
-              .comboQueued);
+  REQUIRE(
+      std::get<PlayerMotion::MeleeChain>(registry.get<Motion>(player))
+          .comboQueued
+  );
 
   // 2フレーム目：攻撃入力なし、comboQueued は立ったまま
   const FrameData frameData2{.dt = 0.01};
@@ -1101,7 +1103,8 @@ TEST_CASE(
   const auto& finisher = std::get<PlayerMotion::MeleeFinisher>(motion);
   REQUIRE(finisher.hitboxEntity != entt::entity{entt::null});
   REQUIRE(registry.valid(finisher.hitboxEntity));
-  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(finisher.hitboxEntity)
+  REQUIRE(
+      registry.all_of<Collider, Attack, LocalOffset>(finisher.hitboxEntity)
   );
 
   const auto& attack = registry.get<Attack>(finisher.hitboxEntity);
@@ -1304,7 +1307,8 @@ TEST_CASE(
   const auto& motion = registry.get<Motion>(player);
   const auto& finisher = std::get<PlayerMotion::MeleeFinisher>(motion);
   REQUIRE(finisher.hitboxEntity != entt::entity{entt::null});
-  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(finisher.hitboxEntity)
+  REQUIRE(
+      registry.all_of<Collider, Attack, LocalOffset>(finisher.hitboxEntity)
   );
   REQUIRE_FALSE(registry.all_of<Drawable>(finisher.hitboxEntity));
 
@@ -1446,7 +1450,8 @@ TEST_CASE(
   REQUIRE(registry.get<Stamina>(player).current == 10);
 }
 
-TEST_CASE("PlayerMotionSystem - Dash grants Invincible during windup and dash"
+TEST_CASE(
+    "PlayerMotionSystem - Dash grants Invincible during windup and dash"
 ) {
   // 構え・ダッシュ中（elapsed < activeEnd）は Invincible が付与される
   entt::registry registry;
@@ -1460,11 +1465,13 @@ TEST_CASE("PlayerMotionSystem - Dash grants Invincible during windup and dash"
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.all_of<Invincible>(player));
-  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player
-  )));
+  REQUIRE(
+      std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player))
+  );
 }
 
-TEST_CASE("PlayerMotionSystem - Dash removes Invincible when entering recovery"
+TEST_CASE(
+    "PlayerMotionSystem - Dash removes Invincible when entering recovery"
 ) {
   // activeEnd(0.15) を超えた時点で Invincible が除去される
   entt::registry registry;
@@ -1501,7 +1508,8 @@ TEST_CASE(
   REQUIRE(vel.d == Approx(0.0));
 }
 
-TEST_CASE("PlayerMotionSystem - Dash moves in free direction when input given"
+TEST_CASE(
+    "PlayerMotionSystem - Dash moves in free direction when input given"
 ) {
   // ダッシュ中にフリー方向の移動入力があればその方向へ移動する
   entt::registry registry;
@@ -1760,8 +1768,9 @@ TEST_CASE(
   MotionSystem::Update(registry, frameData);
 
   REQUIRE(registry.all_of<Invincible>(player));
-  REQUIRE(std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player
-  )));
+  REQUIRE(
+      std::holds_alternative<PlayerMotion::Dash>(registry.get<Motion>(player))
+  );
 }
 
 TEST_CASE(
@@ -1996,8 +2005,9 @@ TEST_CASE(
   const auto& dashAttack = std::get<PlayerMotion::DashAttack>(motion);
   REQUIRE(dashAttack.hitboxEntity != entt::entity{entt::null});
   REQUIRE(registry.valid(dashAttack.hitboxEntity));
-  REQUIRE(registry.all_of<Collider, Attack, LocalOffset>(dashAttack.hitboxEntity
-  ));
+  REQUIRE(
+      registry.all_of<Collider, Attack, LocalOffset>(dashAttack.hitboxEntity)
+  );
 
   // 進行度0.25 → 円上の点（w=0、h=capMidH(40.0)、d=orbitRadius(30.0)）
   const auto& localOffset = registry.get<LocalOffset>(dashAttack.hitboxEntity);

--- a/Ash2/tests/TestProjectileSystem.cpp
+++ b/Ash2/tests/TestProjectileSystem.cpp
@@ -37,7 +37,8 @@ entt::entity MakeBullet(
 
 }  // namespace
 
-TEST_CASE("ProjectileSystem - destroys bullet on impact (hitTargets non-empty)"
+TEST_CASE(
+    "ProjectileSystem - destroys bullet on impact (hitTargets non-empty)"
 ) {
   // Attack.hitTargets が空でなくなった（HitSystem
   // がヒットを記録した）場合は破棄される

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -14,7 +14,7 @@
 | Siv3D v0.6.16 | ゲームエンジン SDK | [公式サイト](https://siv3d.github.io/ja-jp/)のインストーラ |
 | vcpkg | C++ パッケージ管理（entt を manifest モードで取得） | 下記参照 |
 | Python 3 | `tools/sync-assets.sh` が使用（ビルド時に自動実行） | `winget install Python.Python.3.12` |
-| clang-format / clang-tidy | 整形・静的解析 | Visual Studio に同梱（下記参照） |
+| clang-format / clang-tidy | 整形・静的解析 | `pip install`（下記参照） |
 | GitHub CLI（gh） | PR・issue 操作 | `winget install GitHub.cli` |
 | Claude Code | 開発フローの中心（`.claude/` のスキル・エージェントを実行） | 下記参照 |
 
@@ -61,22 +61,28 @@ winget install Python.Python.3.12
 
 ### 5. clang-format / clang-tidy
 
-Visual Studio の C++ ワークロードに同梱されているものを使う。
-**LLVM 19 系を前提とする**（CI が clang-format-19 を使うため。
-VS 2022 17.14 の同梱バージョンは 19.1.x。18 系以前だった場合は VS が 17.14 より古いので、
-Visual Studio Installer から VS 本体を更新する）。
-
-`~/.bashrc` に環境変数を設定する（パスはエディションに合わせて読み替える）:
+CI と同じバージョンに固定するため、pip でインストールする。
 
 ```bash
-export CLANG_FORMAT="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/Llvm/x64/bin/clang-format.exe"
-export CLANG_TIDY="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/Llvm/x64/bin/clang-tidy.exe"
+pip install clang-format==22.1.8 clang-tidy==22.1.8
 ```
+
+`~/.bashrc` に環境変数を設定する。パスは `get_executable` で解決する
+（Python のインストール形態に依存しない）:
+
+```bash
+export CLANG_FORMAT="$(python -c "import clang_format; print(clang_format.get_executable('clang-format'))")"
+export CLANG_TIDY="$(python -c "import clang_tidy; print(clang_tidy.get_executable('clang-tidy'))")"
+```
+
+注意: Visual Studio 同梱の clang-format / clang-tidy を指す旧い export が
+残っていると、そちらが優先されて 19.1.1 を使い続けてしまう。上記の内容で上書きする。
 
 バージョン確認:
 
 ```bash
-"$CLANG_FORMAT" --version   # 19.x であること
+"$CLANG_FORMAT" --version   # 22.1.8 であること
+"$CLANG_TIDY" --version     # 22.1.8 であること
 ```
 
 ### 6. GitHub CLI


### PR DESCRIPTION
close #271

ローカル（VS2022 同梱 19.1.1）と CI（ランナー同梱 20.1.8）で clang-tidy のバージョンが食い違い、CI でしか再現しないエラーが出ていた。最新安定版の LLVM 22.1.8 に統一する。

## 変更内容

- `.github/workflows/clang-format.yml` / `clang-tidy.yml` で LLVM 22.1.8 を明示インストール
- `Ash2/.clang-format` に `PenaltyIndentedWhitespace: 8` を追加
- 上記バージョン・設定での整形差分を全ソースに適用（16 ファイル）
- `Ash2/src/System/DrawSystem.cpp` を指定初期化子に修正
- `docs/SETUP.md` をローカル導入手順に合わせて書き換え

## 技術選択の理由

### 入手方法に PyPI のバイナリホイールを選んだ

Windows・Linux・ローカルの3環境でパッチ番号まで固定できる唯一の経路だった。

- `choco install llvm` は 22.1.7 までしか公開されていない
- 公式インストーラは 434MB のダウンロードが毎回発生する
- apt.llvm.org は 22.1.x 内のパッチ版が浮動する

clang-tidy のホイールは resource ヘッダも同梱するため、`bin/../lib` の解決が効く。

### 実行バイナリを PATH 解決に頼らない

windows ランナーには LLVM 20.1.8 が PATH 上にいる。`clang-tidy` と書くとそちらを拾うため、`clang_tidy.get_executable()` で絶対パスを解決して呼ぶ。ubuntu 側は PEP 668 で `pip install` が弾かれるため pipx を使い、`pipx environment --value PIPX_BIN_DIR` からパスを組み立てる。両方のステップで `--version` を出力し、実際に使われたバージョンをログに残す。

### PenaltyIndentedWhitespace を追加した

clang-format 22 で `AlignAfterOpenBracket` が bool 化され、`BlockIndent` は「引数のブレース初期化を第1引数の隣に置かせない」性質を失った。結果、以下の劣化が生じる。

```cpp
// 19.1.1
registry.emplace<Collider>(
    hitbox,
    Collider{ ... }
);

// 22.1.8（設定そのまま）
registry.emplace<Collider>(
    hitbox, Collider{
                ...
            }
);
```

`PenaltyIndentedWhitespace` はインデント1単位あたりのコストを定める設定で、既存の `AlignAfterOpenBracket: BlockIndent` と同じ「開き括弧への揃えより、スコープからのブロックインデントを優先する」という方針を、三項演算子やラムダにも広げる。

有効域は 6〜9。5 以下ではぶら下がりが残り、10 以上では返り値の型が独立行に分断される。中央寄りの 8 を採った。

`BinPackArguments: false` も同じ劣化を回避できるが、詰めて書かれた呼び出しが全て1行1引数に展開され縦に伸びるため見送った。

### 残る整形差分について

引数がブレース初期化1つだけの呼び出しは、22 では `(` の隣に居座れない。これはどの設定でも避けられず、戻すにはブロックインデント様式そのものを捨てる必要があるため受け入れた。`Config/*.cpp` の差分の大半がこれに当たる。

## 検証

- ソース 16 ファイルの差分が空白のみであることを、空白を除去したトークン比較で確認
- clang-format 22.1.8 の整形チェック: 全 123 ファイル通過
- clang-tidy 22.1.8: リポジトリ全体で指摘ゼロ
- ビルド成功・テスト 191 ケース / 496 アサーション全通過

clang-tidy ワークフローは週次トリガーのため本 PR では走らない。確認する場合は `gh workflow run clang-tidy.yml` の手動起動が必要（約1時間）。

## ローカル環境の更新が必要

マージ後、各端末で以下が必要になる。詳細は `docs/SETUP.md` を参照。

```bash
pip install clang-format==22.1.8 clang-tidy==22.1.8
```

VS 同梱パスを指す `CLANG_FORMAT` / `CLANG_TIDY` の export が残っていると 19.1.1 を使い続けるため、`get_executable` で解決する形に置き換える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)