### PR TITLE
シナリオのセクション参照を読み込み時に検証する

### DIFF
--- a/Ash2/src/Config/ScenarioData.cpp
+++ b/Ash2/src/Config/ScenarioData.cpp
@@ -2,9 +2,16 @@
 
 namespace {
 
-/// @brief TOML の 1 ステップ値を ScenarioStep に変換する
+/// @brief ParseStep の結果：ステップと、それが参照するセクション名
+struct ParsedStep {
+  ScenarioStep step;
+  /// 別のシナリオセクションを参照する場合のみ設定される
+  Optional<String> referencedSection;
+};
+
+/// @brief TOML の 1 ステップ値を ParsedStep に変換する
 /// @note "make" アクションは別 Issue で対応予定のためエラーとする
-[[nodiscard]] std::expected<ScenarioStep, String> ParseStep(
+[[nodiscard]] std::expected<ParsedStep, String> ParseStep(
     const TOMLValue& step, const PhaseLoaderTable& loaders
 ) {
   const auto action = step[U"action"].getOpt<String>();
@@ -23,14 +30,20 @@ namespace {
           U"ScenarioData::ParseStep: 未登録のフェーズ名 \"" + *phaseName + U"\""
       };
     }
-    auto maker = it->second(step);
-    if (!maker) {
-      return std::unexpected{std::move(maker).error()};
+    auto loaded = it->second(step);
+    if (!loaded) {
+      return std::unexpected{std::move(loaded).error()};
     }
+    ScenarioStep parsedStep;
     if (*action == U"push") {
-      return StepPush{.maker = *std::move(maker)};
+      parsedStep = StepPush{.maker = std::move(loaded->maker)};
+    } else {
+      parsedStep = StepReset{.maker = std::move(loaded->maker)};
     }
-    return StepReset{.maker = *std::move(maker)};
+    return ParsedStep{
+        .step = std::move(parsedStep),
+        .referencedSection = std::move(loaded->referencedSection),
+    };
   }
 
   if (*action == U"make") {
@@ -45,12 +58,19 @@ namespace {
   };
 }
 
+/// @brief セクション間の参照関係：from セクションが to セクションを参照する
+struct SectionRef {
+  String from;
+  String to;
+};
+
 }  // namespace
 
 std::expected<ScenarioData, String> ScenarioData::FromToml(
     const TOMLValue& toml, const PhaseLoaderTable& loaders
 ) {
   ScenarioData data;
+  Array<SectionRef> refs;
 
   for (const auto& member : toml.tableView()) {
     Array<ScenarioStep> steps;
@@ -59,9 +79,24 @@ std::expected<ScenarioData, String> ScenarioData::FromToml(
       if (!parsed) {
         return std::unexpected{std::move(parsed).error()};
       }
-      steps.push_back(*std::move(parsed));
+      if (parsed->referencedSection) {
+        refs.push_back(
+            {.from = member.name, .to = *std::move(parsed->referencedSection)}
+        );
+      }
+      steps.push_back(std::move(parsed->step));
     }
     data.sections[member.name] = std::move(steps);
+  }
+
+  // 前方参照を許すため、全セクションを登録し終えてから検証する
+  for (const auto& ref : refs) {
+    if (!data.sections.contains(ref.to)) {
+      return std::unexpected{
+          U"ScenarioData::FromToml: セクション \"{}\" が参照する \"{}\" があ"
+          U"りません"_fmt(ref.from, ref.to)
+      };
+    }
   }
 
   return data;

--- a/Ash2/src/Config/ScenarioData.hpp
+++ b/Ash2/src/Config/ScenarioData.hpp
@@ -18,12 +18,22 @@ struct IPhaseMaker {
   [[nodiscard]] virtual std::unique_ptr<IPhase> make() const = 0;
 };
 
-/// @brief TOML 値から IPhaseMaker を生成する関数の型
+/// @brief PhaseLoader の生成結果
+struct LoadedPhase {
+  IPhaseMaker::Ptr maker;
+  /// 別のシナリオセクションを参照する場合のみ設定される
+  Optional<String> referencedSection;
+};
+
+/// @brief TOML 値から LoadedPhase を生成する関数の型
 using PhaseLoader =
-    std::function<std::expected<IPhaseMaker::Ptr, String>(const TOMLValue&)>;
+    std::function<std::expected<LoadedPhase, String>(const TOMLValue&)>;
 
 /// @brief フェーズ名 → PhaseLoader のマップ
 using PhaseLoaderTable = HashTable<String, PhaseLoader>;
+
+/// @brief 起動時に最初に実行されるシナリオセクション名
+inline constexpr StringView kInitSectionName = U"init";
 
 /// @brief シナリオのステップ：フェーズをスタックに積む
 struct StepPush {

--- a/Ash2/src/GameSetup.cpp
+++ b/Ash2/src/GameSetup.cpp
@@ -100,6 +100,13 @@ std::expected<void, String> InitializeRegistry(entt::registry& registry) {
   if (!scenario) {
     return std::unexpected{std::move(scenario).error()};
   }
+  if (!scenario->sections.contains(String{kInitSectionName})) {
+    return std::unexpected{
+        U"InitializeRegistry: セクション \"{}\" がありません"_fmt(
+            kInitSectionName
+        )
+    };
+  }
   registry.ctx().emplace<ScenarioData>(*std::move(scenario));
 
   return {};

--- a/Ash2/src/Main.cpp
+++ b/Ash2/src/Main.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include "Asset.hpp"
+#include "Config/ScenarioData.hpp"
 #include "CrashHandler.hpp"
 #include "Debug.hpp"
 #include "GameSetup.hpp"
@@ -47,7 +48,7 @@ void Run() {
 
   PhaseStack phaseStack(
       std::make_unique<ScenarioPhase>(
-          ScenarioPhase::Param{.sectionName = U"init"}
+          ScenarioPhase::Param{.sectionName = String{kInitSectionName}}
       ),
       registry
   );

--- a/Ash2/src/Phase/PhaseLoaders.cpp
+++ b/Ash2/src/Phase/PhaseLoaders.cpp
@@ -15,6 +15,13 @@ concept PhaseWithParam =
     std::move_constructible<typename T::Param> &&
     std::constructible_from<T, const typename T::Param&>;
 
+/// @brief 別のシナリオセクションを参照する Param
+/// @note ScenarioPhase::Param の sectionName がこれに該当する
+template <typename P>
+concept SectionRefParam = requires(const P& p) {
+  { p.sectionName } -> std::convertible_to<String>;
+};
+
 /// @brief 型 T のパラメータを保持し、make() で T を生成する IPhaseMaker
 template <PhaseWithParam T>
 class PhaseMaker : public IPhaseMaker {
@@ -35,12 +42,19 @@ class PhaseMaker : public IPhaseMaker {
 template <PhaseWithParam T, typename F>
 PhaseLoader MakeLoader(F&& parse) {
   return [p = std::forward<F>(parse)](const TOMLValue& step)
-             -> std::expected<IPhaseMaker::Ptr, String> {
+             -> std::expected<LoadedPhase, String> {
     auto param = p(step);
     if (!param) {
       return std::unexpected{std::move(param).error()};
     }
-    return std::make_shared<const PhaseMaker<T>>(*std::move(param));
+    Optional<String> ref = none;
+    if constexpr (SectionRefParam<typename T::Param>) {
+      ref = param->sectionName;
+    }
+    return LoadedPhase{
+        .maker = std::make_shared<const PhaseMaker<T>>(*std::move(param)),
+        .referencedSection = std::move(ref),
+    };
   };
 }
 

--- a/Ash2/src/Phase/ScenarioPhase.cpp
+++ b/Ash2/src/Phase/ScenarioPhase.cpp
@@ -1,5 +1,7 @@
 #include "Phase/ScenarioPhase.hpp"
 
+#include <cassert>
+
 #include "Config/ScenarioData.hpp"
 #include "Util/Overloaded.hpp"
 
@@ -11,8 +13,18 @@ void ScenarioPhase::onAfterPush(entt::registry&) { m_currentStep = 0; }
 PhaseCommand ScenarioPhase::update(
     entt::registry& registry, const FrameData& /*frameData*/
 ) {
-  const auto& steps =
-      registry.ctx().get<ScenarioData>().sections.at(m_sectionName);
+  const auto& sections = registry.ctx().get<ScenarioData>().sections;
+  const auto it = sections.find(m_sectionName);
+  // Release では assert が消えるため、ゲームループ内 throw を避ける
+  // フォールバックとして if も残す
+  assert(
+      it != sections.end() &&
+      "セクション名は読み込み時に検証済みでなければならない"
+  );
+  if (it == sections.end()) {
+    return PhaseCommand::Pop{};
+  }
+  const auto& steps = it->second;
   if (m_currentStep >= steps.size()) {
     return PhaseCommand::Pop{};
   }

--- a/Ash2/tests/TestScenarioData.cpp
+++ b/Ash2/tests/TestScenarioData.cpp
@@ -79,4 +79,33 @@ TEST_CASE("ScenarioData::FromToml - missing param returns unexpected") {
   REQUIRE_FALSE(ScenarioData::FromToml(reader, GetPhaseLoaders()).has_value());
 }
 
+TEST_CASE(
+    "ScenarioData::FromToml - reference to nonexistent section returns "
+    "unexpected"
+) {
+  constexpr std::string_view kToml =
+      "[[intro]]\n"
+      "action = \"push\"\n"
+      "phase = \"scenario\"\n"
+      "param = \"nonexistent\"\n";
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
+  REQUIRE_FALSE(ScenarioData::FromToml(reader, GetPhaseLoaders()).has_value());
+}
+
+TEST_CASE(
+    "ScenarioData::FromToml - forward reference to later section succeeds"
+) {
+  constexpr std::string_view kToml =
+      "[[intro]]\n"
+      "action = \"push\"\n"
+      "phase = \"scenario\"\n"
+      "param = \"later\"\n"
+      "[[later]]\n"
+      "action = \"push\"\n"
+      "phase = \"wait\"\n"
+      "duration = 1.0\n";
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
+  REQUIRE(ScenarioData::FromToml(reader, GetPhaseLoaders()).has_value());
+}
+
 #endif

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -251,9 +251,16 @@
 変換テーブルは [`Phase/PhaseLoaders.cpp`](../Ash2/src/Phase/PhaseLoaders.cpp) の
 `GetPhaseLoaders()` で定義されており、**新フェーズ追加時はここにもエントリを追加する必要がある。**
 `PhaseWithParam` コンセプトと `PhaseMaker<T>` が TOML パラメータを型消去して保持する。
+`PhaseLoader` は `LoadedPhase`（`maker` と、別セクションを参照する場合のみ設定される
+`Optional<String> referencedSection`）を返す。`SectionRefParam` コンセプトを満たす
+`Param`（`sectionName` を持つ、`ScenarioPhase::Param` など）は `MakeLoader` が自動で
+`referencedSection` へ詰める。
 `ScenarioData::FromToml` はこのテーブルを `PhaseLoaderTable` として引数で受け取る
 （Config 層から具象フェーズへの依存を作らないため）。呼び出し元は `GameSetup` が
 `GetPhaseLoaders()` を渡して配線する。
+`FromToml` は全セクションを登録し終えた後、集めた `referencedSection` が実在するセクションを
+指すかまとめて検証する（前方参照を許すため、セクションごとのループの外で行う）。不在なら
+`unexpected` を返し、`ScenarioPhase::update` がゲームループ内で `at()` の例外を投げることはない。
 
 ---
 
@@ -325,8 +332,10 @@
 ### [`ScenarioData`](../Ash2/src/Config/ScenarioData.hpp)
 
 - `Ash2/App/assets/config/scenario.toml` から読み込むシナリオ（セクション名 → ステップ列）
-- 同ヘッダが `IPhaseMaker` / `PhaseLoader` / `PhaseLoaderTable` / `StepPush` / `StepReset` /
-  `ScenarioStep` を定義する
+- 同ヘッダが `IPhaseMaker` / `LoadedPhase` / `PhaseLoader` / `PhaseLoaderTable` / `StepPush` /
+  `StepReset` / `ScenarioStep` / `kInitSectionName` を定義する
+- `kInitSectionName`（`U"init"`）は起動時に最初へ渡すセクション名。`Main.cpp` の起動フェーズ生成と
+  `InitializeRegistry` の存在確認が同じ定数を参照する
 - 詳細は上記「フェーズシステム」を参照
 
 ### `registry.ctx()` の内容一覧


### PR DESCRIPTION
close #268

## 概要

`scenario.toml` の `param` に存在しないセクション名が書かれていた場合、これまでは該当フェーズが最前面になったフレームで `HashTable::at()` が `std::out_of_range` を投げ、ゲームループ内から例外が飛んでいた。設定ファイルの誤りという同じ原因が、起動時ではなく実行中に現れる点も原因究明を難しくしていた。

読み込み時に検証して潰す形に変更した。

## 変更内容

- `ScenarioData::FromToml` が `scenario` ステップの参照先セクションの実在を検証し、不在なら `std::unexpected` を返す
- `InitializeRegistry` が `[[init]]` セクションの実在を確認する
- `ScenarioPhase::update` は `at()` をやめて `find()` にし、不在時は `assert` ＋ `PhaseCommand::Pop{}` にフォールバックする
- `Main.cpp` の `U"init"` リテラルを `kInitSectionName` 定数に置き換える

## 実装判断

### 失敗は throw ではなく戻り値で返す

Issue 本文では `ScenarioData::FromToml` で `throw Error{...}` する案を挙げていたが、`std::unexpected` を返す形にした。終了するかどうかの判断は受け取った側（`Run()`）に委ねるという `docs/coding_style/ERROR_HANDLING.md` の方針に合わせている。`Run()` 側で `FatalError{ConfigInvalid}` に変換される。

### 参照名は `PhaseLoader` の戻り値で運ぶ

`PhaseLoader` の成功型を `IPhaseMaker::Ptr` から `LoadedPhase{ maker, referencedSection }` に変えた。

`ParseStep` 内で `phase == "scenario"` を直接判定するほうが実装は短いが、Config 層に具象フェーズ名の文字列を持ち込むことになり、「具象フェーズを知るのは Phase 層だけ」という現状の分離を名前レベルで崩す。

参照名の抽出は `sectionName` メンバーを持つ Param を拾う `SectionRefParam` コンセプトと `if constexpr` で行っており、ローダー登録側 5 エントリの記述は変わらない。`IPhaseMaker` に仮想関数を足す案は、生成後にしか参照名を取り出せず検証のために `make()` が必要になるため採らなかった。

### 検証は全セクションの登録後にまとめて行う

`[[init]]` が後方に定義された `[[GameStart]]` を参照しているため、前方参照を許す必要がある。セクションのループ内で検証すると正当な前方参照を弾いてしまう。

### `[[init]]` の存在確認は `GameSetup` に置く

`[[init]]` を要求するのは起動時の都合であって、TOML から `ScenarioData` への変換一般の要件ではない。`FromToml` に持たせると汎用の変換関数に起動時の都合が混ざり、`[[intro]]` だけを与えている既存テストも落ちる。

### `update` では `assert` と `if` を併用する

読み込み時に検証済みのため、セクション不在は不変条件違反にあたり Debug では `assert` で早期に検出したい。一方 Release では `NDEBUG` により `assert` が消えるため、ゲームループ内 throw を確実に避ける安全側フォールバックとして `if` も残している。この理由はコード上のコメントにも記載した。

## 動作確認

Issue の確認方法に沿って実機で確認した。

| 確認項目 | 結果 |
|---|---|
| `param` を存在しないセクション名に変えて起動 | `ConfigInvalid: ScenarioData::FromToml: セクション "init" が参照する "GameStrat" がありません` |
| `[[init]]` を削除して起動 | `ConfigInvalid: InitializeRegistry: セクション "init" がありません` |
| 正常な `scenario.toml` で起動 | 従来どおりフェーズ遷移、終了コード 0 |

いずれも実行中の例外ではなく起動時のエラーになること、参照元のセクション名も含まれることを確認している。

テストは `ScenarioData::FromToml` の参照検証について 2 件追加した（不在セクションの参照 → `unexpected`、後方定義セクションの参照 → 成功）。

## 本 PR の対象外

- セクションの自己参照・循環参照の検出
- `animation_viewer` の `param` の読み込み時検証（#285 で対応）
- C++ から任意のセクション名で `ScenarioPhase` を push する経路の静的保証。現状の該当箇所は `Main.cpp` の 1 件のみで、これは `kInitSectionName` の存在確認でカバーしている

## 見送った検討

`InitializeRegistry` の `[[init]]` 存在確認は、1 セクションの検証に対して行数がやや多い。必須セクションが複数になった場合を見越して一覧＋ループの形に一般化する案も検討したが、今回は見送った。

- この検証が要るのは C++ 側がハードコードしたセクション名を push する場合のみで、該当は `Main.cpp` の 1 件だけ。2 件目の予定もない
- 7 行のうち 5 行はエラーメッセージの整形で、検証自体は `contains` の 1 行。同じ関数の直上に並ぶ他の失敗判定と同じ形をしている
- 2 件目が出た時点で一覧＋ループに変える修正は機械的で、現状の形が足枷にならない
- 要素 1 個のリストは投機的な抽象になり、`init` が「必須セクションの一つ」であるかのような誤ったニュアンスも生む。`init` は必須セクションではなくエントリポイントである

なお、`Main.cpp` が push する名前を `GameSetup.cpp` が検証しているという距離のほうが本質的な歪みだが、正すには「エントリポイントの所有者は誰か」という設計の話になり、本 Issue のスコープを超えるため触れていない。
