### PR TITLE
アニメーションクリップにループ制御を追加し、締め技の後隙の退行を修正

### DIFF
--- a/Ash2/App/assets/config/animation/player.toml
+++ b/Ash2/App/assets/config/animation/player.toml
@@ -7,11 +7,13 @@ draw_offset = {x = 0.0, y = 0.0}
 row = 0
 count = 2
 speed = 1.5
+loop = true
 
 [move]
 row = 1
 count = 2
 speed = 8.0
+loop = true
 
 [jump_rise]
 row = 2

--- a/Ash2/src/Component/SpriteAnimation.hpp
+++ b/Ash2/src/Component/SpriteAnimation.hpp
@@ -6,7 +6,8 @@ struct SpriteAnimation {
   /// AnimationDataRegistry のキー（アニメーション設定ファイル名由来）
   String dataKey;
   String currentClip;
-  /// 現クリップ内の位相（秒）。[0, count/speed) の範囲にラップされる
+  /// 現クリップ内の位相（秒）。loop なら [0, count/speed) にラップされ、
+  /// そうでなければ count/speed（上限含む）でクランプされる
   double elapsed = 0.0;
   /// スプライトは左向きがデフォルト。true のとき AnimationSystem が反転描画する
   bool facingRight = false;

--- a/Ash2/src/Config/AnimationData.cpp
+++ b/Ash2/src/Config/AnimationData.cpp
@@ -15,6 +15,7 @@ namespace {
           .row = f.get<int32>(U"row"),
           .count = f.get<int32>(U"count"),
           .speed = f.get<double>(U"speed"),
+          .loop = f.getOr<bool>(U"loop", false),
       }
   );
 }

--- a/Ash2/src/Config/AnimationData.hpp
+++ b/Ash2/src/Config/AnimationData.hpp
@@ -10,6 +10,26 @@ struct AnimationClip {
   int32 count;
   /// コマ/秒
   double speed;
+  /// 末尾まで再生したら先頭へ戻るか。false は最終コマで停止する
+  bool loop = false;
+
+  /// @brief 全コマを1周する時間（秒）
+  [[nodiscard]] double cycleDuration() const {
+    return static_cast<double>(count) / speed;
+  }
+  /// @brief dt 秒進めた位相を返す
+  /// @return loop なら [0, cycleDuration()) へラップ、そうでなければ
+  ///         cycleDuration() でクランプした値
+  [[nodiscard]] double advance(double elapsed, double dt) const {
+    const double next = elapsed + dt;
+    return loop ? Math::Fmod(next, cycleDuration())
+                : Min(next, cycleDuration());
+  }
+  /// @brief 位相に対応するコマ番号（列）
+  /// @return [0, count - 1] にクランプした値
+  [[nodiscard]] int32 columnAt(double elapsed) const {
+    return Clamp(static_cast<int32>(elapsed * speed), 0, count - 1);
+  }
 };
 
 /// @brief アニメーション共有データ（エンティティ種別ごとに1つ）

--- a/Ash2/src/Config/TomlFields.hpp
+++ b/Ash2/src/Config/TomlFields.hpp
@@ -3,7 +3,7 @@
 
 #include <expected>
 
-/// @brief TOML テーブルの必須キーを読み、欠落キーをまとめて記録する
+/// @brief TOML テーブルのキーを読み、必須キーの欠落をまとめて記録する
 ///
 /// 1インスタンスが1テーブル・1プレフィックスを担当する。get() は欠落時に
 /// 既定値 T{} を返して読み進め、check()/wrap() でまとめて失敗に畳む。
@@ -27,6 +27,13 @@ class TomlFields {
         m_prefix.isEmpty() ? String{key} : (m_prefix + U"." + String{key})
     );
     return T{};
