### PR TITLE
空のオブジェクトを返す s3d API の確認漏れを塞ぐ

### DIFF
--- a/Ash2/Ash2.vcxproj
+++ b/Ash2/Ash2.vcxproj
@@ -418,6 +418,7 @@
     <ClInclude Include="src\Phase\PhaseLoaders.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\Asset.hpp" />
+    <ClInclude Include="src\UiFonts.hpp" />
     <ClInclude Include="src\Debug.hpp" />
     <ClInclude Include="src\CrashHandler.hpp" />
     <ClInclude Include="src\FatalError.hpp" />

--- a/Ash2/Ash2.vcxproj.filters
+++ b/Ash2/Ash2.vcxproj.filters
@@ -1100,6 +1100,9 @@
     <ClInclude Include="Asset.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="UiFonts.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Debug.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/Ash2/src/Asset.hpp
+++ b/Ash2/src/Asset.hpp
@@ -34,6 +34,18 @@
   return list;
 }
 
+/// @brief アセット配下の TOML を開く
+/// @return 開けない場合はパスを含むメッセージ
+[[nodiscard]] inline std::expected<TOMLReader, String> OpenToml(
+    StringView path
+) {
+  TOMLReader toml{AssetPath(path)};
+  if (not toml.isOpen()) {
+    return std::unexpected{U"OpenToml: {} を読み込めません"_fmt(path)};
+  }
+  return toml;
+}
+
 /// @brief アセットをアセットシステムに登録する
 ///
 /// `.png` を TextureAsset、`.mp3` を AudioAsset として登録する。

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -11,6 +11,7 @@
 #include "Phase/PhaseLoaders.hpp"
 #include "System/HierarchySystem.hpp"
 #include "System/NameLookup.hpp"
