### PR TITLE
GetAssetList / RegisterAssets を expected 化し、終了の判断を Run に寄せる

### DIFF
--- a/Ash2/src/Asset.hpp
+++ b/Ash2/src/Asset.hpp
@@ -1,32 +1,10 @@
 #pragma once
 #include <Siv3D.hpp>
 
-/// @brief デバッグ・リリース共通のアセットリストを返す
-///
-/// `tools/sync-assets.sh` で生成した `assets/asset_list` を読む。
-/// デバッグ時はファイルから、リリース時は埋め込みリソースから読む。
-[[nodiscard]] inline Array<FilePath> GetAssetList() {
-#ifdef _DEBUG
-  TextReader reader(U"assets/asset_list");
-  if (not reader) {
-    Logger << U"[Asset] assets/asset_list not found. Run tools/sync-assets.sh.";
-    return {};
-  }
-#else
-  TextReader reader(Resource(U"assets/asset_list"));
-  if (not reader) {
-    throw Error{U"assets/asset_list not embedded. Add it to Resource.rc."};
-  }
-#endif
-  Array<FilePath> list;
-  while (const auto line = reader.readLine()) {
-    list << line.value();
-  }
-  return list;
-}
+#include <expected>
 
 /// @brief デバッグ・リリース共通のアセットパスを返す
-/// @return デバッグ時は FilePath、リリース時は Resource パス
+/// @return デバッグ時は FilePath、リリース時は Resource パスを返す
 [[nodiscard]] inline FilePath AssetPath(StringView path) {
 #ifdef _DEBUG
   return FilePath{path};
@@ -35,17 +13,52 @@
 #endif
 }
 
+/// @brief デバッグ・リリース共通のアセットリストを返す
+///
+/// `tools/sync-assets.sh` で生成した `assets/asset_list` を読む。
+/// @return 失敗時は開けなかったパスを含むメッセージ
+[[nodiscard]] inline std::expected<Array<FilePath>, String> GetAssetList() {
+  const FilePath path = AssetPath(U"assets/asset_list");
+  TextReader reader(path);
+  if (not reader) {
+    return std::unexpected{
+        U"GetAssetList: {} を開けません / tools/sync-assets.sh を実行する"_fmt(
+            path
+        )
+    };
+  }
+  Array<FilePath> list;
+  while (const auto line = reader.readLine()) {
+    list << line.value();
+  }
+  return list;
+}
+
 /// @brief アセットをアセットシステムに登録する
 ///
 /// `.png` を TextureAsset、`.mp3` を AudioAsset として登録する。
 /// キーはファイルの相対パス（例: `assets/images/player.png`）。