+  }
+
+  /// @brief 省略可能キーを読む
+  /// @return 欠落時は defaultValue（欠落を記録しない）
+  template <class T>
+  [[nodiscard]] T getOr(StringView key, T defaultValue) const {
+    return m_table[String{key}].getOr<T>(std::move(defaultValue));
   }
 
   /// @brief 記録した欠落を確認する

--- a/Ash2/src/Phase/AnimationViewerPhase.cpp
+++ b/Ash2/src/Phase/AnimationViewerPhase.cpp
@@ -82,6 +82,13 @@ PhaseCommand AnimationViewerPhase::update(
         anim->facingRight = !anim->facingRight;
       }
     }
+
+    if (KeyR.down() && m_entity != entt::null) {
+      auto* anim = registry.try_get<SpriteAnimation>(m_entity);
+      if (anim) {
+        anim->elapsed = 0.0;
+      }
+    }
   }
 
   AnimationSystem::Update(registry, frameData.dt);
@@ -98,7 +105,7 @@ PhaseCommand AnimationViewerPhase::update(
     )
         .draw(kTitleX, kClipInfoY);
   }
-  font(U"← → : clip  F : flip  Esc : back")
+  font(U"← → : clip  F : flip  R : replay  Esc : back")
       .draw(kTitleX, kHintY, Palette::Gray);
 
   return PhaseCommand::None{};

--- a/Ash2/src/System/AnimationSystem.cpp
+++ b/Ash2/src/System/AnimationSystem.cpp
@@ -22,14 +22,10 @@ void AnimationSystem::Update(entt::registry& registry, double dt) {
     );
     const auto& clip = data.clips.at(anim.currentClip);
 
-    anim.elapsed += dt;
-
     assert(clip.count > 0 && "clip.count は正の値でなければならない");
     assert(clip.speed > 0.0 && "clip.speed は正の値でなければならない");
-    const double cycleDuration = clip.count / clip.speed;
-    anim.elapsed = Math::Fmod(anim.elapsed, cycleDuration);
-    const int32 col =
-        static_cast<int32>(anim.elapsed * clip.speed) % clip.count;
+    anim.elapsed = clip.advance(anim.elapsed, dt);
+    const int32 col = clip.columnAt(anim.elapsed);
     const Point cell{col, clip.row};
     // data.textureKey の登録・読み込み済みは LoadAnimations（GameSetup.cpp）
     // がロード時に保証する

--- a/Ash2/src/System/PlayerMotion/Ranged.cpp
+++ b/Ash2/src/System/PlayerMotion/Ranged.cpp
@@ -26,7 +26,7 @@ constexpr ColorF kBulletColor = {0.9, 0.9, 0.3};
 double GetClipDuration(const AnimationData& data, const String& clip) {
   const auto it = data.clips.find(clip);
   if (it == data.clips.end()) return 0.0;
-  return static_cast<double>(it->second.count) / it->second.speed;
+  return it->second.cycleDuration();
 }
 
 }  // namespace

--- a/Ash2/tests/TestAnimationData.cpp
+++ b/Ash2/tests/TestAnimationData.cpp
@@ -83,6 +83,74 @@ TEST_CASE("AnimationData::FromToml - missing clip row returns unexpected") {
   REQUIRE_FALSE(AnimationData::FromToml(reader).has_value());
 }
 