+#include "UiFonts.hpp"
 
 namespace {
 
@@ -25,9 +26,27 @@ namespace {
   for (const auto& path : *list) {
     if (FileSystem::Extension(path) != U"toml") continue;
     if (!path.starts_with(U"assets/config/animation/")) continue;
-    auto data = AnimationData::FromToml(TOMLReader{AssetPath(path)});
+    auto toml = OpenToml(path);
+    if (!toml) {
+      return std::unexpected{std::move(toml).error()};
+    }
+    auto data = AnimationData::FromToml(*toml);
     if (!data) {
       return std::unexpected{path + U": " + std::move(data).error()};
+    }
+    if (!TextureAsset::IsRegistered(data->textureKey)) {
+      return std::unexpected{
+          U"LoadAnimations: {} の texture '{}' が未登録です"_fmt(
+              path, data->textureKey
+          )
+      };
+    }
+    if (!TextureAsset::Load(data->textureKey)) {
+      return std::unexpected{
+          U"LoadAnimations: {} の texture '{}' を読み込めません"_fmt(
+              path, data->textureKey
+          )
+      };
     }
     animReg[FileSystem::BaseName(path)] = *std::move(data);
   }
@@ -41,15 +60,27 @@ std::expected<void, String> InitializeRegistry(entt::registry& registry) {
   NameLookupSystem::Connect(registry);
   HierarchySystem::Connect(registry);
 
-  const TOMLReader playerToml(AssetPath(U"assets/config/player.toml"));
-  auto player = PlayerConfig::FromToml(playerToml);
+  auto fonts = UiFonts::Create();
+  if (!fonts) {
+    return std::unexpected{std::move(fonts).error()};
+  }
+  registry.ctx().emplace<UiFonts>(*std::move(fonts));
+
+  auto playerToml = OpenToml(U"assets/config/player.toml");
+  if (!playerToml) {
+    return std::unexpected{std::move(playerToml).error()};
+  }
+  auto player = PlayerConfig::FromToml(*playerToml);
   if (!player) {
     return std::unexpected{std::move(player).error()};
   }
   registry.ctx().emplace<PlayerConfig>(*std::move(player));
 
-  const TOMLReader enemyToml(AssetPath(U"assets/config/enemy.toml"));
-  auto enemy = EnemyConfig::FromToml(enemyToml);
+  auto enemyToml = OpenToml(U"assets/config/enemy.toml");
+  if (!enemyToml) {
+    return std::unexpected{std::move(enemyToml).error()};
+  }
+  auto enemy = EnemyConfig::FromToml(*enemyToml);
   if (!enemy) {
     return std::unexpected{std::move(enemy).error()};
   }
@@ -61,8 +92,11 @@ std::expected<void, String> InitializeRegistry(entt::registry& registry) {
   }
   registry.ctx().emplace<AnimationDataRegistry>(*std::move(anims));
 
-  const TOMLReader scenarioToml(AssetPath(U"assets/config/scenario.toml"));
-  auto scenario = ScenarioData::FromToml(scenarioToml, GetPhaseLoaders());
+  auto scenarioToml = OpenToml(U"assets/config/scenario.toml");
+  if (!scenarioToml) {
+    return std::unexpected{std::move(scenarioToml).error()};
+  }
+  auto scenario = ScenarioData::FromToml(*scenarioToml, GetPhaseLoaders());
   if (!scenario) {
     return std::unexpected{std::move(scenario).error()};
   }
@@ -72,15 +106,23 @@ std::expected<void, String> InitializeRegistry(entt::registry& registry) {
 }
 
 void ReloadConfig(entt::registry& registry) {
-  const TOMLReader playerToml(AssetPath(U"assets/config/player.toml"));
-  auto player = PlayerConfig::FromToml(playerToml);
+  auto playerToml = OpenToml(U"assets/config/player.toml");
+  if (!playerToml) {
+    APP_LOG(U"ReloadConfig: 旧データを維持 / " + playerToml.error());
+    return;
+  }
+  auto player = PlayerConfig::FromToml(*playerToml);
   if (!player) {
     APP_LOG(U"ReloadConfig: 旧データを維持 / " + player.error());
     return;
   }
 
-  const TOMLReader enemyToml(AssetPath(U"assets/config/enemy.toml"));
-  auto enemy = EnemyConfig::FromToml(enemyToml);
+  auto enemyToml = OpenToml(U"assets/config/enemy.toml");
+  if (!enemyToml) {
+    APP_LOG(U"ReloadConfig: 旧データを維持 / " + enemyToml.error());
+    return;
+  }
+  auto enemy = EnemyConfig::FromToml(*enemyToml);
   if (!enemy) {
     APP_LOG(U"ReloadConfig: 旧データを維持 / " + enemy.error());
     return;

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -7,6 +7,7 @@
 #include "Config/AnimationData.hpp"
 #include "Phase/FrameData.hpp"
 #include "System/AnimationSystem.hpp"
+#include "UiFonts.hpp"
 
 namespace {
 constexpr double kBgBrightness = 0.15;
@@ -85,17 +86,19 @@ PhaseCommand AnimationViewerPhase::update(
 
   AnimationSystem::Update(registry, frameData.dt);
 
+  const auto& font = registry.ctx().get<UiFonts>().small;
+
   Scene::SetBackground(ColorF{kBgBrightness});
-  m_font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(kTitleX, kTitleY);
+  font(U"AnimationViewer: {}"_fmt(m_dataKey)).draw(kTitleX, kTitleY);
   if (!m_clips.empty()) {
-    m_font(
+    font(
         U"Clip [{}/{}]: {}"_fmt(
             m_clipIndex + 1, m_clips.size(), m_clips[m_clipIndex]
         )
     )
         .draw(kTitleX, kClipInfoY);
   }
-  m_font(U"← → : clip  F : flip  Esc : back")
+  font(U"← → : clip  F : flip  Esc : back")
       .draw(kTitleX, kHintY, Palette::Gray);
 
   return PhaseCommand::None{};

--- a/Ash2/src/Phase/AnimationViewerPhase.hpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.hpp
@@ -26,8 +26,6 @@ class AnimationViewerPhase : public IPhase {
   void onBeforePop(entt::registry& registry) override;
 
  private:
-  static constexpr int32 kFontSize = 20;
-
   /// AnimationDataRegistry のキー
   String m_dataKey;
   /// 表示対象エンティティ
@@ -35,5 +33,4 @@ class AnimationViewerPhase : public IPhase {
   /// クリップ名の配列（ソート済み）
   Array<String> m_clips;
   size_t m_clipIndex = 0;
-  Font m_font{kFontSize};
 };

--- a/Ash2/src/Phase/TestMenuPhase.cpp
+++ b/Ash2/src/Phase/TestMenuPhase.cpp
@@ -2,6 +2,7 @@
 
 #include "Phase/AnimationViewerPhase.hpp"
 #include "Phase/PlayerTestPhase.hpp"
+#include "UiFonts.hpp"
 
 namespace {
 constexpr double kBgBrightness = 0.1;
@@ -47,13 +48,15 @@ PhaseCommand TestMenuPhase::update(
     return PhaseCommand::Push{.nextPhase = std::move(phase)};
   }
 
+  const auto& font = registry.ctx().get<UiFonts>().large;
+
   Scene::SetBackground(ColorF{kBgBrightness});
-  m_font(U"Test Menu").draw(kTitleX, kTitleY);
+  font(U"Test Menu").draw(kTitleX, kTitleY);
 
   for (size_t i = 0; i < m_items.size(); ++i) {
     const ColorF color =
         (i == m_selectedIndex) ? Palette::Yellow : Palette::White;
-    m_font(m_items[i].label)
+    font(m_items[i].label)
         .draw(
             kItemX, kItemBaseY + static_cast<double>(i) * kItemSpacing, color
         );

--- a/Ash2/src/Phase/TestMenuPhase.hpp
+++ b/Ash2/src/Phase/TestMenuPhase.hpp
@@ -30,9 +30,6 @@ class TestMenuPhase : public IPhase {
     std::function<std::unique_ptr<IPhase>(entt::registry&)> create;
   };
 
-  static constexpr int32 kFontSize = 24;
-
   Array<MenuItem> m_items;
   size_t m_selectedIndex = 0;
-  Font m_font{kFontSize};
 };

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -31,6 +31,12 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
     const int32 col =
         static_cast<int32>(anim.elapsed * clip.speed) % clip.count;
     const Point cell{col, clip.row};
+    // data.textureKey の登録・読み込み済みは LoadAnimations（GameSetup.cpp）
+    // がロード時に保証する
+    assert(
+        TextureAsset::IsRegistered(data.textureKey) &&
+        "TextureAsset にキーが登録されていない"
+    );
     auto region = TextureAsset{data.textureKey}(cell * data.size, data.size);
 
     if (anim.facingRight) {

--- a/Ash2/src/UiFonts.hpp
+++ b/Ash2/src/UiFonts.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include <Siv3D.hpp>
+
+#include <expected>
+
+/// @brief UI 描画に使うフォント一式（registry.ctx() に格納）
+struct UiFonts {
+  Font large;
+  Font small;
+
+  /// @return 生成に失敗した場合はサイズを含むメッセージ
+  [[nodiscard]] static std::expected<UiFonts, String> Create() {
+    constexpr int32 kLargeSize = 24;
+    constexpr int32 kSmallSize = 20;
+    UiFonts fonts{.large = Font{kLargeSize}, .small = Font{kSmallSize}};
+    if (fonts.large.isEmpty()) {
+      return std::unexpected{
+          U"UiFonts::Create: サイズ {} のフォントを生成できません"_fmt(
+              kLargeSize
+          )
+      };
+    }
+    if (fonts.small.isEmpty()) {
+      return std::unexpected{
+          U"UiFonts::Create: サイズ {} のフォントを生成できません"_fmt(
+              kSmallSize
+          )
+      };
+    }
+    return fonts;
+  }
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@ Ash2/src/
 ├── Main.cpp              # エントリポイント・ゲームループ
 ├── GameSetup.hpp/.cpp    # registry 初期化・設定リロード
 ├── Asset.hpp             # アセット登録・パス解決ユーティリティ
+├── UiFonts.hpp           # UI 描画用フォント一式（registry.ctx() に格納）
 ├── Debug.hpp             # APP_LOG マクロ等のデバッグ用ユーティリティ
 ├── FatalError.hpp        # 致命エラーの型（分類と詳細）
 ├── CrashHandler.hpp/.cpp # 致命エラーの記録・表示・終了

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -336,6 +336,7 @@
 | 型 | 用途 |
 |---|---|
 | `NameLookup` | 名前 → エンティティの逆引きテーブル |
+| [`UiFonts`](../Ash2/src/UiFonts.hpp) | UI 描画用フォント一式（`large`/`small`） |
 | `PlayerConfig` | プレイヤー設定 |
 | `EnemyConfig` | 敵設定 |
 | `AnimationDataRegistry` | アニメーション共有データ |
@@ -375,6 +376,13 @@
 - アニメーション設定: `Ash2/App/assets/config/animation/*.toml`（起動時に全ファイルをスキャン）
 - `asset_list` を開けない場合は起動しない（`GetAssetList` が `std::expected` で失敗を返し、
   `Run()` が `FatalError{FatalReason::AssetMissing, ...}` に変えて投げる）
+- TOML の読み込みは `OpenToml` を単一の入口とする。開けない場合はパスを含むメッセージの
+  `std::expected` で失敗を返す（中身が空の TOML は「開けている」として扱い、キー欠落は
+  各 `FromToml` 側の失敗として区別する）
+- アニメーション設定の `texture` キーはロード時（`LoadAnimations`）に
+  `TextureAsset::IsRegistered`（未登録の検出）と `TextureAsset::Load`（実体読み込みの確定）で
+  検証する。タイプミスや `asset_list` の漏れを起動時に検出するため、`AnimationSystem::Update`
+  側では毎フレームの確認をしない
 
 ---
 
@@ -385,11 +393,13 @@
 | [`Main`](../Ash2/src/Main.cpp) | アプリの入口。アセット登録 → `Scene::SetTextureFilter(TextureFilter::Nearest)` → registry 初期化 → `PhaseStack` を生成し、毎フレーム `PhaseStack::update` → `AttachmentSystem` → `DrawSystem` → `HudSystem` を回す。`RegisterAssets` の失敗は `FatalError{FatalReason::AssetMissing, ...}` に、`InitializeRegistry` の失敗は `FatalError{FatalReason::ConfigInvalid, ...}` に変えて投げる。例外は `FatalError` / `s3d::Error` / `std::exception` / `...` の4種を捕捉し `ExitWithFatal` へ渡す。Debug ビルドで環境変数 `ASH2_RUN_TESTS` が設定されていれば Catch2 のテストのみ実行し、成否を終了コードに反映して終了 |
 | [`FatalError`](../Ash2/src/FatalError.hpp) | 続行できない失敗を表す型。分類（`FatalReason`）と開発者向けの `detail` を持つ |
 | [`ExitWithFatal`](../Ash2/src/CrashHandler.hpp) | 致命エラーを `crash.log` に記録し、Release では分類に応じた文言を表示して終了する |
-| [`InitializeRegistry`](../Ash2/src/GameSetup.hpp) | `registry.ctx()` へ `NameLookup` / 各 Config / `AnimationDataRegistry` / `ScenarioData` を登録し、シグナルを接続する。`std::expected<void, String>` を返し、失敗を呼び出し元（`Main`）へ渡す |
+| [`InitializeRegistry`](../Ash2/src/GameSetup.hpp) | `registry.ctx()` へ `NameLookup` / `UiFonts` / 各 Config / `AnimationDataRegistry` / `ScenarioData` を登録し、シグナルを接続する。`std::expected<void, String>` を返し、失敗を呼び出し元（`Main`）へ渡す |
 | [`ReloadConfig`](../Ash2/src/GameSetup.hpp) | Debug ビルド専用。`PlayerConfig` / `EnemyConfig` / アニメーションデータを再読込する。3つとも成功したときのみ `registry.ctx()` を差し替え、途中で失敗したら旧データを維持したまま `APP_LOG` に出して戻る |
 | [`GetAssetList`](../Ash2/src/Asset.hpp) | `Ash2/App/assets/asset_list` を読んでアセットパス一覧を返す。`std::expected<Array<FilePath>, String>` を返し、開けなければ失敗を返す |
 | [`AssetPath`](../Ash2/src/Asset.hpp) | Debug では `FilePath`、Release では `Resource` パスを返す |
 | [`RegisterAssets`](../Ash2/src/Asset.hpp) | `.png`/`.mp3` をアセットシステムに登録する。`std::expected<void, String>` を返し、失敗を呼び出し元（`Main`）へ渡す |
+| [`OpenToml`](../Ash2/src/Asset.hpp) | `AssetPath()` を通してアセット配下の TOML を開く。`std::expected<TOMLReader, String>` を返し、開けなければパスを含むメッセージを返す |
+| [`UiFonts`](../Ash2/src/UiFonts.hpp) | UI 描画に使うフォント一式（`large`/`small`）。`Create()` が `std::expected<UiFonts, String>` を返し、`InitializeRegistry` が `registry.ctx()` に登録する |
 | [`APP_LOG`](../Ash2/src/Debug.hpp) | Debug ビルドで `Console` に出力するログマクロ（Release では何もしない） |
 | [`AppDebug::testMode`](../Ash2/src/Debug.hpp) | テスト実行中フラグ。true の間 `APP_LOG` を無効化する |
 | [`Overloaded`](../Ash2/src/Util/Overloaded.hpp) | 複数のラムダを1つの visitor にまとめる `std::visit` 用ヘルパー |

--- a/docs/coding_style/ERROR_HANDLING.md
+++ b/docs/coding_style/ERROR_HANDLING.md
@@ -45,7 +45,7 @@ throw FatalError{
 |--------|-----|------|
 | 例外を投げる | `Parse<T>()`、`JSON::get<T>()` | 非例外版（`ParseOpt<T>()`、`getOpt<T>()`）を使う |
 | 既定値を返す | `TOMLValue::get<T>()` | 使わない。既定値を使うなら `getOr()` で明示する |
-| 空のオブジェクトを返す | `Texture`、`Audio` の生成 | `isEmpty()` で確認する |
+| 空のオブジェクトを返す | `Texture`、`Audio`、`TOMLReader` の生成 | `isEmpty()` で確認する（`TOMLReader` は開けたかどうかに直接答える `isOpen()` を使う） |
 
 非例外版のない API に限り、`try-catch` で包んで `expected` に変換する関数を書く。
 その関数の `try` には、その API の呼び出しだけを置く。


### PR DESCRIPTION
## 概要

`docs/coding_style/ERROR_HANDLING.md` 4章の「空のオブジェクトを返す」の確認が漏れていた3箇所を塞ぐ。close #283

## 変更内容

### 1. TOMLReader の open 確認

`Asset.hpp` に `OpenToml()` を新設し、`std::expected<TOMLReader, String>` を返す形にした。`GameSetup.cpp` の `TOMLReader` 生成6箇所をすべてこれ経由にしている。

ファイルが読めないときに「キーがありません: speed, jump_speed, ...」と報告される状態を解消し、「読み込めない」と「中身が不正」が別のメッセージになった。

判定に `isEmpty()` ではなく `isOpen()` を使っている。中身が空の TOML ファイルは「開けている」ため、`isEmpty()` で弾くとキー欠落の正しい報告まで「読み込めない」に化けてしまう。ERROR_HANDLING.md 4章の表にもこの旨を追記した。

`GetAssetList` と同じく `AssetPath()` を通してファイルを開く入り口を `Asset.hpp` に集約している。

### 2. textureKey のロード時検証

`LoadAnimations` で `TextureAsset::IsRegistered` と `TextureAsset::Load` を確認するようにした。toml の `texture` のタイプミスや `asset_list` の漏れ、ファイルの実体の欠落がロード時に表面化する。

`TextureAsset::Load` は未登録でも false を返すため、`IsRegistered` を先に見てメッセージを区別している。

検証を `AnimationData::FromToml` に入れる案は見送った。`Config/` は最下層でアセットシステムに依存させないため。`AnimationSystem::Update` 側には毎フレームの検証処理を置かず、不変条件の `assert` のみ置いている（同ループ内の他の不変条件と同じ形）。

### 3. Font を registry.ctx() に寄せる

`UiFonts.hpp` を新設し、`Create()` が `expected` を返す形にして `registry.ctx()` に載せた。2つのフェーズから `m_font` / `kFontSize` を削除している。

フェーズ自身に `Create()` を置く案は取れない。フェーズの生成は `IPhaseMaker::make()` が `unique_ptr<IPhase>` を返す形で固定されており、失敗を返す経路が無いため。フェーズごとにフォントを持つ重複も解消される。

### FontAsset を使わない理由

グローバルに使うフォントをアセットシステムに載せないのは Siv3D の慣習から外れるのではないか、という検討を行った。結論として外れていない。

Siv3D 公式の `SceneManager` サンプル（`include/Siv3D/SceneManager.hpp`）は、シーンをまたいで使う `Font` を `FontAsset` ではなく共有データ構造体に置き、`getData().font` で参照している。`registry.ctx().get<UiFonts>().large` はこれと同じ構造にあたる。サンプルで `FontAsset` が多用されるのは、共有データを持たない構成では他に置き場がないため。

このコードベースには既に「ファイル由来のアセットはアセットシステム、コード・TOML 由来のデータは `ctx()`」という境界がある。`RegisterAssets` は `assets/asset_list` を回して拡張子で振り分けており、キーはファイルの相対パスになる。`Font{24}` はシステム標準フォントでファイルの実体がなく、この境界の向こう側にない。

`FontAsset` が持つ `Release` / `ReleaseAll` / タグによる一括解放、`LoadAsync` / `Wait` / `IsReady` による非同期ロード、`Enumerate` による一覧のいずれも、寿命がアプリ全体の 2 つのフォントには効かない。

以下のいずれかが起きた時点で後追いで `FontAsset` に移す。

1. `assets/` に `.ttf` / `.otf` を置いたとき。`asset_list` に載るため、`RegisterAssets` に分岐を 1 つ足せば `.png` / `.mp3` と同じ扱いになる
2. フォントの種類が増えたとき。言語別・`FontMethod` 違い・縁取り用などで `UiFonts` のメンバが増えれば、キー付きストアが有利になる

なお公式サンプルの `Font font = Font{ 50 };` はメンバ初期化子での生成であり、`ERROR_HANDLING.md` 5 章が禁じる形にあたる。`UiFonts::Create()` はその差分。

## 確認

- ビルド・テスト・format・tidy: OK
- アプリを起動し、終了コード 0 で正常終了することを確認
- テストは追加していない。対象がファイル・アセット・描画という管理外依存のため（`docs/TEST_POLICY.md`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
