### PR TITLE
PhaseCommand を variant にして不正な状態を型で防ぐ

### DIFF
--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -49,11 +49,11 @@ void AnimationViewerPhase::onAfterPush(entt::registry& registry) {
   AnimationSystem::Update(registry, 0.0);
 }
 
-IPhase::PhaseCommand AnimationViewerPhase::update(
+PhaseCommand AnimationViewerPhase::update(
     entt::registry& registry, const FrameData& frameData
 ) {
   if (KeyEscape.down()) {
-    return PhaseCommand::Pop();
+    return PhaseCommand::Pop{};
   }
 
   if (!m_clips.empty()) {
@@ -98,7 +98,7 @@ IPhase::PhaseCommand AnimationViewerPhase::update(
   m_font(U"← → : clip  F : flip  Esc : back")
       .draw(kTitleX, kHintY, Palette::Gray);
 
-  return PhaseCommand::None();
+  return PhaseCommand::None{};
 }
 
 void AnimationViewerPhase::onBeforePop(entt::registry& registry) {

--- a/Ash2/src/Phase/IPhase.hpp
+++ b/Ash2/src/Phase/IPhase.hpp
@@ -2,42 +2,52 @@
 
 #include <Siv3D.hpp>
 
+#include <concepts>
 #include <entt/entt.hpp>
+#include <type_traits>
+#include <variant>
 
 #include "Phase/FrameData.hpp"
+
+class IPhase;
+
+/// @brief フェーズスタックへの操作
+class PhaseCommand {
+ public:
+  /// @brief 何もしない
+  struct None {};
+
+  /// @brief スタックから取り出す
+  struct Pop {};
+
+  /// @brief フェーズを積む
+  struct Push {
+    std::unique_ptr<IPhase> nextPhase;
+  };
+
+  /// @brief スタックをクリアして積む
+  struct Reset {
+    std::unique_ptr<IPhase> nextPhase;
+  };
+
+  using Value = std::variant<None, Pop, Push, Reset>;
+
+  /// @brief 要素型（None / Pop / Push / Reset）から暗黙に構築する
+  template <class T>
+    requires(!std::same_as<std::remove_cvref_t<T>, PhaseCommand>) &&
+            std::constructible_from<Value, T>
+  PhaseCommand(T&& command) : m_command(std::forward<T>(command)) {}
+
+  [[nodiscard]] Value& value() { return m_command; }
+  [[nodiscard]] const Value& value() const { return m_command; }
+
+ private:
+  Value m_command;
+};
 
 /// @brief フェーズの基底クラス
 class IPhase {
  public:
-  /// @brief フェーズスタックへの操作を表す構造体
-  struct PhaseCommand {
-    /// @brief 操作の種類
-    enum class Type : uint8 {
-      None,
-      Pop,
-      Push,
-      Reset,
-    };
-
-    Type type;
-    /// 次のフェーズ（Push / Reset 時のみ有効）
-    std::unique_ptr<IPhase> nextPhase;
-
-    /// @brief 何もしないコマンドを返す
-    [[nodiscard]] static PhaseCommand None();
-
-    /// @brief スタックから取り出すコマンドを返す
-    [[nodiscard]] static PhaseCommand Pop();
-
-    /// @brief スタックにフェーズを積むコマンドを返す
-    /// @param phase 次のフェーズ（nullptr 不可）
-    [[nodiscard]] static PhaseCommand Push(std::unique_ptr<IPhase>&& phase);
-
-    /// @brief スタックをクリアしてフェーズを積むコマンドを返す
-    /// @param phase 次のフェーズ（nullptr 不可）
-    [[nodiscard]] static PhaseCommand Reset(std::unique_ptr<IPhase>&& phase);
-  };
-
   virtual ~IPhase() = default;
 
   /// @brief スタックに積まれた直後に呼ばれる
@@ -50,25 +60,3 @@ class IPhase {
   /// @brief スタックから取り出される直前に呼ばれる
   virtual void onBeforePop(entt::registry&) {}
 };
-
-inline IPhase::PhaseCommand IPhase::PhaseCommand::None() {
-  return {.type = Type::None, .nextPhase = nullptr};
-}
-
-inline IPhase::PhaseCommand IPhase::PhaseCommand::Pop() {
-  return {.type = Type::Pop, .nextPhase = nullptr};
-}
-
-inline IPhase::PhaseCommand IPhase::PhaseCommand::Push(
-    std::unique_ptr<IPhase>&& phase
-) {
-  assert(phase != nullptr);
-  return {.type = Type::Push, .nextPhase = std::move(phase)};
-}
-
-inline IPhase::PhaseCommand IPhase::PhaseCommand::Reset(
-    std::unique_ptr<IPhase>&& phase
-) {
-  assert(phase != nullptr);
-  return {.type = Type::Reset, .nextPhase = std::move(phase)};
-}

--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -1,5 +1,7 @@
 #include "Phase/PhaseStack.hpp"
 
+#include "Util/Overloaded.hpp"
+
 PhaseStack::PhaseStack(
     std::unique_ptr<IPhase>&& initialPhase, entt::registry& registry
 ) {
@@ -13,27 +15,22 @@ void PhaseStack::update(entt::registry& registry, const FrameData& frameData) {
 
   auto command = m_stack.back()->update(registry, frameData);
 
-  switch (command.type) {
-    case IPhase::PhaseCommand::Type::None:
-      break;
-
-    case IPhase::PhaseCommand::Type::Pop:
-      pop(registry);
-      break;
-
-    case IPhase::PhaseCommand::Type::Push:
-      assert(command.nextPhase != nullptr);
-      push(registry, std::move(command.nextPhase));
-      break;
-
-    case IPhase::PhaseCommand::Type::Reset:
-      assert(command.nextPhase != nullptr);
-      while (not m_stack.empty()) {
-        pop(registry);
-      }
-      push(registry, std::move(command.nextPhase));
-      break;
-  }
+  std::visit(
+      Overloaded{
+          [](const PhaseCommand::None&) {},
+          [&](const PhaseCommand::Pop&) { pop(registry); },
+          [&](PhaseCommand::Push& cmd) {
+            push(registry, std::move(cmd.nextPhase));
+          },
+          [&](PhaseCommand::Reset& cmd) {
+            while (not m_stack.empty()) {
+              pop(registry);
+            }
+            push(registry, std::move(cmd.nextPhase));
+          },
+      },
+      command.value()
+  );
 }
 
 void PhaseStack::pop(entt::registry& registry) {

--- a/Ash2/src/Phase/PlayerTestPhase.cpp
+++ b/Ash2/src/Phase/PlayerTestPhase.cpp
@@ -98,7 +98,7 @@ entt::entity PlayerTestPhase::spawnEnemy(entt::registry& registry) {
   return enemy;
 }
 
-IPhase::PhaseCommand PlayerTestPhase::update(
+PhaseCommand PlayerTestPhase::update(
     entt::registry& registry, const FrameData& frameData
 ) {
   const double dt = frameData.dt;
@@ -134,10 +134,10 @@ IPhase::PhaseCommand PlayerTestPhase::update(
   }
 
   if (KeyEscape.down()) {
-    return PhaseCommand::Pop();
+    return PhaseCommand::Pop{};
   }
 
-  return PhaseCommand::None();
+  return PhaseCommand::None{};
 }
 
 void PlayerTestPhase::reloadPlayer(entt::registry& registry) {

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -8,13 +8,13 @@ ScenarioPhase::ScenarioPhase(const Param& param)
 
 void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 
-IPhase::PhaseCommand ScenarioPhase::update(
+PhaseCommand ScenarioPhase::update(
     entt::registry& registry, const FrameData& /*frameData*/
 ) {
   const auto& steps =
       registry.ctx().get<ScenarioData>().sections.at(m_sectionName);
   if (m_currentStep >= steps.size()) {
-    return PhaseCommand::Pop();
+    return PhaseCommand::Pop{};
   }
 
   const auto& step = steps[m_currentStep];
@@ -22,11 +22,11 @@ IPhase::PhaseCommand ScenarioPhase::update(
 
   return std::visit(
       Overloaded{
-          [&](const StepPush& s) {
-            return PhaseCommand::Push(s.maker->make());
+          [&](const StepPush& s) -> PhaseCommand {
+            return PhaseCommand::Push{.nextPhase = s.maker->make()};
           },
-          [&](const StepReset& s) {
-            return PhaseCommand::Reset(s.maker->make());
+          [&](const StepReset& s) -> PhaseCommand {
+            return PhaseCommand::Reset{.nextPhase = s.maker->make()};
           },
       },
       step

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -32,7 +32,7 @@ void TestMenuPhase::onAfterPush(entt::registry& /*registry*/) {
   m_selectedIndex = 0;
 }
 
-IPhase::PhaseCommand TestMenuPhase::update(
+PhaseCommand TestMenuPhase::update(
     entt::registry& registry, const FrameData& /*frameData*/
 ) {
   if (KeyUp.down()) {
@@ -44,7 +44,7 @@ IPhase::PhaseCommand TestMenuPhase::update(
 
   if (KeyEnter.down() && !m_items.empty()) {
     auto phase = m_items[m_selectedIndex].create(registry);
-    return PhaseCommand::Push(std::move(phase));
+    return PhaseCommand::Push{.nextPhase = std::move(phase)};
   }
 
   Scene::SetBackground(ColorF{kBgBrightness});
@@ -59,5 +59,5 @@ IPhase::PhaseCommand TestMenuPhase::update(
         );
   }
 
-  return PhaseCommand::None();
+  return PhaseCommand::None{};
 }

--- a/Ash2/src/Phase/WaitPhase.cpp
+++ b/Ash2/src/Phase/WaitPhase.cpp
@@ -2,9 +2,9 @@
 
 WaitPhase::WaitPhase(const Param& param) : m_duration(param.duration) {}
 
-IPhase::PhaseCommand WaitPhase::update(
-    entt::registry&, const FrameData& frameData
-) {
+PhaseCommand WaitPhase::update(entt::registry&, const FrameData& frameData) {
   m_elapsed += frameData.dt;
-  return m_elapsed >= m_duration ? PhaseCommand::Pop() : PhaseCommand::None();
+  return m_elapsed >= m_duration
+             ? PhaseCommand{PhaseCommand::Pop{}}
+             : PhaseCommand{PhaseCommand::None{}};
 }

--- a/Ash2/tests/TestPhaseStack.cpp
+++ b/Ash2/tests/TestPhaseStack.cpp
@@ -13,11 +13,18 @@ struct PhaseSpy {
   int32 updateCount = 0;
 };
 
+/// @brief MockPhase が update() で返すコマンドの種類
+enum class MockCommand : uint8 {
+  None,
+  Pop,
+  Push,
+  Reset,
+};
+
 class MockPhase : public IPhase {
  public:
   explicit MockPhase(
-      std::shared_ptr<PhaseSpy> spy,
-      PhaseCommand::Type cmd = PhaseCommand::Type::None,
+      std::shared_ptr<PhaseSpy> spy, MockCommand cmd = MockCommand::None,
       std::unique_ptr<IPhase> next = nullptr
   )
       : m_spy(std::move(spy)), m_cmd(cmd), m_next(std::move(next)) {}
@@ -28,21 +35,21 @@ class MockPhase : public IPhase {
   PhaseCommand update(entt::registry&, const FrameData&) override {
     m_spy->updateCount++;
     switch (m_cmd) {
-      case PhaseCommand::Type::None:
-        return PhaseCommand::None();
-      case PhaseCommand::Type::Pop:
-        return PhaseCommand::Pop();
-      case PhaseCommand::Type::Push:
-        return PhaseCommand::Push(std::move(m_next));
-      case PhaseCommand::Type::Reset:
-        return PhaseCommand::Reset(std::move(m_next));
+      case MockCommand::None:
+        return PhaseCommand::None{};
+      case MockCommand::Pop:
+        return PhaseCommand::Pop{};
+      case MockCommand::Push:
+        return PhaseCommand::Push{.nextPhase = std::move(m_next)};
+      case MockCommand::Reset:
+        return PhaseCommand::Reset{.nextPhase = std::move(m_next)};
     }
-    return PhaseCommand::None();
+    return PhaseCommand::None{};
   }
 
  private:
   std::shared_ptr<PhaseSpy> m_spy;
-  PhaseCommand::Type m_cmd;
+  MockCommand m_cmd;
   std::unique_ptr<IPhase> m_next;
 };
 
@@ -64,8 +71,7 @@ TEST_CASE("PhaseStack - Pop command calls onBeforePop and removes phase") {
   entt::registry registry;
   auto spy = std::make_shared<PhaseSpy>();
   PhaseStack stack{
-      std::make_unique<MockPhase>(spy, IPhase::PhaseCommand::Type::Pop),
-      registry
+      std::make_unique<MockPhase>(spy, MockCommand::Pop), registry
   };
 
   REQUIRE(spy->beforePopCount == 0);
@@ -82,8 +88,7 @@ TEST_CASE("PhaseStack - Push command calls onAfterPush on new phase") {
   auto spy2 = std::make_shared<PhaseSpy>();
   PhaseStack stack{
       std::make_unique<MockPhase>(
-          spy1, IPhase::PhaseCommand::Type::Push,
-          std::make_unique<MockPhase>(spy2)
+          spy1, MockCommand::Push, std::make_unique<MockPhase>(spy2)
       ),
       registry
   };
@@ -101,8 +106,7 @@ TEST_CASE("PhaseStack - Reset command pops all phases then pushes new phase") {
   auto spy2 = std::make_shared<PhaseSpy>();
   PhaseStack stack{
       std::make_unique<MockPhase>(
-          spy1, IPhase::PhaseCommand::Type::Reset,
-          std::make_unique<MockPhase>(spy2)
+          spy1, MockCommand::Reset, std::make_unique<MockPhase>(spy2)
       ),
       registry
   };
@@ -116,8 +120,7 @@ TEST_CASE("PhaseStack - update on empty stack does nothing") {
   entt::registry registry;
   auto spy = std::make_shared<PhaseSpy>();
   PhaseStack stack{
-      std::make_unique<MockPhase>(spy, IPhase::PhaseCommand::Type::Pop),
-      registry
+      std::make_unique<MockPhase>(spy, MockCommand::Pop), registry
   };
 
   stack.update(registry, FrameData{});

--- a/Ash2/tests/TestWaitPhase.cpp
+++ b/Ash2/tests/TestWaitPhase.cpp
@@ -9,23 +9,23 @@ TEST_CASE("WaitPhase - returns None before duration elapses") {
   entt::registry registry;
   WaitPhase phase{WaitPhase::Param{.duration = 2.0}};
   auto cmd = phase.update(registry, FrameData{.dt = 1.0});
-  REQUIRE(cmd.type == IPhase::PhaseCommand::Type::None);
+  REQUIRE(std::holds_alternative<PhaseCommand::None>(cmd.value()));
 }
 
 TEST_CASE("WaitPhase - returns Pop when duration is reached exactly") {
   entt::registry registry;
   WaitPhase phase{WaitPhase::Param{.duration = 1.0}};
   auto cmd = phase.update(registry, FrameData{.dt = 1.0});
-  REQUIRE(cmd.type == IPhase::PhaseCommand::Type::Pop);
+  REQUIRE(std::holds_alternative<PhaseCommand::Pop>(cmd.value()));
 }
 
 TEST_CASE("WaitPhase - returns Pop after accumulated dt exceeds duration") {
   entt::registry registry;
   WaitPhase phase{WaitPhase::Param{.duration = 1.0}};
   auto first = phase.update(registry, FrameData{.dt = 0.6});
-  REQUIRE(first.type == IPhase::PhaseCommand::Type::None);
+  REQUIRE(std::holds_alternative<PhaseCommand::None>(first.value()));
   auto second = phase.update(registry, FrameData{.dt = 0.6});
-  REQUIRE(second.type == IPhase::PhaseCommand::Type::Pop);
+  REQUIRE(std::holds_alternative<PhaseCommand::Pop>(second.value()));
 }
 
 #endif


### PR DESCRIPTION
## 概要

`PhaseCommand` を `enum class Type` + 常在する `unique_ptr` の組から、`std::variant<None, Pop, Push, Reset>` を包む独立クラスへ置き換えた。close #265

## 変更内容

- `None` / `Pop` は空構造体、`Push` / `Reset` のみ `nextPhase` を持つ集成体にし、「`Pop` なのに phase を持つ」等の不正な組み合わせを型で表現不能にした
- 要素型からの暗黙変換テンプレートコンストラクタで `return PhaseCommand::Pop{};` の形を可能にした
- 消費側 `PhaseStack::update` を `switch` から `std::visit` + `Overloaded` に置き換えた
- 生成側5フェーズを designated initializer（`Push{.nextPhase = ...}`）で統一した
- テスト2本を `std::holds_alternative` / ローカル `MockCommand` enum に追従させた

## 技術選択の補足

- 要素型を `PhaseCommand` のネスト構造体にすることで、公開型を `PhaseCommand` ただ一つに保った（別名前空間や variant 型名との衝突を避けるため）
- 変換コンストラクタは要素型を直接受け取るテンプレートにした。`std::variant` を1つ受け取る形だと `Pop{}` → variant → `PhaseCommand` にユーザー定義変換が2回必要になり暗黙変換が通らないため
- `Push` / `Reset` は集成体にして構築時 assert を持たせない。null 防止は `PhaseStack::push` の既存 assert に一元化した（`PhaseStack.cpp` の 25・30 行目の冗長な assert は削除）