+TEST_CASE("AnimationData::FromToml - loop key omitted defaults to false") {
+  constexpr std::string_view kToml =
+      "texture = \"assets/images/player.png\"\n"
+      "width = 32\n"
+      "height = 64\n"
+      "\n"
+      "[draw_offset]\n"
+      "x = 0.0\n"
+      "y = 0.0\n"
+      "\n"
+      "[idle]\n"
+      "row = 0\n"
+      "count = 4\n"
+      "speed = 8.0\n";
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
+  const auto data = AnimationData::FromToml(reader);
+  REQUIRE(data.has_value());
+  REQUIRE_FALSE(data->clips.at(U"idle").loop);
+}
+
+TEST_CASE("AnimationData::FromToml - loop = true is parsed") {
+  constexpr std::string_view kToml =
+      "texture = \"assets/images/player.png\"\n"
+      "width = 32\n"
+      "height = 64\n"
+      "\n"
+      "[draw_offset]\n"
+      "x = 0.0\n"
+      "y = 0.0\n"
+      "\n"
+      "[idle]\n"
+      "row = 0\n"
+      "count = 4\n"
+      "speed = 8.0\n"
+      "loop = true\n";
+  const TOMLReader reader{MemoryViewReader{kToml.data(), kToml.size()}};
+  const auto data = AnimationData::FromToml(reader);
+  REQUIRE(data.has_value());
+  REQUIRE(data->clips.at(U"idle").loop);
+}
+
+TEST_CASE(
+    "AnimationClip::advance - loop wraps past the end back to the start"
+) {
+  const AnimationClip clip{.row = 0, .count = 4, .speed = 2.0, .loop = true};
+  // cycleDuration() == 2.0
+  const double elapsed = clip.advance(1.9, 0.2);
+  REQUIRE(elapsed == Approx(0.1));
+}
+
+TEST_CASE(
+    "AnimationClip::advance - non-loop stops at the end without wrapping"
+) {
+  const AnimationClip clip{.row = 0, .count = 4, .speed = 2.0, .loop = false};
+  // cycleDuration() == 2.0。超過分を足しても cycleDuration() で止まる
+  const double elapsed = clip.advance(1.9, 0.5);
+  REQUIRE(elapsed == Approx(2.0));
+}
+
+TEST_CASE("AnimationClip::columnAt - clamps to [0, count - 1]") {
+  const AnimationClip clip{.row = 0, .count = 4, .speed = 2.0, .loop = false};
+  REQUIRE(clip.columnAt(0.0) == 0);
+  // 最終コマ（列3）の開始位相
+  REQUIRE(clip.columnAt(1.5) == 3);
+  // cycleDuration() 到達時も最終コマに留まり、列0へは戻らない
+  REQUIRE(clip.columnAt(clip.cycleDuration()) == 3);
+}
+
 TEST_CASE("AnimationData::FromToml - reserved keys are not treated as clips") {
   // texture / width / height / draw_offset はクリップとして誤認されてはならない
   constexpr std::string_view kToml =

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -134,7 +134,7 @@
 | [`ProjectileSystem::Update`](../Ash2/src/System/ProjectileSystem.hpp) | フェーズ内（PlayerTestPhase、HitReactionSystem の後） | Projectile の着弾（hitTargets 非空）/ 画面外での破棄 |
 | [`EnemySystem::Update`](../Ash2/src/System/EnemySystem.hpp) | フェーズ内（PlayerTestPhase、ProjectileSystem の後） | `EnemyMotion::Defeated` の残り時間が尽きたエンティティを収集し、`MotionSystem` のビュー走査外でまとめて破棄する |
 | [`FadeOutSystem::Update`](../Ash2/src/System/FadeOutSystem.hpp) | フェーズ内（PlayerTestPhase、EnemySystem の後） | `FadeOut` の残り時間を減算して `DrawColor::color.a`（`get_or_emplace` で確保）に反映し、満了したエンティティを破棄する。`Hitstop` による除外はしない |
-| [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | `Hitstop` を持たない SpriteAnimation の elapsed を進め、切り出した `TextureRegion` を `TextureDrawable` に反映する（`facingRight` なら反転） |
+| [`AnimationSystem::Update`](../Ash2/src/System/AnimationSystem.hpp) | フェーズ内（各フェーズが直接呼出） | `Hitstop` を持たない SpriteAnimation の elapsed を進め、切り出した `TextureRegion` を `TextureDrawable` に反映する（`facingRight` なら反転）。`AnimationClip::loop` が false のクリップは最終コマで停止し、先頭へ戻らない |
 | [`DrawSystem::Draw`](../Ash2/src/System/DrawSystem.hpp) | 毎フレーム（HudSystem の前） | WorldPos+Drawable を奥行き順にソートして描画。`DrawColor`（未所持は白・不透明）を塗り色・テクスチャの乗算色として適用する。関数スコープに閉じた `ScopedRenderStates2D` で最近傍サンプラーを適用し、`TextureDrawable` の描画位置は `Math::Round` で整数化する（HUD・フォントには波及しない） |
 | [`HudSystem::Draw`](../Ash2/src/System/HudSystem.hpp) | 毎フレーム（DrawSystem の後） | Player の Hp / Stamina を画面左上にゲージ描画（プレイヤー 1 体のみ想定）。他のシステムと異なり実装をヘッダに直書きしている |
 | [`NameLookupSystem::Connect`](../Ash2/src/System/NameLookup.hpp) | 起動時 | Name 追加・削除時に NameLookup を自動同期するシグナル登録 |
@@ -230,7 +230,7 @@
 | [`ScenarioPhase`](../Ash2/src/Phase/ScenarioPhase.hpp) | `scenario` | TOML シナリオを 1 ステップずつ実行（push/reset）。起動時の最初のフェーズ（`init` セクション） |
 | [`TestMenuPhase`](../Ash2/src/Phase/TestMenuPhase.hpp) | `test_menu` | テストフェーズ一覧メニュー（↑↓選択、Enter で Push） |
 | [`PlayerTestPhase`](../Ash2/src/Phase/PlayerTestPhase.hpp) | `player_test` | プレイヤー操作・物理・アニメーションのビジュアルテスト。`EnemyConfig` から敵（`Enemy`+`Motion`+`Collider`+`Hp` 等）を1体生成し、`HitReactionSystem`/`EnemySystem` に被弾リアクション・撃破後の破棄を委ねる。敵が破棄されたら `EnemyConfig::respawnSec` 後に再生成する。F5 でプレイヤー・設定再生成、Esc で Pop |
-| [`AnimationViewerPhase`](../Ash2/src/Phase/AnimationViewerPhase.hpp) | `animation_viewer` | アニメーションクリップ単体確認（←→切替、F反転、Esc で Pop） |
+| [`AnimationViewerPhase`](../Ash2/src/Phase/AnimationViewerPhase.hpp) | `animation_viewer` | アニメーションクリップ単体確認（←→切替、F反転、Rでリプレイ、Esc で Pop） |
 | [`WaitPhase`](../Ash2/src/Phase/WaitPhase.hpp) | `wait` | 指定秒数待機して Pop |
 
 ### シナリオ TOML から生成できるフェーズ名
@@ -324,7 +324,9 @@
 
 - スプライトシート単位のアニメーション共有データ（テクスチャキー・コマサイズ・描画オフセット・
   クリップ表）
-- `AnimationClip` は行番号・コマ数・再生速度（コマ/秒）を持つ
+- `AnimationClip` は行番号・コマ数・再生速度（コマ/秒）・ループ有無（`loop`、既定 false）を持ち、
+  位相の更新（`advance`）とコマ算出（`columnAt`）、1周の時間（`cycleDuration`）を自身のメンバ関数で
+  提供する
 - `AnimationDataRegistry`（キー: 設定ファイルのベース名）として
   `Ash2/App/assets/config/animation/*.toml` から一括ロードされる
 - `texture`/`width`/`height`/`draw_offset` は予約キーで、それ以外のテーブルがクリップとして扱われる
@@ -370,7 +372,7 @@
 十字ボタンの軸ベクトルと加算したうえで `limitLength(1.0)` により正規化する。
 
 **フェーズの直接キー入力：** `TestMenuPhase`（↑↓/Enter）・`PlayerTestPhase`（Esc）・
-`AnimationViewerPhase`（Esc/←→/F）は `InputState` を経由せず Siv3D の `Key*` を直接参照している。
+`AnimationViewerPhase`（Esc/←→/F/R）は `InputState` を経由せず Siv3D の `Key*` を直接参照している。
 これらの操作にはゲームパッドの割り当てがない。
 
 ---
@@ -472,3 +474,4 @@
 - `Motion` に新しい状態型を追加したときは、その型に `Tick(state, registry, entity, frameData) -> Optional<Motion>`（ADL で解決される非修飾 `Tick`）を実装する必要がある。`MotionSystem::Update` の `std::visit` が `MotionState` concept（`MotionSystem.hpp`）で制約されているため。
 - 新フェーズを追加し TOML から `push`/`reset` できるようにするときは、`Phase/PhaseLoaders.cpp` の `GetPhaseLoaders()` にもエントリを追加する。
 - 新しいアニメーションクリップを参照するときは `Ash2/App/assets/config/animation/*.toml` 側にも追加する（欠落は `AnimationSystem` の `assert` で落ちる）。
+- アニメーションクリップは既定で一発再生（最終コマで停止）。ループさせたいクリップにのみ `loop = true` を明記する。


### PR DESCRIPTION
close #296

## 概要

`AnimationSystem` が全クリップを無条件でループさせていたため、モーション長とクリップ1周の時間が一致しないと末尾で先頭コマが再表示されていた。`AnimationClip` に `loop` を追加し、既定を一発再生にすることで解消する。

## 変更内容

- `AnimationClip` に `loop`（既定 false）を追加し、`idle` / `move` にのみ `loop = true` を明記
- 位相の更新とコマ算出を `cycleDuration()` / `advance()` / `columnAt()` として `AnimationClip` に切り出し、`AnimationSystem::Update` はそれを呼ぶだけにした
- `TomlFields` に省略可能キー用の `getOr` を追加
- `AnimationViewerPhase` に `R` キーでのリプレイを追加
- `Ranged.cpp` の `GetClipDuration` を `cycleDuration()` に委譲
- `AnimationClip` の位相・コマ算出と `loop` のパースについてテストを追加

## 実装判断

### 純粋関数として切り出した理由

`AnimationSystem::Update` は `TextureAsset` に触れるためテストから呼べず、退行の当事者であるコマ算出そのものを検証できない状態だった。計算だけを config 構造体のメンバ関数へ移すことで、テスト可能になる。`MotionTimeline` が同じ形の先例。

### 非ループ時に `% count` を使わない理由

`elapsed == cycleDuration()` のとき剰余はコマ0へ戻るため、症状がそのまま再発する。`Clamp` で最終コマに留める。`elapsed` 自体も `cycleDuration()` でクランプし、`columnAt` の `int32` キャストが破綻しないようにしている。

### `speed` を変更していない理由

`melee_finish` の `speed = 4.0` は据え置き、コマ1が余剰の 0.05 秒を保持する形で症状を解消した。逆算値として残っている `speed` の整理と各モーションの調整は、見た目が変わるため #298 として分けている。

### `TomlFields::getOr` を追加した理由

`loop` は省略可能キーであり、既存の `get` では欠落を必須キーとして記録してパース全体が失敗する。`ParseClip` 内で `TOMLValue` を直接読む案は、1つのパース関数にキー読み出しの経路が2系統混ざるため見送った。

### AnimationViewer に `R` キーを足した理由

非ループ化により12クリップ中10が最終コマで停止する一方、ビューアは左右キーでのクリップ切り替えでしか位相を戻せなかった。ビューア側をループ再生にする案は、実機と見え方が異なり #298 の調整の判断材料にならないため採らなかった。

## 確認

- ビルド・テスト通過（525 assertions / 202 test cases）
- 実機で近接コンボ3段目の後隙に構えの絵が出ないこと、`idle` / `move` が従来どおりループすることを確認