-inline void RegisterAssets() {
-  for (const auto& path : GetAssetList()) {
+/// @return 失敗時は登録できなかったパスを含むメッセージ
+[[nodiscard]] inline std::expected<void, String> RegisterAssets() {
+  auto list = GetAssetList();
+  if (!list) {
+    return std::unexpected{std::move(list).error()};
+  }
+  for (const auto& path : *list) {
     const auto ext = FileSystem::Extension(path);
     if (ext == U"png") {
-      TextureAsset::Register(path, AssetPath(path));
+      if (!TextureAsset::Register(path, AssetPath(path))) {
+        return std::unexpected{
+            U"RegisterAssets: {} を登録できません"_fmt(path)
+        };
+      }
     } else if (ext == U"mp3") {
-      AudioAsset::Register(path, AssetPath(path));
+      if (!AudioAsset::Register(path, AssetPath(path))) {
+        return std::unexpected{
+            U"RegisterAssets: {} を登録できません"_fmt(path)
+        };
+      }
     }
   }
+  return {};
 }

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -17,8 +17,12 @@ namespace {
 /// @brief アニメーション設定 TOML を全件読み込む
 /// @return 失敗時は toml のパスを前置したメッセージ
 [[nodiscard]] std::expected<AnimationDataRegistry, String> LoadAnimations() {
+  auto list = GetAssetList();
+  if (!list) {
+    return std::unexpected{std::move(list).error()};
+  }
   AnimationDataRegistry animReg;
-  for (const auto& path : GetAssetList()) {
+  for (const auto& path : *list) {
     if (FileSystem::Extension(path) != U"toml") continue;
     if (!path.starts_with(U"assets/config/animation/")) continue;
     auto data = AnimationData::FromToml(TOMLReader{AssetPath(path)});

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -27,7 +27,12 @@ namespace {
 
 /// @brief アセットの登録からゲームループの終了までを行う
 void Run() {
-  RegisterAssets();
+  if (auto result = RegisterAssets(); !result) {
+    throw FatalError{
+        .reason = FatalReason::AssetMissing,
+        .detail = std::move(result).error(),
+    };
+  }
   Scene::SetTextureFilter(TextureFilter::Nearest);
 
   entt::registry registry;

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -373,6 +373,8 @@
 - リリース: `assets/asset_list` を埋め込みリソースから読む
 - `.png` → `TextureAsset`、`.mp3` → `AudioAsset` としてキー（相対パス）で登録
 - アニメーション設定: `Ash2/App/assets/config/animation/*.toml`（起動時に全ファイルをスキャン）
+- `asset_list` を開けない場合は起動しない（`GetAssetList` が `std::expected` で失敗を返し、
+  `Run()` が `FatalError{FatalReason::AssetMissing, ...}` に変えて投げる）
 
 ---
 
@@ -380,14 +382,14 @@
 
 | 名前 | 役割 |
 |---|---|
-| [`Main`](../Ash2/src/Main.cpp) | アプリの入口。アセット登録 → `Scene::SetTextureFilter(TextureFilter::Nearest)` → registry 初期化 → `PhaseStack` を生成し、毎フレーム `PhaseStack::update` → `AttachmentSystem` → `DrawSystem` → `HudSystem` を回す。`InitializeRegistry` の失敗は `FatalError{FatalReason::ConfigInvalid, ...}` に変えて投げる。例外は `FatalError` / `s3d::Error` / `std::exception` / `...` の4種を捕捉し `ExitWithFatal` へ渡す。Debug ビルドで環境変数 `ASH2_RUN_TESTS` が設定されていれば Catch2 のテストのみ実行し、成否を終了コードに反映して終了 |
+| [`Main`](../Ash2/src/Main.cpp) | アプリの入口。アセット登録 → `Scene::SetTextureFilter(TextureFilter::Nearest)` → registry 初期化 → `PhaseStack` を生成し、毎フレーム `PhaseStack::update` → `AttachmentSystem` → `DrawSystem` → `HudSystem` を回す。`RegisterAssets` の失敗は `FatalError{FatalReason::AssetMissing, ...}` に、`InitializeRegistry` の失敗は `FatalError{FatalReason::ConfigInvalid, ...}` に変えて投げる。例外は `FatalError` / `s3d::Error` / `std::exception` / `...` の4種を捕捉し `ExitWithFatal` へ渡す。Debug ビルドで環境変数 `ASH2_RUN_TESTS` が設定されていれば Catch2 のテストのみ実行し、成否を終了コードに反映して終了 |
 | [`FatalError`](../Ash2/src/FatalError.hpp) | 続行できない失敗を表す型。分類（`FatalReason`）と開発者向けの `detail` を持つ |
 | [`ExitWithFatal`](../Ash2/src/CrashHandler.hpp) | 致命エラーを `crash.log` に記録し、Release では分類に応じた文言を表示して終了する |
 | [`InitializeRegistry`](../Ash2/src/GameSetup.hpp) | `registry.ctx()` へ `NameLookup` / 各 Config / `AnimationDataRegistry` / `ScenarioData` を登録し、シグナルを接続する。`std::expected<void, String>` を返し、失敗を呼び出し元（`Main`）へ渡す |
 | [`ReloadConfig`](../Ash2/src/GameSetup.hpp) | Debug ビルド専用。`PlayerConfig` / `EnemyConfig` / アニメーションデータを再読込する。3つとも成功したときのみ `registry.ctx()` を差し替え、途中で失敗したら旧データを維持したまま `APP_LOG` に出して戻る |
-| [`GetAssetList`](../Ash2/src/Asset.hpp) | `Ash2/App/assets/asset_list` を読んでアセットパス一覧を返す |
+| [`GetAssetList`](../Ash2/src/Asset.hpp) | `Ash2/App/assets/asset_list` を読んでアセットパス一覧を返す。`std::expected<Array<FilePath>, String>` を返し、開けなければ失敗を返す |
 | [`AssetPath`](../Ash2/src/Asset.hpp) | Debug では `FilePath`、Release では `Resource` パスを返す |
-| [`RegisterAssets`](../Ash2/src/Asset.hpp) | `.png`/`.mp3` をアセットシステムに登録する |
+| [`RegisterAssets`](../Ash2/src/Asset.hpp) | `.png`/`.mp3` をアセットシステムに登録する。`std::expected<void, String>` を返し、失敗を呼び出し元（`Main`）へ渡す |
 | [`APP_LOG`](../Ash2/src/Debug.hpp) | Debug ビルドで `Console` に出力するログマクロ（Release では何もしない） |
 | [`AppDebug::testMode`](../Ash2/src/Debug.hpp) | テスト実行中フラグ。true の間 `APP_LOG` を無効化する |
 | [`Overloaded`](../Ash2/src/Util/Overloaded.hpp) | 複数のラムダを1つの visitor にまとめる `std::visit` 用ヘルパー |


### PR DESCRIPTION
## 概要

`GetAssetList()` / `RegisterAssets()` を `std::expected` 化し、終了の判断を `Main.cpp` の `Run()` へ持ち上げた。
これにより Debug で失敗を握り潰す挙動と、Release で `s3d::Error` を投げる挙動の両方を解消した。

close #282

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `Ash2/src/Asset.hpp` | `GetAssetList()` を `std::expected<Array<FilePath>, String>` に、`RegisterAssets()` を `std::expected<void, String>` に変更 |
| `Ash2/src/GameSetup.cpp` | `LoadAnimations()` で `GetAssetList()` の失敗を伝播 |
| `Ash2/src/Main.cpp` | `Run()` で `RegisterAssets()` の失敗を `FatalError{FatalReason::AssetMissing, ...}` に変えて投げる |
| `docs/REFERENCE.md` | アセット管理節と基盤・ユーティリティ表を実装に合わせて更新 |

## 実装判断

### Debug / Release の分岐を `AssetPath()` に寄せた

`GetAssetList()` 内の `#ifdef _DEBUG` を消し、既存の `AssetPath(U"assets/asset_list")` を使う形にした。
`AssetPath()` は Debug で `FilePath`、Release で `Resource` パスを返し、削除した2分岐と等価である。
分岐が1箇所に集まり、「Debug / Release で同じ形にする」という要件を構造で満たす。
そのために `AssetPath()` の定義を `GetAssetList()` より前へ移動している。

### エラーメッセージを Debug / Release で共通にした

Debug の `asset_list` 欠落も Release の `Resource.rc` 未登録も、復旧手段は `tools/sync-assets.sh` の実行で同じ。
そのため文言を分けず、`GetAssetList: {} を開けません / tools/sync-assets.sh を実行する` の1つにまとめた。

### 終了の判断を `Run()` に置いた

#280 が `InitializeRegistry` の失敗に対して定めた形をそのまま踏襲し、分類のみ `ConfigInvalid` から `AssetMissing` に変えた。
これが `FatalReason::AssetMissing` の本番コードでの最初の利用箇所になる。

### `ReloadConfig` は `void` のままにした

`LoadAnimations` の新しい失敗経路も、既存の `!anims` 分岐で受かる。
ゲームループ内で `FatalError` を投げるわけにはいかないため、「旧データを維持して `APP_LOG` に出す」挙動を変えていない。

### 見送った選択肢

- **`Register` の失敗を `assert` にする** — `asset_list` は生成物だが、Debug では実行時にディスクから読む外部入力であり `assert` の対象外
- **アセット一覧を `Run()` で1回だけ読んで引数で渡す** — `ReloadConfig` も `LoadAnimations` 経由で一覧を必要とし、引数が全経路に波及する。二重読み込みは現状で実害がない

## 動作確認

- `asset_list` を退避して起動 → 起動せずに終了コード 1、`crash.log` に `AssetMissing: GetAssetList: assets/asset_list を開けません / tools/sync-assets.sh を実行する` を記録
- `asset_list` を戻して起動 → 通常どおり動作し、`crash.log` は生成されない
- format / tidy / build / test すべて通過

## 対象外

`TextureAsset::Register` / `AudioAsset::Register` の戻り値は登録の成否（キーの重複など）であり、ファイル自体の読み込み失敗はここでは検出されない。
読み込み失敗（空オブジェクトの確認）は別 Issue の範囲とする。
