### PR TITLE
メッセージのない assert に日本語メッセージを付ける

### DIFF
--- a/Ash2/src/Phase/PhaseStack.cpp
+++ b/Ash2/src/Phase/PhaseStack.cpp
@@ -1,5 +1,7 @@
 #include "Phase/PhaseStack.hpp"
 
+#include <cassert>
+
 #include "Util/Overloaded.hpp"
 
 PhaseStack::PhaseStack(
@@ -41,7 +43,7 @@ void PhaseStack::pop(entt::registry& registry) {
 void PhaseStack::push(
     entt::registry& registry, std::unique_ptr<IPhase>&& phase
 ) {
-  assert(phase != nullptr);
+  assert(phase != nullptr && "積むフェーズは nullptr であってはならない");
   m_stack.push_back(std::move(phase));
   m_stack.back()->onAfterPush(registry);
 }

--- a/Ash2/src/System/NameLookup.hpp
+++ b/Ash2/src/System/NameLookup.hpp
@@ -14,14 +14,20 @@ namespace NameLookupSystem {
 /// @brief Name コンポーネント追加時に NameLookup
 /// へエントリを挿入するシグナルハンドラ
 inline void OnNameConstructed(entt::registry& registry, entt::entity entity) {
-  assert(registry.ctx().find<NameLookup>() != nullptr);
+  assert(
+      registry.ctx().find<NameLookup>() != nullptr &&
+      "NameLookup が registry.ctx() に登録されていなければならない"
+  );
   registry.ctx().get<NameLookup>()[registry.get<Name>(entity).value] = entity;
 }
 
 /// @brief Name コンポーネント削除時に NameLookup
 /// のエントリを削除するシグナルハンドラ
 inline void OnNameDestroyed(entt::registry& registry, entt::entity entity) {
-  assert(registry.ctx().find<NameLookup>() != nullptr);
+  assert(
+      registry.ctx().find<NameLookup>() != nullptr &&
+      "NameLookup が registry.ctx() に登録されていなければならない"
+  );
   registry.ctx().get<NameLookup>().erase(registry.get<Name>(entity).value);
 }
 


### PR DESCRIPTION
## 概要

`docs/coding_style/ERROR_HANDLING.md` の2章が定める `assert(条件 && "日本語メッセージ")` の書式に揃え、メッセージのない `assert` にメッセージを追加した。

- `Ash2/src/Phase/PhaseStack.cpp` — `PhaseStack::push` の nullptr チェック
- `Ash2/src/System/NameLookup.hpp` — `OnNameConstructed` / `OnNameDestroyed` の `NameLookup` 登録チェック（2箇所）

条件式は変更していないため、`assert` の発火条件は従来どおり。Release ビルドでは `NDEBUG` により消えるため挙動への影響はない。

## 実装判断

### 対象は3箇所

Issue 本文が挙げた4箇所のうち `Ash2/src/GameSetup.cpp:17` の `assert` は、#280 / #281 の対応で `LoadAnimations` が純粋関数になった際に既に削除されている。新たに追加し直すことはせず、対象を残り3箇所とした（Issue にコメント済み）。

### メッセージの表現

既存のメッセージ付き `assert`（`Melee.cpp` / `AnimationSystem.cpp`）に揃え、「〜でなければならない」の要求形で書いた。

### `<cassert>` の明示追加

`PhaseStack.cpp` は `<cassert>` を含めずに `assert` を使っており、`stdafx.h` 経由の `Siv3D.hpp` に暗黙に依存していた。`assert` を使う他のファイル（`AnimationSystem.cpp` / `NameLookup.hpp` / `Melee.cpp` / `Ranged.cpp`）は全て明示しているため、同じ行を触るついでに揃えた。

### 見送った選択肢

- `assert` を `FatalError` や `expected` へ置き換える — 3箇所とも呼び出し契約の違反であり、`ERROR_HANDLING.md` 2章が定める `assert` の適用範囲そのものであるため
- `AnimationSystem.cpp` / `Ranged.cpp` の `assert` の用途見直し — 設定ファイル由来データの検証であり #243 の担当

close #284